### PR TITLE
Music Player improvements + JWPlayer updates integration

### DIFF
--- a/packages/ia-components/sandbox/pagination/pagination-with-flexbox.jsx
+++ b/packages/ia-components/sandbox/pagination/pagination-with-flexbox.jsx
@@ -77,10 +77,9 @@ class Paginator extends Component {
    * If item is off page, then scroll item to view & save the page in view in state
    */
   setItemInView() {
-    const { itemInViewClass } = this.props;
     const { scrollThresholds } = this.state;
-    const item = document.querySelector(itemInViewClass);
     const viewport = this.Paginator.current;
+    const item = viewport.firstElementChild;
 
     const pages = Object.keys(scrollThresholds);
     let thisPage = null;

--- a/packages/ia-components/sandbox/pagination/pagination.less
+++ b/packages/ia-components/sandbox/pagination/pagination.less
@@ -31,7 +31,7 @@
     border-style: solid;
     border-width: 0.1rem;
     background-color: transparent;
-    height: 1.4rem;
+    height: 1.5rem;
     width: 1rem;
     margin: 0 .5rem;
   

--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player-main.jsx
@@ -37,8 +37,20 @@ export default class TheatreAudioPlayer extends Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      urlSetterFN: null,
+    };
+
     this.showMedia = this.showMedia.bind(this);
     this.createTabs = this.createTabs.bind(this);
+    this.receiveURLSetter = this.receiveURLSetter.bind(this);
+  }
+
+  /**
+   * Save URL Setter function that comes back from Play8 instantiation
+   */
+  receiveURLSetter(urlSetterFN) {
+    this.setState({ urlSetterFN });
   }
 
   /**
@@ -47,25 +59,40 @@ export default class TheatreAudioPlayer extends Component {
   showMedia() {
     const { source, sourceData } = this.props;
     const isExternal = source === 'youtube' || source === 'spotify';
-    let mediaElement = <ArchiveAudioPlayer {...this.props} />;
+    let mediaElement = (
+      <ArchiveAudioPlayer
+        {...this.props}
+        onRegistrationComplete={this.receiveURLSetter}
+        needsURLSettingAccess
+      />
+    );
     if (isExternal) {
       // make iframe with URL
+      const { urlSetterFN } = this.state;
       const externalSourceDetails = sourceData[source] || {};
       const {
         urlPrefix = '', id = '', urlExtensions = '', name = ''
       } = externalSourceDetails;
+
+      const { trackNumber = 1 } = sourceData;
 
       const sourceURL = `${urlPrefix}${id}${urlExtensions}`;
       mediaElement = (
         <ThirdPartyEmbeddedPlayer
           sourceURL={sourceURL}
           title={name}
+
         />
       );
+      // updateURL
+      if (urlSetterFN) {
+        urlSetterFN(trackNumber);
+      }
     }
 
     return mediaElement;
   }
+
 
   /**
    * Render function - create tabs that live under the main content area

--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
@@ -34,6 +34,7 @@
 
     .background-photo {
       min-height: 20rem;
+      max-height: 40rem;
     }
 
     .no-photo {

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -23,6 +23,7 @@ class ArchiveAudioPlayer extends Component {
     this.registerPlayer = this.registerPlayer.bind(this);
     this.onPlaylistItemCB = this.onPlaylistItemCB.bind(this);
     this.emitPlaylistChange = this.emitPlaylistChange.bind(this);
+    this.postRegistration = this.postRegistration.bind(this);
     this.onReady = this.onReady.bind(this);
   }
 
@@ -71,6 +72,7 @@ class ArchiveAudioPlayer extends Component {
     // User Play class instance to set event listeners
     const { player } = this.state;
     player.on('playlistItem', this.onPlaylistItemCB);
+    this.postRegistration();
   }
 
   /**
@@ -106,6 +108,27 @@ class ArchiveAudioPlayer extends Component {
   }
 
   /**
+   * Post JWPlayer registration handler - returns optional registration callback
+   *
+   * Currently, this is where we support external ability to set URL
+   * through Internet Archive's JWPlayer Wrapper
+   */
+  postRegistration() {
+    const { onRegistrationComplete, jwplayerInfo, needsURLSettingAccess = false } = this.props;
+    const { identifier = '' } = jwplayerInfo;
+
+    if (onRegistrationComplete && needsURLSettingAccess) {
+      const externallySyncURL = function externallySyncURL (identifier, trackNumber) {
+        const playlistIndex = trackNumber - 1 || 0;
+        if (window.Play && Play && identifier) {
+          return Play(identifier).playN(playlistIndex, false, true);
+        }
+      }.bind(null, identifier);
+      onRegistrationComplete(externallySyncURL);
+    }
+  }
+
+  /**
    * Fires callback `jwplayerPlaylistChange` given by props
    */
   emitPlaylistChange() {
@@ -133,16 +156,24 @@ ArchiveAudioPlayer.defaultProps = {
   backgroundPhoto: '',
   photoAltTag: '',
   jwplayerID: '',
+  jwplayerPlaylistChange: null,
+  jwPlayerPlaylist: [],
+  jwplayerInfo: {},
+  sourceData: null,
+  onRegistrationComplete: null,
+  needsURLSettingAccess: false,
 };
 
 ArchiveAudioPlayer.propTypes = {
   backgroundPhoto: PropTypes.string,
   photoAltTag: PropTypes.string,
   jwplayerID: PropTypes.string,
-  jwplayerPlaylistChange: PropTypes.func.isRequired,
-  jwPlayerPlaylist: PropTypes.array.isRequired,
-  jwplayerInfo: PropTypes.object.isRequired,
-  sourceData: PropTypes.object.isRequired,
+  jwplayerPlaylistChange: PropTypes.func,
+  jwPlayerPlaylist: PropTypes.array,
+  jwplayerInfo: PropTypes.object,
+  sourceData: PropTypes.object,
+  onRegistrationComplete: PropTypes.func,
+  needsURLSettingAccess: PropTypes.bool,
 };
 
 export default ArchiveAudioPlayer;

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -57,10 +57,10 @@ class ArchiveAudioPlayer extends Component {
       stateUpdate.playerPlaylistIndex = index;
       postStateCB = () => {
         player.playN(index);
-      }
+      };
     }
 
-    if (Object.keys(stateUpdate).length) {
+    if (Object.keys(stateUpdate).length > 0) {
       this.setState(stateUpdate, postStateCB);
     }
 
@@ -135,7 +135,7 @@ class ArchiveAudioPlayer extends Component {
     const { identifier = '' } = jwplayerInfo;
 
     if (onRegistrationComplete && needsURLSettingAccess) {
-      const externallySyncURL = function externallySyncURL (identifier, trackNumber) {
+      const externallySyncURL = function externallySyncURL(identifier, trackNumber) {
         const playlistIndex = trackNumber - 1 || 0;
         if (window.Play && Play && identifier) {
           return Play(identifier).playN(playlistIndex, false, true);

--- a/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
+++ b/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
@@ -14,12 +14,12 @@ import { FlexboxPagination } from '../../../..';
  * @return { string or react fragment } trackTitle
  */
 const parseTrackTitle = ({
-  name,
-  title,
+  name = '',
+  title = '',
   albumCreator,
   creator = '',
   artist = '',
-  isAlbum
+  isAlbum = false
 }) => {
   if (isAlbum) { return 'Full album'; }
 
@@ -47,9 +47,10 @@ const parseTrackTitle = ({
  *
  * @return component
  */
-const trackButton = ({
-  selected, onSelected, thisTrack, displayTrackNumbers, albumCreator
-}) => {
+const trackButton = (props) => {
+  const {
+    selected, onSelected, thisTrack, displayTrackNumbers, albumCreator
+  } = props;
   const { trackNumber, length, formattedLength } = thisTrack;
   const key = `individual-track-${trackNumber}`;
   const trackTitle = parseTrackTitle({ ...thisTrack, albumCreator });

--- a/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
+++ b/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
@@ -87,16 +87,20 @@ class TheatreTrackList extends Component {
     } = this.props;
 
     if (!tracks.length) return <p className="no-tracks">No tracks to display.</p>;
+
+    const [ firstTrack = {} ] = tracks;
+    const trackNumberToHighlight = selectedTrack || firstTrack.trackNumber || null;
+    const itemToViewClass = `[data-track-number="${trackNumberToHighlight}"]`;
     return (
       <div className="audio-track-list">
         <FlexboxPagination
-          itemInViewClass={`[data-track-number="${selectedTrack}"]`}
+          itemInViewClass={itemToViewClass}
           {...this.props}
         >
           {
             tracks.map((thisTrack) => {
               const { trackNumber } = thisTrack;
-              const selected = trackNumber === selectedTrack;
+              const selected = trackNumber === trackNumberToHighlight;
               return trackButton({
                 thisTrack, onSelected, selected, displayTrackNumbers, albumCreator
               });

--- a/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
+++ b/packages/ia-components/sandbox/theatres/components/track-list/track-list.jsx
@@ -89,7 +89,7 @@ class TheatreTrackList extends Component {
 
     if (!tracks.length) return <p className="no-tracks">No tracks to display.</p>;
 
-    const [ firstTrack = {} ] = tracks;
+    const [firstTrack = {}] = tracks;
     const trackNumberToHighlight = selectedTrack || firstTrack.trackNumber || null;
     const itemToViewClass = `[data-track-number="${trackNumberToHighlight}"]`;
     return (

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -68,7 +68,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       albumData,
       tracklistToShow: [],
       channelToPlay: 'archive',
-      trackSelected: 1, /* 0 = album */
+      trackSelected: null, /* 0 = album */
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -79,8 +79,17 @@ class AudioPlayerWithYoutubeSpotify extends Component {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { albumData } = state;
+    const { albumMetadata = {}, playFullIAAudio } = props;
+    const { metadata = {} } = albumMetadata;
+    const { identifier } = metadata;
+    const { albumData: stateData } = state;
+
+    let albumData = stateData;
+    if (identifier[0] !== stateData.identifier[0]) {
+      albumData = flattenAlbumData(albumMetadata, playFullIAAudio);
+    }
     const tracklistToShow = getTrackListBySource(albumData, state.channelToPlay);
+
     return {
       albumData,
       tracklistToShow,

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -161,6 +161,19 @@ class DataHydrator extends Component {
                 </td>
               </tr>
               <tr>
+                <td>what_cd (Irregular Photo)</td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-success"
+                    data-identifier="wcd_message-in-a-box-th_the-police_flac_lossless_807968"
+                    onClick={this.getItem}
+                  >
+                    wcd_message-in-a-box-th_the-police_flac_lossless_807968
+                  </button>
+                </td>
+              </tr>
+              <tr>
                 <td>acdc (NO PHOTO)</td>
                 <td>
                   <button


### PR DESCRIPTION
This includes fixes specifically for these:
- Music Player, content window: background photo must hold aspect ratio
- Make pagination buttons round
- Music Player: on page load, click on highlighted track starts IA music player


JWPlayer Play8.js plumbing for:
- waveform toggle (only show waveform if no background photo is available)
- using Play8.js to set url so changing tracks between channels stay in sync

PLUS:
- data handling improvements
