### PR TITLE
RelatedItems component

### DIFF
--- a/packages/ia-components/sandbox/AnchorDetails.js
+++ b/packages/ia-components/sandbox/AnchorDetails.js
@@ -12,39 +12,31 @@ export default class AnchorDetails extends IAReactComponent {
     React+Dweb:  onClick={this.click}
     FakeReact+Dweb: strangely seems to work with onClick={this.click}
     */
-
-    /* Maybe Used in IAUX in future, but not in ReactFake
-    Note other propTypes are passed to underlying Anchor - ones known in use are:
-    static propTypes = {
-        identifier: PropTypes.string.isRequired,
-        href: PropTypes.string.isRequired,
-    };
-    */
     constructor(props)
     {
-        //TODO-IAUX what about other props and children
-        // children: [ react.element* ]
         super(props);
-        this.onClick = (ev) => { return this.clickCallable.call(this, ev); };
     }
     clickCallable(ev) {
+        // Note this is only called in dweb; !Dweb has a director href
         debug("Cicking on link to details: %s",this.props.identifier);
-        Nav.nav_details(this.props.identifier);
-        ev.preventDefault();    // Prevent it going to the anchor (equivlent to "return false" in non-React
-        // ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); // Suggested alternatives which dont work
-        return false; // Stop the non-react version propogating
+        DwebArchive.Nav.nav_details(this.props.identifier);
+        return false; // Dont propogate event
     }
     render() {
         // this.props passes identifier which is required for Dweb, but typically also passes tabIndex, class, title
-        return ((typeof DwebArchive === "undefined") ?
-                <a href={`https://archive.org/details/${this.props.identifier}`} {...this.props}>
-                    {this.props.children}
-                </a>
-            :
+        const url = new URL(`https://archive.org/details/${this.props.identifier}`);
+        const usp = new URLSearchParams;
+        AnchorDetails.urlparms.forEach(k=> usp.append(k, this.props[k]))
+        usp.search = usp; // Note this copies, not updatable
+        const anchorProps = ObjectFilter(this.props, (k,v)=>(!AnchorDetails.urlparms.includes(k) && !['chidren'].includes(k)));
+        return ( // Note there is intentionally no spacing in case JSX adds a unwanted line break
+            (typeof DwebArchive === "undefined") ?
+                <a href={url.href} {...anchorProps}>{this.props.children}</a>
+                :
                 // This is the Dweb version for React|!React
-                <a href={`https://archive.org/details/${this.props.identifier}`} onClick={this.onClick}  {...this.props}>
-                    {this.props.children}
-                </a>
-            );
+                <a href={url.href} onClick={this.onClick}  {...anchorProps}>{this.props.children}</a>
+        );
     }
 }
+AnchorDetails.urlparms=['sort']; // Properties that go in the URL to details
+//Note other propTypes are passed to underlying Anchor - ones known in use are: tabIndex, id, className, data-event-click-tracking, title

--- a/packages/ia-components/sandbox/tiles/ParentTileImg.js
+++ b/packages/ia-components/sandbox/tiles/ParentTileImg.js
@@ -1,3 +1,5 @@
+//import React from '../../ReactFake';
+//import IAFakeReactComponent from '../IAFakeReactComponent';
 import React from 'react';
 import IAReactComponent from '../IAReactComponent';
 

