### PR TITLE
Port from Dweb: Fix TileComponent and add AnchorDetails

### DIFF
--- a/packages/ia-components/index.js
+++ b/packages/ia-components/index.js
@@ -12,3 +12,7 @@ export { default as FlexboxPagination } from './sandbox/pagination/pagination-wi
 export { default as TheatreTrackList } from './sandbox/theatres/components/track-list/track-list';
 export { default as TheatreAudioPlayer } from './sandbox/theatres/components/audio-player/audio-player-main';
 export { default as AudioPlayerWithYoutubeSpotify } from './sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main';
+export { default as ParentTileImage } from './sandbox/tiles/ParentTileImg';
+export { default as TileComponent } from './sandbox/tiles/TileComponent';
+export { default as TileImage } from './sandbox/tiles/TileImage';
+export { default as AnchorDetails } from './sandbox/AnchorDetails';

--- a/packages/ia-components/sandbox/AnchorDetails.js
+++ b/packages/ia-components/sandbox/AnchorDetails.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import IAReactComponent from './IAReactComponent';
+const debug = require('debug')('dweb-archive:AnchorDetails');
+
+export default class AnchorDetails extends IAReactComponent {
+    // Component that encapsulates the difference between four options: Dweb||IAUX, React||FakeReact for links.
+    // NOTE the one impossible combination is using React:AnchorDetails inside FakeReact element as will be passed wrong kind of children
+
+    /*
+    React+!Dweb: no onClick unless want analytics
+    FakeReact+!Dweb: No onClick unless want analytics
+    React+Dweb:  onClick={this.click}
+    FakeReact+Dweb: strangely seems to work with onClick={this.click}
+    */
+
+    /* Maybe Used in IAUX in future, but not in ReactFake
+    Note other propTypes are passed to underlying Anchor - ones known in use are:
+    static propTypes = {
+        identifier: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
+    };
+    */
+    constructor(props)
+    {
+        //TODO-IAUX what about other props and children
+        // children: [ react.element* ]
+        super(props);
+        this.onClick = (ev) => { return this.clickCallable.call(this, ev); };
+    }
+    clickCallable(ev) {
+        debug("Cicking on link to details: %s",this.props.identifier);
+        Nav.nav_details(this.props.identifier);
+        ev.preventDefault();    // Prevent it going to the anchor (equivlent to "return false" in non-React
+        // ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); // Suggested alternatives which dont work
+        return false; // Stop the non-react version propogating
+    }
+    render() {
+        // this.props passes identifier which is required for Dweb, but typically also passes tabIndex, class, title
+        return ((typeof DwebArchive === "undefined") ?
+                <a href={`https://archive.org/details/${this.props.identifier}`} {...this.props}>
+                    {this.props.children}
+                </a>
+            :
+                // This is the Dweb version for React|!React
+                <a href={`https://archive.org/details/${this.props.identifier}`} onClick={this.onClick}  {...this.props}>
+                    {this.props.children}
+                </a>
+            );
+    }
+}

