### PR TITLE
Music Player: content box updates

### DIFF
--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
@@ -12,7 +12,7 @@
   }
 
   @media (min-width: 768px) {
-    max-height: 400px;
+    height: 400px;
     max-width: 400px;
   }
 
@@ -23,16 +23,17 @@
     border-right: .1rem solid;
     position: relative;
     overflow: hidden;
-    max-height: inherit;
     padding: .1rem;
-    min-height: 150px;
 
     .background-photo,
     .no-photo {
       display: block;
       margin: auto;
       max-width: 100%;
-      max-height: inherit;
+    }
+
+    .background-photo {
+      min-height: 20rem;
     }
 
     .no-photo {
@@ -65,14 +66,19 @@
 
   .iframe-wrapper,
   .ia-player-wrapper {
-    width: 100%;
-    min-height: inherit;
+    width: 99.5%;
   }
 
   .ia-player-wrapper {
     position: absolute;
     width: 100%;
     bottom: 0px;
+
+    .jwplayer {
+      // this is here because Play8 sets a specific width on the style attribute
+      // we need to trump it
+      width: 100% !important;
+    }
   }
 
   .iframe-wrapper {
@@ -83,8 +89,8 @@
       position: absolute;
       top: 0.1rem;
       left: 0.1rem;
-      width: 99.9%;
-      height: 99.9%;
+      width: 100%;
+      height: 100%;
       right: 0.1rem;
       bottom: 0.1rem;
     }

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -77,9 +77,11 @@ class ArchiveAudioPlayer extends Component {
    * Register this instance of JWPlayer
    */
   registerPlayer() {
-    const { jwplayerInfo, jwplayerID } = this.props;
+    const { jwplayerInfo, jwplayerID, backgroundPhoto } = this.props;
     const { jwplayerPlaylist, identifier, collection } = jwplayerInfo;
-
+    const waveformer = backgroundPhoto
+      ? {}
+      : { waveformer: 'jw-holder', responsive: true };
     // We are using IA custom global Player class to instatiate the player
     const baseConfig = {
       start: 0,
@@ -90,16 +92,15 @@ class ArchiveAudioPlayer extends Component {
       height: 0,
       list_height: 0,
       audio: true,
-      responsive: true,
       identifier,
       collection,
-      waveformer: 'jw-holder',
       hide_list: true,
       onReady: this.onReady
     };
 
     if (window.Play && Play) {
-      const player = Play(jwplayerID, jwplayerPlaylist, baseConfig);
+      const compiledConfig = Object.assign({}, baseConfig, waveformer);
+      const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
       this.setState({ player });
     }
   }


### PR DESCRIPTION
**Description**
There are a few display bugs with the music player's content window -
- waveform is blocking background photo
- if no background photo, the content box is flattened
- the content box's player wrapper was holding a height, this should grow/shrink accordingly
- IA's jwplayer wrapper is too short in width, needs to be full width


**Technical**
To address the above, the following has been updated:
- content box's height is fixed when desktop view
- add a min-height to background photos
- force jwplayer to be full width as a stop gap until there is more time for Play8 updates (not ideal, but not a deal breaker)
- toggle waveform if there is background photo