--- a/packages/ia-components/sandbox/tiles/RelatedItems.js
+++ b/packages/ia-components/sandbox/tiles/RelatedItems.js
@@ -1,0 +1,93 @@
+const debug = require('debug')('dweb-archive:RelatedItems');
+//Note this component is Real-React only, it may or may not work in ReactFake
+import React from 'react';
+import IAReactComponent from '../IAReactComponent'; // Encapsulates differences between dweb-archive/ReactFake and iaux/React
+import TileComponent from "@internetarchive/ia-components/sandbox/tiles/TileComponent.js";
+//import PropTypes from 'prop-types' // Not currently used by IAUX
+
+/* RelatedItems is a component intended for the bottom of details page to display related items.
+    It can be called either with members=[member*] in which case it will render them immediately
+    or more usually will be called with item=ArchiveItem in which case it will call ArchiveItem.relatedMembers and render the result via RelatedItemsInner
+    It should be easy to hook this into IAUX's related items service if anyone is using this.
+
+
+    Members are, or should look like, ArchiveMember as defined in the dweb-archivecontroller repo.
+    If there is an alternative structure that is suitable for passing in, then it should be easy to handle any minor differences here.
+
+    Its currently used in dweb-archive/Details.js
+ */
+
+class RelatedItemsInner extends IAReactComponent {
+    // Utility component run when asynchronous fetch returns
+
+    constructor(props)
+    {
+        super(props) //members
+        console.assert(props.members)
+    }
+    render() { return (
+        <div className="row">
+            <div className="col-xs-12 tilebars" style={{display: "block"}}>
+                <h5 className="small-label">SIMILAR ITEMS (based on metadata){/*<span id="playplayset">
+                        *<a data-reactroot="" className="stealth" href="#play-items" data-event-click-tracking="Playset|PlayAllLink"><span
+                        className="iconochive-play" aria-hidden="true"></span><span className="sr-only">play</span><span
+                        className="hidden-xs-span"> Play All</span><br></a></span>*/}</h5>
+                <div id="also-found-result">
+                    <section data-reactroot="" aria-label="Related Items">
+                        { this.props.members.map(member => // Note this is odd - results normally encloses all teh tasks, but AJS.tiler doesnt seem to work without this
+                            <div className="results" key={member.identifier} style={{visibility: "visible"}}>
+                                <TileComponent member={member}/>
+                            </div>
+                        ) }
+                    </section>
+                </div>
+            </div>
+        </div>
+    )}
+}
+
+export default class RelatedItems extends IAReactComponent {
+    /* -- Not used with ReactFake or current IAUX yet
+    static propTypes = {
+        identifier: PropTypes.string,
+        members: PropTypes.array, // of ArchiveMembers or similar
+        item:   ArchiveItem (essentially something that has a relatedItems({...}) method that can return [member*]
+     */
+    constructor(props)
+    {
+        super(props); //identifier, members, item
+        this.state.members = this.props.members; // Maybe undefined, but has to be in .state so can change
+        console.assert(this.props.item || this.props.members,"Must pass either item or members")
+    }
+
+    loadcallable(enclosingdiv) {
+        // called via ref=this.load when the component is loaded, triggers async load via API if .members undefined
+        if (this.props.item && !this.state.members) {
+            this.props.item.relatedItems({wantStream:false, wantMembers:true}, (err, members) => {
+                if (!err) { // If there is an error then fetch_json will have reported it, and can just ignore it here and not display
+                    // In real react, rely on side-effect of setting state, this is untested in ReactFake
+                    this.setState({members: members});
+                    //Next two lines dont work in React as cant .appendChild a React obj to DOM but in real react setState triggers a rerender
+                    //while (enclosingdiv.lastChild) { enclosingdiv.removeChild(enclosingdiv.lastChild); } // Remove "Loading related..."
+                    //enclosingdiv.appendChild( <RelatedItemsInner members={members}/> );
+                }
+            });
+        }
+    }
+
+    render() {
+        return ((this.props.identifier) ?
+                    // Static or asynchronously loaded members handled here
+                    <div id="also-found" className="container container-ia width-max"
+                        data-identifier={this.props.identifier} ref={this.load}>
+                        {!this.state.members ?
+                            <span>Loading related items...</span>
+                            :
+                            <RelatedItemsInner members={this.state.members}/>
+                        }
+                    </div>
+                // No related items on home page, searches, maybe other places
+                : null);
+    }
+}
+

--- a/packages/ia-components/sandbox/tiles/RelatedItems.js
+++ b/packages/ia-components/sandbox/tiles/RelatedItems.js
@@ -1,15 +1,13 @@
-const debug = require('debug')('dweb-archive:RelatedItems');
+const debug = require('debug')('ia-components:RelatedItems');
 //Note this component is Real-React only, it may or may not work in ReactFake
 import React from 'react';
 import IAReactComponent from '../IAReactComponent'; // Encapsulates differences between dweb-archive/ReactFake and iaux/React
-import TileComponent from "@internetarchive/ia-components/sandbox/tiles/TileComponent.js";
-//import PropTypes from 'prop-types' // Not currently used by IAUX
+import TileComponent from "./TileComponent.js";
 
 /* RelatedItems is a component intended for the bottom of details page to display related items.
     It can be called either with members=[member*] in which case it will render them immediately
     or more usually will be called with item=ArchiveItem in which case it will call ArchiveItem.relatedMembers and render the result via RelatedItemsInner
-    It should be easy to hook this into IAUX's related items service if anyone is using this.
-
+    It should be easy to hook this into IAUX's related items service if anyone wants to use that.
 
     Members are, or should look like, ArchiveMember as defined in the dweb-archivecontroller repo.
     If there is an alternative structure that is suitable for passing in, then it should be easy to handle any minor differences here.

--- a/packages/ia-components/sandbox/tiles/TileComponent.js
+++ b/packages/ia-components/sandbox/tiles/TileComponent.js
@@ -6,6 +6,16 @@ import IAReactComponent from '../IAReactComponent'; // Encapsulates differences 
 //TODO-IAUX need to standardise API as this uses the "ArchiveMemberSearch" class to provide necessary details for the Tile.
 //import ArchiveMemberSearch from "@internetarchive/dweb-archivecontroller/ArchiveMemberSearch";
 import TileImage from "./TileImage";
+
+/* USE OUTSIDE DWEB
+For use outside Dweb its going to need the "collection0title" which is the title of the 0th collection in the collections the item is part of, its
+popped up when the user mouses over the top left corner.
+This is (reasonably) not provided by the search. I'm guessing in the Php that there is a cache mapping collection > collection.title.
+In Dweb it is added to the metadata by the gateway
+Once other use's figure out how to handle this the interface might need tweaking, for example to pass in an optional prop "collection0title"
+*/
+//TODO The pop up of the parent collection image doesnt work well, this is a CSS issue, present on dweb as well. Needs a CSS expert to look at it.
+
 import ParentTileImg from "./ParentTileImg";
 import AnchorDetails from "../AnchorDetails";
 
