### PR TITLE
Adds -p flag to create directory only if it does not exist

### DIFF
--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "storybook": "yarn run test:generate-output && yarn run storybook:start",
         "storybook:start": "start-storybook -p 9001 -c .storybook",
-        "test:generate-output": "mkdir jest-test-utils && jest --json --outputFile=jest-test-utils/jest-test-results.json || true",
+        "test:generate-output": "mkdir -p jest-test-utils && jest --json --outputFile=jest-test-utils/jest-test-results.json || true",
         "test:update-snapshots": "jest --updateSnapshot",
         "test": "jest --watch --coverage"
     },


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #21 

> **Technical**: What should be noted about the implementation?

Adds -p flag to skip creating the directory if it already exists.

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?

From the "packages/ia-components" directory, run `yarn run storybook`, stop the running process, then run it again.

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

![mkdir_p](https://user-images.githubusercontent.com/39553/55488749-a03e4380-55fe-11e9-99c3-5e822ac4fee1.gif)
