### PR TITLE
Moving Youtube player file and Ref anonymous func resolved

### DIFF
--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/youtube-player.js
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/youtube-player.js
@@ -10,7 +10,7 @@ export default class YoutubePlayer extends Component {
        this.loadAPI();
 
         window.onYouTubeIframeAPIReady=()=>{
-          let YTPlayer=new window.YT.Player(this.state.playerAnchor,{
+          let YTPlayer=new window.YT.Player(this.state.playerAnchor.current,{
             height: this.props.height || 390,
             width: this.props.width || 640,
             videoId: this.props.videoId,
@@ -41,7 +41,7 @@ export default class YoutubePlayer extends Component {
   render () {
     return (
       <div className='YoutubePlayer'>
-        <div ref={(r) => { this.state.playerAnchor = r }}></div>
+        <div ref={this.state.playerAnchor}></div>
       </div>
     )
   }

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/youtube-player.js
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/youtube-player.js
@@ -1,0 +1,54 @@
+import React, { Component} from 'react'
+import PropTypes from 'prop-types'
+
+export default class YoutubePlayer extends Component {
+  state={
+    playerAnchor:React.createRef(),
+    YTPlayer:null
+  }
+  componentDidMount () {
+       this.loadAPI();
+
+        window.onYouTubeIframeAPIReady=()=>{
+          let YTPlayer=new window.YT.Player(this.state.playerAnchor,{
+            height: this.props.height || 390,
+            width: this.props.width || 640,
+            videoId: this.props.videoId,
+            playerVars:{
+              controls:'1',
+              autoplay:false
+            },
+            events: {
+              onReady: this.onPlayerReady,
+            }
+          })
+          this.setState({
+            YTPlayer:YTPlayer
+          })
+        }
+  }
+  loadAPI(){
+    const tag = document.createElement('script')
+    tag.src = 'https://www.youtube.com/iframe_api'
+    const firstScriptTag = document.getElementsByTagName('script')[0]
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
+  }
+  onPlayerReady(e) {
+    // e.target.playVideo();
+    // alert('video is on...');
+  }
+
+  render () {
+    return (
+      <div className='YoutubePlayer'>
+        <div ref={(r) => { this.state.playerAnchor = r }}></div>
+      </div>
+    )
+  }
+}
+
+YoutubePlayer.propTypes = {
+  videoId: PropTypes.string.required,
+  width: PropTypes.number,
+  height: PropTypes.number
+}

--- a/packages/ia-components/sandbox/youtube-wrapper/youtube-wrapper.js
+++ b/packages/ia-components/sandbox/youtube-wrapper/youtube-wrapper.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import YoutubePlayer from '../theatres/components/audio-player/players_by_type/youtube-player';
+
+class YoutubeWrapper extends Component {
+  render() {
+    return (
+      <div className="YoutubeWrapper">
+        <YoutubePlayer
+          videoId={this.props.videoId} 
+          height={this.props.height}
+          width={this.props.width}/>
+      </div>
+    );
+  }
+}
+
+YoutubeWrapper.propTypes = {
+  videoId: PropTypes.string.required,
+  width: PropTypes.number,
+  height: PropTypes.number
+};
+
+export default YouTubeWrapper;

--- a/packages/ia-components/sandbox/youtube-wrapper/youtube-wrapper.stories.js
+++ b/packages/ia-components/sandbox/youtube-wrapper/youtube-wrapper.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, boolean, number } from '@storybook/addon-knobs';
+import YoutubePlayerTestComponent from '../theatres/components/audio-player/players_by_type/youtube-player';
+
+storiesOf('Sandbox', module)
+  // .addParameters({ jest: ['example.test.js'] })
+  .addWithJSX('Youtube Wrapper', () => {
+    const videoId = text('videoId', '9QbltzIUV6w');
+    const height = number('height',400);
+    const width = number('width', 600);
+
+    return <YoutubePlayerTestComponent 
+                videoId={videoId} 
+                height={height}
+                width={width}
+                />
+  })
+


### PR DESCRIPTION
**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? 
youtube player file moved to ``/sandbox/theatres/components/audio_player/players_by_type`` directory as suggested and using ref directly which was used using an anonymous function.

> What steps should the reviewer take to verify this PR resolves the issue?
Please review the new file structure of the youtube wrapper component.
Evidence:
![Screenshot from 2019-04-20 21-55-01](https://user-images.githubusercontent.com/22962336/56459849-4e940800-63b7-11e9-90c5-da495e65b2a8.png)


@iisa 