@@ -37,15 +47,7 @@ export default class TileComponent extends IAReactComponent {
     {
         super(props);
         this.state.identifier = props.identifier || props.member.identifier;
-    }
 
-    iconnameClass(mediatype) {
-        // Get the class for the icon, has to handle some exceptions - there used to be many more obsolete mediatypes without iconochive's but these appear to have been cleaned up
-        const exceptions = { account: "person", video: "movies"}
-        return "iconochive-"+ (exceptions[mediatype] || mediatype)
-    }
-
-    render() {
         try {
             console.assert(this.props.member, "If using TileComponent.render should have a member with at least mediatype to work with");
             const member = this.props.member;
@@ -69,9 +71,18 @@ export default class TileComponent extends IAReactComponent {
                 numReviews: member.num_reviews || (item && item.reviews && item.reviews.length) || 0
             })
         } catch(err) { // Catch error here as not generating debugging info at caller level for some reason
-            debug("ERROR in TileComponent.render for %s:", this.state.identifier, err.message);
-            enclosingdiv.parentNode.removeChild(enclosingdiv);
+            debug("ERROR in TileComponent.constructor for %s: %s", this.state.identifier, err.message);
         }
+
+    }
+
+    iconnameClass(mediatype) {
+        // Get the class for the icon, has to handle some exceptions - there used to be many more obsolete mediatypes without iconochive's but these appear to have been cleaned up
+        const exceptions = { account: "person", video: "movies"}
+        return "iconochive-"+ (exceptions[mediatype] || mediatype)
+    }
+
+    render() {
         return (
             <div className={this.state.classes} data-id={this.state.identifier}  key={this.state.identifier}>
                 { (this.state.collection0) ? // Believe, but not certain, that there is always going to be a collection0

--- a/packages/ia-components/sandbox/tiles/TileGrid.js
+++ b/packages/ia-components/sandbox/tiles/TileGrid.js
@@ -1,0 +1,113 @@
+const debug = require('debug')('ia-components:TileGrid');
+//Note this component is only tested on Real React it may or may not work in ReactFake
+import React from 'react';
+import IAReactComponent from '../IAReactComponent'; // Encapsulates differences between dweb-archive/ReactFake and iaux/React
+import TileComponent from "./TileComponent.js";
+//import PropTypes from 'prop-types' // Not currently used by IAUX
+
+/* This is the inner part of a tile grid, see dweb-archive/Search.js for an example of its use
+    There are two components here.
+    <TileGrid members=[ArchiveMember*]>
+    <ScrollableTileGrid item=ArchiveItem>
+    Both depend on dweb-archivecontroller since TileComponent does, and in particular ScrollableTileGrid calls ArchiveItem.proto.more() to update
+
+    They depend on the CSS copied from archive.org to dweb-archive.org, that could be put inside this component if required.
+
+ */
+
+class TileGrid extends IAReactComponent {
+    constructor(props) {
+        super(props); //members
+        console.assert(props.members)
+    }
+    render() {
+        return (
+                    <div className="results" id="appendTiles">
+                        <div className="item-ia mobile-header hidden-tiles" data-id="__mobile_header__">
+                            <div className="views C C1"><span className="iconochive-eye" aria-hidden="true"></span><span
+                                className="sr-only">eye</span></div>
+                            <div className="C234">
+                                <div className="C C2">Title</div>
+                                <div className="pubdate C C3">
+                                    <div>
+                                        <div>Date Archived</div>
+                                    </div>
+                                </div>
+                                <div className="by C C4">Creator</div>
+                            </div>
+                            <div className="C C5"></div>
+                        </div>
+                        {this.props.members.map(member => // Note rendering tiles is quick, its the fetch of the img (async) which is slow.
+                            <TileComponent key={member.identifier} member={member}/>
+                        )}
+                    </div>
+        );
+    }
+}
+class ScrollableTileGrid extends IAReactComponent {
+    constructor(props) {
+        super(props); //item
+        console.assert(props.item.members);
+        this.state.xxx=true;
+        $(window).scroll(()=>{ this.scrolled.call(this)} )
+    }
+
+    // Replaces AJS.scrolled which doesnt have a way to send a click to a react object
+    scrolled() {
+        // TODO shouldnt really depend on jquery
+        const newtop = $(window).scrollTop()
+        // log('scrolled to ', newtop)
+
+        const selector = '.more_search:visible'
+        const $e = $(selector)
+        if (!$e.length)
+            return
+
+        // make the edge detect for "hit bottom" 40 pixels from the bottom
+        const check = (($e.offset().top + $e.outerHeight()) - $(window).height()) - 40
+        // log('-v- check', check)
+        if (newtop > check) {
+            debug('hit rock bottom > ', check)
+            if (!AJS.more_searching)
+                this.clickCallable()
+        }
+    }
+
+
+    clickCallable() { // More
+        AJS.more_searching = true;
+        const el = document.getElementById("appendTiles"); // Get the el, before the search in case user clicks away we add to right place
+        this.props.item.more({}, (err, newmembers) => {  // Appends to this.members but returns just the new ones
+            if (this.isFakeReact) {
+                if (!err) { // If there is an error, just ignore it but un-increment page
+                    newmembers.forEach(member => React.addKids(el, <TileComponent member={member}/>));
+                    AJS.tiler();
+                }
+            } else { //Real react
+                debug("TODO should be getting state here");
+                this.setState({xxx: !this.xxx});    // Force it to rerender since its state.members didnt change, but the contents of it did.
+            }
+            AJS.more_searching = false;
+        });
+    }
+
+    /* TODO If we still want automatic scrolling under React
+       Collection.archive_setup_push registers AJS.scrolled in $(window).scroll, that works but sending the "click" method doesn't work
+    */
+    render() {
+        return (
+            <div style={{position:"relative"}}>
+                <div id="ikind-search" className="ikind in">
+                    <TileGrid members={this.props.item.members}/>
+                    <center className="more_search">
+                        <a className="btn btn-info btn-sm" onClick={this.onClick} style={{visibility:"hidden"}} href="#">MORE RESULTS</a><br/>
+                        <span className="more-search-fetching">Fetching more results <img
+                            src="./images/loading.gif" alt="loading"/></span>
+                    </center>
+                </div>
+            </div>
+        );
+        // AJS.tiler(); Don't run AJS.tiler here as it will tile before any loaded and just give one column stopping inner AJS.tiler's from working
+    }
+}
+export {TileGrid, ScrollableTileGrid}

--- a/packages/ia-components/sandbox/tiles/TileImage.js
+++ b/packages/ia-components/sandbox/tiles/TileImage.js
@@ -1,6 +1,7 @@
 //import React from '../../ReactFake';
 import React from 'react';
 import IAReactComponent from '../IAReactComponent';
+const debug = require('debug')("ia-components:TileImage");
 
 export default class TileImage extends IAReactComponent {
     /* Used in IAUX, but not in ReactFake
@@ -18,8 +19,12 @@ export default class TileImage extends IAReactComponent {
     // loadImg is only called in the ReactFake case, not in the "real" React.
     loadcallable(enclosingspan) { // Defined as a closure so that can access identifier
         DwebArchive.ReactFake.p_loadImg(enclosingspan, "__ia_thumb.jpg", `/services/img/${this.props.identifier}`, (err, el) => {
-            DwebArchive.ReactFake.setAttributes(el, "img", {className: this.props.className, imgname: this.props.imgname});
-            AJS.tiler(); // Make it redraw after img size known
+            if (err) {
+                debug("Fail to load %s: %s", "/services/img/${this.props.identifier", err.message);
+            } else {
+                DwebArchive.ReactFake.setAttributes(el, "img", {className: this.props.className, imgname: this.props.imgname});
+                AJS.tiler(); // Make it redraw after img size known
+            }
         }) ////Intentionally no host so ReactFake will process
     }
 


### PR DESCRIPTION
**Description**
Component suitable for bottom of Details page

**Technical**
Depends on PR #134 (updatedcomponents) so it looks more complex than it is ... once that is merged it should just be one file

Depends on the ArchiveItem and ArchiveMember controllers, but could easily be reworked to use the RelatedItem service if wanted before ArchiveItem/ArchiveMember get merged in here.

**Tested**
Its tested and live in dweb-archive 
