### PR TITLE
Updated documentation with the correct path to prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ Prototypes are basically little websites built using code from `ia-components`. 
 
 Of course, a prototype could also be made outside of this repo, and that will make sense in some cases.
 
-Since the prototypes package is a "packages/prototypes" and there are a lot of other files at that level, there is a second directory "packages/prototypes/prototypes" and this is where the actual content lives.
+Since the prototypes package is a "packages/ia-prototype-apps" and there are a lot of other files at that level, there is a second directory "packages/ia-prototype-apps/apps" and this is where the actual content lives.
 
 See [packages/ia-prototype-apps/README.md](packages/ia-prototype-apps/README.md) for more info.
 
 
 Prototypes can be run like this:
 ```
-cd packages/prototypes
-yarn run parcel prototypes/examples/example-hello/index.html
+cd packages/ia-prototype-apps
+yarn run parcel apps/examples/example-hello/index.html
 ```
 
 After, you can try running a more complex example:
 ```
-yarn run parcel prototypes/details-react/index.html
+yarn run parcel apps/details-react/index.html
 ```
 
 ## Publishing

--- a/packages/ia-prototype-apps/README.md
+++ b/packages/ia-prototype-apps/README.md
@@ -4,7 +4,7 @@ Prototypes are basically little websites built using code from `ia-components`. 
 
 Of course, a prototype could also be made outside of this repo, and that will make sense in some cases.
 
-Since the prototypes package is a "packages/prototypes" and there are a lot of other files at that level, there is a second directory "packages/prototypes/prototypes" and this is where the actual content lives.
+Since the prototypes package is a "packages/ia-prototype-apps" and there are a lot of other files at that level, there is a second directory "packages/ia-prototype-apps/apps" and this is where the actual content lives.
 
 Prototypes are run using [Parcel](https://parceljs.org). This means only one npm install is needed and all the prototypes use the same node_modules. Eg it's more light-weight this way.
 
@@ -14,14 +14,14 @@ Prototypes are run using [Parcel](https://parceljs.org). This means only one npm
 Running a prototype
 
 ```
-yarn run parcel prototypes/details-react/index.html
+yarn run parcel apps/details-react/index.html
 ```
 
 
 Building a prototype
 
 ```
-yarn run parcel build prototypes/details-react/index.html --public-url ./
+yarn run parcel build apps/details-react/index.html --public-url ./
 ```
 
 This can then be uploaded somewhere for shared.


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]

Closes #76 

Fixes incorrect directory paths under "ia-prototypes-apps" in documentation

The directory paths under "ia-prototype-apps" in the documentation are wrong.
"packages/prototypes" should be changed to "packages/ia-prototype-apps"
"packages/prototypes/prototypes" should be changes to "packages/ia-prototype-apps/apps"