### PR TITLE
Fix extra unneccessary Promises , and document some of the places whe…

### DIFF
--- a/packages/ia-components/sandbox/iajs-test-component/index.jsx
+++ b/packages/ia-components/sandbox/iajs-test-component/index.jsx
@@ -31,6 +31,7 @@ export default class extends Component {
 
   fetchMetadata(identifier) {
     let metadataService = new MetadataService()
+    // TODO-ERRORS Note this has an unhandled error if MetadataService.get fails
     metadataService.get({identifier: identifier}).then(metadata => {
       this.setState({metadata: metadata.data})
     })

--- a/packages/ia-components/sandbox/related-as-list.js
+++ b/packages/ia-components/sandbox/related-as-list.js
@@ -18,6 +18,7 @@ export default class extends React.Component {
     }
 
     const relatedService = new RelatedService()
+    // TODO-ERRORS relatedService.get can fail - should check or this call can fail
     relatedService.get({identifier: this.props.identifier}).then((results) => {
       this.setState({related: results.hits.hits})
     })

--- a/packages/ia-components/sandbox/theatres/audio-1/audio-1-bootstrap.js
+++ b/packages/ia-components/sandbox/theatres/audio-1/audio-1-bootstrap.js
@@ -38,6 +38,7 @@ export default class extends React.Component {
 
     const mdClient = new MetadataService()
 
+    // TODO-ERRORS Note this has an unhandled error if MetadataService.get fails
     mdClient.get({identifier: this.props.identifier}).then((md) => {
       this.setState({
         title: md.data.getSafe('title')[0],

--- a/packages/ia-components/sandbox/theatres/audio-1/audio-1-br-nav-wav.js
+++ b/packages/ia-components/sandbox/theatres/audio-1/audio-1-br-nav-wav.js
@@ -47,6 +47,7 @@ export default class extends React.Component {
 
     const mdClient = new MetadataService()
 
+    // TODO-ERRORS Note this has an unhandled error if MetadataService.get fails
     mdClient.get({identifier: this.props.identifier}).then((md) => {
       this.setState({
         title: md.data.getSafe('title')[0],

--- a/packages/ia-components/sandbox/theatres/audio-1/audio-1.js
+++ b/packages/ia-components/sandbox/theatres/audio-1/audio-1.js
@@ -47,6 +47,7 @@ export default class extends React.Component {
 
     const mdClient = new MetadataService()
 
+    // TODO-ERRORS Note this has an unhandled error if MetadataService.get fails
     mdClient.get({identifier: this.props.identifier}).then((md) => {
       this.setState({
         title: md.data.getSafe('title')[0],

--- a/packages/ia-components/sandbox/theatres/bookreader-theatre/bookreader-theatre.js
+++ b/packages/ia-components/sandbox/theatres/bookreader-theatre/bookreader-theatre.js
@@ -22,6 +22,7 @@ export default class extends React.Component {
 
   componentDidMount() {
     let bookReaderJsIaService = new BookReaderJsIaService()
+    //TODO-ERRORS "get" can fail so should be checked for here, or this can fail.
     bookReaderJsIaService.get({identifier: this.props.item.identifier}).then((jsIaData => {
       this.setState({jsIaData: jsIaData.data})
     }))

--- a/packages/ia-components/sandbox/theatres/theatre-switcher.js
+++ b/packages/ia-components/sandbox/theatres/theatre-switcher.js
@@ -24,7 +24,7 @@ export default class TheatreSwitcher extends React.Component {
     this.state = {
       theatreType: TheatreSwitcher.THEATRE_TYPES.LOADING
     }
-    this.props.item.getMetadataField('mediatype', true).then(values => {
+    this.props.item.getMetadataField('mediatype', true).then(values => { //TODO recommend switch this for getMetadata to avoid multiple parallel calls to Metadata API
       let theatreType = {
         'texts': TheatreSwitcher.THEATRE_TYPES.BOOKREADER,
         'audio': TheatreSwitcher.THEATRE_TYPES.AUDIO,

--- a/packages/ia-js-client/src/controllers/book/book.ts
+++ b/packages/ia-js-client/src/controllers/book/book.ts
@@ -18,6 +18,7 @@ export class BookController {
   //       resolve(this.metadataCache)
   //     } else {
   //       let metadataService = new MetadataService()
+  //       // TODO-ERRORS Note this has an unhandled error if MetadataService.get fails
   //       this.metadataCache = await metadataService.get({identifier: this.identifier})
   //       resolve(this.metadataCache)
   //     }

--- a/packages/ia-js-client/src/services/bookreader-jsia.ts
+++ b/packages/ia-js-client/src/services/bookreader-jsia.ts
@@ -8,23 +8,23 @@ import fetch from 'node-fetch';
 
 export class BookReaderJsIaService {
 
-  public async get (options: {identifier:string, subPrefix?:string}):Promise<any> {
-    return new Promise<any>(async (res, rej) => {
+  public get (options: {identifier:string, subPrefix?:string}):Promise<any> {
       let fullRequestUrl = `https://www-richard.archive.org/bookreader/BookReaderJSLocate.php?id=${encodeURIComponent(options.identifier)}&subPrefix=${encodeURIComponent(options.subPrefix||'')}&format=json`
 
       // let fullRequestUrl = await this.fetchFullUrl(options.identifier)
       // console.log(fullRequestUrl)
-      fetch(fullRequestUrl)
+      return fetch(fullRequestUrl)
         .then(res => res.text())
         .then(body => {
           let raw_response = <any>JSON.parse(body)
           // console.log(raw_response)
-          res(raw_response)
+          return(raw_response)
         })
-        .catch(() => {
-          let empty_reponse = {}
-          rej(empty_reponse)
+        .catch((err) => {
+          throw err;
+          //TODO-ERRORS callers need to check for this reject, (or at least document that they can also fail) and they aren't doing either currently
+          //let empty_reponse = {}
+          //rej(empty_reponse) // This is nonsense - shouldn't reject with data, only errors - its a "resolve" if data is substituted, and anyway none of the callers are checking for this reject anyway !
         });
-    });
   }
 }

--- a/packages/ia-js-client/src/services/details.ts
+++ b/packages/ia-js-client/src/services/details.ts
@@ -34,18 +34,18 @@ export class DetailsService {
    * Fetches the details page data
    * @param identifier the archive.org identifier
    */
-  public async get (options: {identifier:string}):Promise<DetailsResponse> {
-    return new Promise<DetailsResponse>((resolve, reject) => {
-      fetch(`${this.API_BASE}?identifier=${options.identifier}`)
+  public get (options: {identifier:string}):Promise<DetailsResponse> {
+      return fetch(`${this.API_BASE}?identifier=${options.identifier}`)
         .then(res => res.text())
         .then(body => {
           let raw_response = <DetailsResponse>JSON.parse(body)
-          resolve(raw_response)
+          return(raw_response)
         })
-        .catch(() => {
-          let empty_reponse = new DetailsResponse()
-          reject(empty_reponse)
+        .catch((err) => {
+          //TODO-ERRORS callers of this aren't checking for the reject
+          throw err;
+          //let empty_reponse = new DetailsResponse()
+          //rej(empty_reponse) // This is nonsense - shouldn't reject with data, only errors - its a "resolve" if data is substituted, and anyway only caller isnt checking for this reject anyway !
         });
-    });
   }
 }

--- a/packages/ia-js-client/src/services/metadata.ts
+++ b/packages/ia-js-client/src/services/metadata.ts
@@ -5,6 +5,7 @@ import fetch from 'node-fetch';
  * This class is a wrapper for raw Metadata JSON responses
  */
 export class RawMetadataAPIResponse {
+  // This is the data exactly as returned from the metadata API - in particular no check against fulfilling content has been done.
   created:number
   d1:string
   d2:string
@@ -78,22 +79,26 @@ export class MetadataService {
   /**
    * Fetches the full Metadata for an item
    * @param identifier the archive.org identifier
+   * @returns Metadata - encapsulation of raw metadata from the API call
    */
-  public async get (options:{identifier:string}):Promise<Metadata> {
-    return new Promise<Metadata>((resolve, reject) => {
-      fetch(`${this.API_BASE}/${options.identifier}`)
+  public get (options:{identifier:string}):Promise<Metadata> {
+    return fetch(`${this.API_BASE}/${options.identifier}`)
         .then(res => res.text())
         .then(body => {
           let md_response = new RawMetadataAPIResponse(JSON.parse(body))
           let md = new Metadata(md_response)
-          resolve(md)
+          return(md);
         })
-        .catch(() => {
+        .catch((err) => {
+          console.log("Metadata fetch failed");
+          //TODO-ERRORS - note nothing that calls this actually checks whether the promise ended in a rejection ! Each caller has been commented as well.
+          throw(err);
+          /* It makes no sense to reject(md) can only reject errors
           let md_response = new RawMetadataAPIResponse({})
           let responseCode = 500 // TODO get responseCode
           let md = new Metadata(md_response, true, responseCode)
           reject(md)
+           */
         });
-    });
   }
 }

--- a/packages/ia-js-client/src/services/related.ts
+++ b/packages/ia-js-client/src/services/related.ts
@@ -12,20 +12,16 @@ export class RelatedService {
    * @param identifier the archive.org identifier
    */
   public async get (options: {identifier:string}):Promise<any> {
-    return new Promise<any>((resolve, reject) => {
       fetch(`${this.API_BASE}/get_related/all/${options.identifier}`)
         .then(res => res.text())
         .then(body => {
           let raw_response = JSON.parse(body)
-          resolve(raw_response)
+          return(raw_response)
         })
-        .catch(() => {
-          let empty_reponse = {
-            hits: {
-              hits: []
-            }
-          }
-          reject(empty_reponse)
+        .catch((err) => {
+            throw err;
+            // let empty_reponse = { hits: { hits: [] } }
+            //reject(empty_reponse) // This is nonsense - shouldn't reject with data, only errors - its a "resolve" if data is substituted, and anyway only current caller is not checking for this reject anyway !
         });
     });
   }


### PR DESCRIPTION
> **Description**: Fixes poor promise architecture, extra wrapping promises removes, including some async functions that return a promise in a promise in a promise ! Also documents some (not all) of the places where network functions are likely to cause an error, but the code isn't checking for that error or documenting that the functions themselves could fail.  

Closes #90 

> **Technical**: What should be noted about the implementation?

a) its nonsense to reject(data), it should always be reject(err)
b) none of the code actually checked for those rejects coming back
c) async automaticlly returns a promise, no need to wrap in another one
d) fetch.then.catch also returns a promise so no need to wrap that in a promise or async
e) inside async should return or throw, not reject or resolve. 
f) anything that can throw an error (from network functions, which always have failure cases) should IMHO document that fact, or catch the error. 


> **Testing**: Steps for reviewer to reproduce / verify this PR fixes the problem?
I don't have a good way to test this as my code doesnt use these calls at all yet (more cleanup required before that can happen)

I don't have a good way to test this as my code doesnt use these calls at all yet (more cleanup required before that can happen). If there are some tests here and they were 
a) working on old code
b) failing on new code (this PR)
Please let me know how to run the test and I'll fix the code!

> **Evidence**: If this PR touches UI, please post evidence (screenshot) of it behaving correctly:

