### PR TITLE
Music Player, JWPlayer: adding a black background to wrapper so controls can be seen

### DIFF
--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
@@ -74,7 +74,7 @@
     position: absolute;
     width: 100%;
     bottom: 0px;
-    
+
     .jwplayer {
       // this is here because Play8 sets a specific width on the style attribute
       // we need to trump it

--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
@@ -74,7 +74,7 @@
     position: absolute;
     width: 100%;
     bottom: 0px;
-
+    
     .jwplayer {
       // this is here because Play8 sets a specific width on the style attribute
       // we need to trump it

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -156,11 +156,18 @@ class ArchiveAudioPlayer extends Component {
 
   render() {
     const {
-      jwplayerID
+      jwplayerID,
+      backgroundPhoto
     } = this.props;
+
+    // jwplayerStyleHack - specifically calling this out because
+    // fix needs to be made on IA's JWPlayer wrapper style
+    // issue is that waveform is still showing up in the truncated view of the player
+    // adding a black background should allow for controls to be visible.
+    const jwplayerStyleHack = backgroundPhoto ? { backgroundColor: 'black' } : {};
     return (
       <div className="ia-player-wrapper">
-        <div className="iaux-player-wrapper">
+        <div className="iaux-player-wrapper" style={jwplayerStyleHack}>
           <div id={jwplayerID} />
         </div>
       </div>


### PR DESCRIPTION
This is a hack and should be removed once it is fixed on the IA JWPlayer Wrapper side
