### PR TITLE
Music Player updates

### DIFF
--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player-main.jsx
@@ -115,12 +115,27 @@ export default class TheatreAudioPlayer extends Component {
   }
 
   render() {
+    // Make sure content window stays the same when toggling between sources
+    // the JWplayer controls sit UNDER the album photo
+    // while the other players overtake the whole content-window
+    // We will have to accomodate the window's fixed height here.
+    const { backgroundPhoto } = this.props;
+    const jwplayerHeightNoWaveform = '4.4rem';
+    const jwplayerHeightYesWaveform = '14rem';
+    const mediaPlayerSectionStyle = backgroundPhoto
+      ? { height: jwplayerHeightNoWaveform }
+      : { height: jwplayerHeightYesWaveform };
+
     return (
       <section className="theatre__audio-player">
         <div className="content-window">
-          {drawBackgroundPhoto(this.props)}
-          {this.showMedia()}
-          { /* todo: add liner notes book reader here */ }
+          <div className="album-cover">
+            {drawBackgroundPhoto(this.props)}
+          </div>
+          <div className="media-player" style={mediaPlayerSectionStyle}>
+            {this.showMedia()}
+            { /* todo: add liner notes book reader here */ }
+          </div>
         </div>
         <div className="tabs">
           {this.createTabs()}

--- a/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/audio-player.less
@@ -1,7 +1,6 @@
 
 .theatre__audio-player {
-  margin: 1rem auto 2rem;
-  width: 97%;
+  margin: auto;
 
   @media (min-width: 500px) and (max-width: 599px) {
     width: 90%;
@@ -12,7 +11,6 @@
   }
 
   @media (min-width: 768px) {
-    height: 400px;
     max-width: 400px;
   }
 
@@ -41,7 +39,7 @@
       font-size: 10rem;
       text-align: center;
       padding-top: 14%;
-      height: 30rem;
+      height: 20rem;
     }
   }
 
@@ -70,11 +68,12 @@
     width: 99.5%;
   }
 
-  .ia-player-wrapper {
-    position: absolute;
-    width: 100%;
-    bottom: 0px;
+  .ia-player-wrapper,
+  .iframe-wrapper {
+    height: 4.4rem; // accomodate height for jwplayer controls
+  }
 
+  .ia-player-wrapper {
     .jwplayer {
       // this is here because Play8 sets a specific width on the style attribute
       // we need to trump it
@@ -83,9 +82,6 @@
   }
 
   .iframe-wrapper {
-    position: absolute;
-    top: 0;
-    bottom: 0;
     .iframe {
       position: absolute;
       top: 0.1rem;

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -237,7 +237,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       externalSources = [],
       itemPhoto,
       externalSourcesDisplayValues,
-      playSamples
+      playSamples,
+      creator: origCreator = []
     } = albumData;
     const {
       title,
@@ -298,7 +299,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
               selectedTrack={trackSelected}
               albumName={title}
               displayTrackNumbers={isArchiveChannel}
-              creator={creator}
+              creator={origCreator[0] || creator}
               dataEventCategory="Audio-Player"
             />
           </section>

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
@@ -53,6 +53,10 @@
   }
 
   @media (max-width: @audio-player-tablet-max-width) {
+    .media-section {
+      margin-bottom: 2rem;
+    }
+
     .channel-controls {
       margin-left: auto;
       margin-right: auto;
@@ -84,11 +88,13 @@
     }
 
     padding-left: 1rem;
-    padding-bottom: 2rem;
+    padding-bottom: 1rem;
 
     .media-section {
       max-width: 40rem;
       margin-right: 2rem;
+      margin-left: 1rem;
+      margin-bottom: 1rem;
     }
 
     .playlist-section {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -32,7 +32,8 @@ const stringifyAlbumDetails = (albumMetadata) => {
   const constructedData = reduce(normalizedMetadata, (stringifiedInfo, value, key) => {
     stringifiedInfo = stringifiedInfo || {};
     const isArray = Array.isArray(value);
-    const newValue = isArray ? value.join(', ') : (value || '');
+    const delimiter = key === 'creator' ? '; ' : ', ';
+    const newValue = isArray ? value.join(delimiter) : (value || '');
     stringifiedInfo[key] = newValue;
     return stringifiedInfo;
   }, {});

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
@@ -25,9 +25,12 @@ const getTrackListBySource = (albumData, sourceToPlay) => {
   if (sourceToPlay === 'archive') {
     if (playSamples) {
       const sampleMP3s = tracks.map((track, index) => {
-        const { sampleMP3 } = track;
+        const {
+          sampleMP3, title, creator, artist = ''
+        } = track;
+        const trackDetails = { title, creator, artist };
         const trackNumber = index + 1;
-        return Object.assign({}, sampleMP3, { trackNumber });
+        return Object.assign({}, sampleMP3, { trackNumber, ...trackDetails });
       });
 
       return sampleMP3s;
@@ -52,11 +55,14 @@ const getTrackListBySource = (albumData, sourceToPlay) => {
     };
     const tracksToReturn = [];
     const tracksWithExternalSource = tracks.reduce((allTracks = [albumPlaceholder], track, index) => {
-      const { length = '' } = track;
+      const {
+        length = '', title, creator, artist = ''
+      } = track;
+      const trackDetails = { title, creator, artist };
       const trackLengthFormatted = length.indexOf(':') > 0;
       const formattedLength = !trackLengthFormatted ? formatTime(length) : length;
       const trackNumber = index + 1;
-      const formattedTrack = Object.assign({}, track, { formattedLength, trackNumber });
+      const formattedTrack = Object.assign({}, track, { formattedLength, trackNumber, ...trackDetails });
       if (track.hasOwnProperty(sourceToPlay)) { allTracks.push(formattedTrack); }
       return allTracks;
     }, []);


### PR DESCRIPTION
Fixes the following:
- [x] Music Player: JWPlayer sits under album cover
  - Keeps `content-window` box height while changing channels
  - keeps photo height, width cap at 400px
  - handles portrait aspect photos
- [x] Music Player, track display: 
  - show title in sample mp3
  - omit album artist