--- a/packages/ia-components/sandbox/tiles/ParentTileImg.js
+++ b/packages/ia-components/sandbox/tiles/ParentTileImg.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import IAReactComponent from '../IAReactComponent';
 
 export default class ParentTileImg extends IAReactComponent {
@@ -20,7 +20,7 @@ export default class ParentTileImg extends IAReactComponent {
         } else {
             if (!this.props.parentidentifier) {
                 this.props.parentidentifier = this.props.member.collection0()
-                    //TODO WOnt work its async || new ArchiveItem(this.props.member.identifier).fetch_metadata().metadata.collection[0];
+                //TODO WOnt work its async || new ArchiveItem(this.props.member.identifier).fetch_metadata().metadata.collection[0];
             }
             urls = `/services/img/${this.props.parentidentifier}`;    // Intentionally no host - so works on both archive.org and via ReactFake.loadImg() on dweb and localhost
         }

--- a/packages/ia-components/sandbox/tiles/TileComponent.js
+++ b/packages/ia-components/sandbox/tiles/TileComponent.js
@@ -5,16 +5,27 @@ import IAReactComponent from '../IAReactComponent'; // Encapsulates differences 
 //import PropTypes from 'prop-types'
 //TODO-IAUX need to standardise API as this uses the "ArchiveMemberSearch" class to provide necessary details for the Tile.
 //import ArchiveMemberSearch from "@internetarchive/dweb-archivecontroller/ArchiveMemberSearch";
-import Util from "../../Util"; //TODO-IAUX for mediatype_canonical and number_format which need porting to some kind of common libary between IAUX and dweb-archive
 import TileImage from "./TileImage";
 import ParentTileImg from "./ParentTileImg";
-//Both these fail - not compiling the JSX
-//import TileImage from "@internetarchive/ia-components/sandbox/tiles/TileImage";
-//import TileImage from "../../iaux/packages/ia-components/sandbox/tiles/TileImage";
+import AnchorDetails from "../AnchorDetails";
+
+
+function number_format(nStr) //this is just addCommas now
+{
+    //http://www.mredkj.com/javascript/numberFormat.html
+    nStr += '';
+    const x = nStr.split('.');
+    let x1 = x[0];
+    const x2 = x.length > 1 ? '.' + x[1] : '';
+    const rgx = /(\d+)(\d{3})/;
+    while (rgx.test(x1))
+        x1 = x1.replace(rgx, '$1' + ',' + '$2');
+    return x1 + x2;
+}
 
 
 export default class TileComponent extends IAReactComponent {
-    /* -- Not used with ReactFake yet
+    /* -- Not used with ReactFake or current IAUX yet
     static propTypes = {
         identifier: PropTypes.string,
         member: PropTypes.object,
@@ -28,30 +39,15 @@ export default class TileComponent extends IAReactComponent {
         this.state.identifier = props.identifier || props.member.identifier;
     }
 
+    iconnameClass(mediatype) {
+        // Get the class for the icon, has to handle some exceptions - there used to be many more obsolete mediatypes without iconochive's but these appear to have been cleaned up
+        const exceptions = { account: "person", video: "movies"}
+        return "iconochive-"+ (exceptions[mediatype] || mediatype)
+    }
+
     render() {
         try {
-            console.assert(this.props.member, "If using loadAndSync should have a member with at least mediatype to work with");
-            // We need some data for tiles, if its not found then have to fetch item metadata and then render
-            //TODO = catch cases (if-any) where this is triggered (maybe related, maybe fav-brewster) and see if can use expansion instead
-            // note test of creator is bad, as for example the "etree" entry in audio collection doesnt have a creator, publicdate or title would be better, but will try ArchiveMemberSearch
-            //console.assert(this.props.member.creator && this.props.member.creator.length, "next code shouldnt be needed as expand");
-            //console.assert(this.props.member instanceof ArchiveMemberSearch, "next code shouldnt be needed as expand");
-            /*
-            if (!(this.props.member.creator && this.props.member.creator.length)) { // This may not be best test
-                if (!this.props.item) this.props.item = new ArchiveItem({itemid: this.state.identifier});
-                if (!this.props.item.metadata) {
-                    this.props.item.fetch_metadata((err, ai) => {
-                        if (err) {
-                            debug("Failed to read metadata for %s", this.state.identifier);
-                            enclosingdiv.parentNode.removeChild(enclosingdiv);
-                        } else {
-                            this.loadAndSync(enclosingdiv);
-                        }
-                    });
-                    return;
-                } // If metadata drop through
-            }
-            */
+            console.assert(this.props.member, "If using TileComponent.render should have a member with at least mediatype to work with");
             const member = this.props.member;
             const item = this.props.item;
             const isCollection = (member.mediatype === 'collection');
@@ -63,66 +59,63 @@ export default class TileComponent extends IAReactComponent {
             this.setState({
                 isCollection, collection0, by, nFavorites, collectionSize,
                 mediatype: member.mediatype,
-                collection0title: member.collection0title || (item && item.collection_titles[collection0]),
+                collection0title: member.collection0title || (item && item.collection_titles[collection0]),  //TODO-IAUX collection_titles is dweb only, unsure how server side IAUX gets it
                 classes: 'item-ia' + (isCollection ? ' collection-ia' : ''),
                 byTitle: Array.isArray(by) ? by.join(',') : by,
                 downloads: member.downloads, // Often undefined
                 title: member.title || (item && item.metadata.title),
                 date: (member.publicdate || member.updateddate || (item && item.metadata.publicdate)).substr(0, 10), // No current cases where none of these dates exist
-                // Convert the mediatype into a canonical one (text, image etc)
-                // TODO-IAUX this is in Util - needs porting to the IAUX repo
-                iconnameClass: "iconochive-"+Util.mediatype_canonical(member.mediatype),
+                iconnameClass: this.iconnameClass(member.mediatype),
                 numReviews: member.num_reviews || (item && item.reviews && item.reviews.length) || 0
             })
         } catch(err) { // Catch error here as not generating debugging info at caller level for some reason
-            debug("ERROR in TileComponent.loadAndSync for %s:", this.state.identifier, err.message);
+            debug("ERROR in TileComponent.render for %s:", this.state.identifier, err.message);
             enclosingdiv.parentNode.removeChild(enclosingdiv);
         }
         return (
-        <div className={this.state.classes} data-id={this.state.identifier}  key={this.state.identifier}>
-            { (this.state.collection0) ? //TODO make it work for ParentTileImage in new TileComponent then remove this condition
-                <a className="stealth" tabIndex="-1" href={`/details/${this.state.collection0}`} onClick={`Nav.nav_details("${this.state.collection0}");`}>
-                    <div className="item-parent">
-                        <div className="item-parent-img">
-                            <ParentTileImg member={this.props.member} identifier={this.state.identifier} parentidentifier={this.state.collection0} />
-                        </div>
-                        <div className="item-parent-ttl">{this.state.collection0title}</div>
-                    </div>{/*.item-parent*/}
-                </a>
-                : undefined }
-            <div className="hidden-tiles views C C1">
-                <nobr className="hidden-xs">{Util.number_format(this.state.downloads)}</nobr>
-                <nobr className="hidden-sm hidden-md hidden-lg">{Util.number_format(this.state.downloads)}</nobr>
-            </div>
-
-
-            <div className="C234">
-                <div className="item-ttl C C2">
-                    <a onClick={`Nav.nav_details("${this.state.identifier}");`} title={this.state.title}>
-                        <div className="tile-img">
-                            <TileImage className="item-img clipW clipH" imgname={"__ia_thumb.jpg"} member={this.props.member} identifier={this.state.identifier} />
-                            {/*<img className="item-img clipW clipH" imgname={imgname} src={member}/>*/}
-                        </div>{/*.tile-img*/}
-                        <div className="ttl">
-                            {this.state.title}
-                        </div>
-                    </a>
-                </div>
-
-                <div className="hidden-tiles pubdate C C3">
-                    <nobr className="hidden-xs">{this.state.date}</nobr>
-                    <nobr className="hidden-sm hidden-md hidden-lg">{this.state.date}</nobr>
-                </div>
-
-                {this.state.by && this.state.by.length ?
-                    <div className="by C C4">
-                        <span className="hidden-lists">by </span>
-                        <span title={this.state.byTitle}>{this.state.byTitle}</span>
-                    </div>
+            <div className={this.state.classes} data-id={this.state.identifier}  key={this.state.identifier}>
+                { (this.state.collection0) ? // Believe, but not certain, that there is always going to be a collection0
+                    <AnchorDetails className="stealth" tabIndex="-1" identifier={this.state.collection0}>
+                        <div className="item-parent">
+                            <div className="item-parent-img">
+                                <ParentTileImg member={this.props.member} identifier={this.state.identifier} parentidentifier={this.state.collection0} />
+                            </div>
+                            <div className="item-parent-ttl">{this.state.collection0title}</div>
+                        </div>{/*.item-parent*/}
+                    </AnchorDetails>
                     : undefined }
-            </div>{/*.C234*/}
-            {this.state.isCollection ? this.renderDivCollectionStats() : this.renderDivStatbar() }
-        </div>
+                <div className="hidden-tiles views C C1">
+                    <nobr className="hidden-xs">{number_format(this.state.downloads)}</nobr>
+                    <nobr className="hidden-sm hidden-md hidden-lg">{number_format(this.state.downloads)}</nobr>
+                </div>
+
+
+                <div className="C234">
+                    <div className="item-ttl C C2">
+                        <AnchorDetails identifier={this.state.identifier} title={this.state.title}>
+                            <div className="tile-img">
+                                <TileImage className="item-img clipW clipH" imgname={"__ia_thumb.jpg"} member={this.props.member} identifier={this.state.identifier} />
+                            </div>
+                            <div className="ttl">
+                                {this.state.title}
+                            </div>
+                        </AnchorDetails>
+                    </div>
+
+                    <div className="hidden-tiles pubdate C C3">
+                        <nobr className="hidden-xs">{this.state.date}</nobr>
+                        <nobr className="hidden-sm hidden-md hidden-lg">{this.state.date}</nobr>
+                    </div>
+
+                    {this.state.by && this.state.by.length ?
+                        <div className="by C C4">
+                            <span className="hidden-lists">by </span>
+                            <span title={this.state.byTitle}>{this.state.byTitle}</span>
+                        </div>
+                        : undefined }
+                </div>{/*.C234*/}
+                {this.state.isCollection ? this.renderDivCollectionStats() : this.renderDivStatbar() }
+            </div>
         );
     }
 
@@ -134,10 +127,10 @@ export default class TileComponent extends IAReactComponent {
                 <div className="iconochive-collection topinblock hidden-lists" aria-hidden="true"></div>
                 <span className="sr-only">collection</span>
                 <div className="num-items topinblock">
-                    {Util.number_format(this.state.collectionSize)} <div className="micro-label">ITEMS</div>
+                    {number_format(this.state.collectionSize)} <div className="micro-label">ITEMS</div>
                 </div>
                 <div className="num-items hidden-tiles">
-                    {Util.number_format(this.state.downloads)}
+                    {number_format(this.state.downloads)}
                     <div className="micro-label">VIEWS</div>
                 </div>
             </div>
@@ -151,16 +144,16 @@ export default class TileComponent extends IAReactComponent {
                     <span className={this.state.iconnameClass} aria-hidden="true"></span><span className="sr-only">{this.state.mediatype}</span></div>
                 <h6 className="stat ">
                     <span className="iconochive-eye" aria-hidden="true"></span><span className="sr-only">eye</span>
-                    <nobr>{Util.number_format(Util.number_format(this.state.downloads))}</nobr>
+                    <nobr>{number_format(this.state.downloads)}</nobr>
                 </h6>
 
                 { typeof this.state.nFavorites === "undefined" ? undefined :
                     <h6 className="stat">
                         <span className="iconochive-favorite" aria-hidden="true"></span><span
-                        className="sr-only">favorite</span> {Util.number_format(this.state.nFavorites)} </h6>
+                        className="sr-only">favorite</span> {number_format(this.state.nFavorites)} </h6>
                 }
                 <h6 className="stat">
-                    <span className="iconochive-comment" aria-hidden="true"></span><span className="sr-only">comment</span> {Util.number_format(this.state.numReviews)}
+                    <span className="iconochive-comment" aria-hidden="true"></span><span className="sr-only">comment</span> {number_format(this.state.numReviews)}
                 </h6>
             </div>
         )


### PR DESCRIPTION
> **Description**: What does this PR achieve? [feature|hotfix|refactor]
Remove (most) dweb dependencies from TileComponent, and adds AnchorDetails

> **Technical**: What should be noted about the implementation?
There are still a couple of fields in TileComponent that are available in Dweb, but its unclear where they come from in a server-side implementation, especially the title of the first collection, since that is required for the text on the Parent-Collection popup image. 

> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
Its tested in dweb-archive using both React or FakeReact, and will be pushed to live version soon. I don't have an obvious way to test in IAUX itself. 

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

