### PR TITLE
fixed all references to imports from linked packages in prototype

### DIFF
--- a/packages/ia-components/sandbox/related-as-list.js
+++ b/packages/ia-components/sandbox/related-as-list.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { RelatedService } from 'ia-js-client'
+import { RelatedService } from '@internetarchive/ia-js-client'
 
 // TODO separate the data fetching from the presentation
 

--- a/packages/ia-components/sandbox/simple-desc-meta.js
+++ b/packages/ia-components/sandbox/simple-desc-meta.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Item } from 'ia-js-client'
+import { Item } from '@internetarchive/ia-js-client'
 
 export default class extends React.Component {
 

--- a/packages/ia-components/sandbox/theatres/audio-1/audio-1.js
+++ b/packages/ia-components/sandbox/theatres/audio-1/audio-1.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types';
 
-import { MetadataService, Item } from 'ia-js-client'
+import { MetadataService, Item } from '@internetarchive/ia-js-client'
 
 import SpotifyIcon from './spotify-icon.svg'
 import SpotifyIconWithBorder from './spotify-icon-with-border.svg'
@@ -14,7 +14,7 @@ import PlayTriangle from './play-triangle.svg'
 // import JwNavImg from './jw-screenshot2.png'
 
 import AudioNavigation from './audio-nav'
-import TheatreHamburger from '../../theatre-hamburger/theatre-hamburger'
+import TheatreHamburger from '../theatre-hamburger/theatre-hamburger'
 
 import JWPlayerContainer from '../../jwplayer-comp/jwplayer-comp'
 

--- a/packages/ia-components/sandbox/theatres/theatre-switcher.js
+++ b/packages/ia-components/sandbox/theatres/theatre-switcher.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Item } from 'ia-js-client';
+import { Item } from '@internetarchive/ia-js-client';
 import BookreaderTheatre from './bookreader-theatre/bookreader-theatre';
 import Audio1 from './audio-1/audio-1'
 

--- a/packages/ia-components/sandbox/v2mocks/details-page-container.js
+++ b/packages/ia-components/sandbox/v2mocks/details-page-container.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { Item } from 'ia-js-client'
+import { Item } from '@internetarchive/ia-js-client'
 
 import MockDetailsPage from './details-page'
 // import MockDetailsPage from './details-page-reviews-bottom'

--- a/packages/ia-prototype-apps/apps/details-react/index.js
+++ b/packages/ia-prototype-apps/apps/details-react/index.js
@@ -3,23 +3,23 @@ import ReactDOM from 'react-dom';
 
 // v2 mocks
 // import MockHeader from 'ia-components/v2mocks/header'
-import MockDetailsPageContainer from 'ia-components/sandbox/v2mocks/details-page-container'
-import MockTheatreAudio from 'ia-components/sandbox/v2mocks/theatre-audio'
-import MockReviews from 'ia-components/sandbox/v2mocks/reviews-empty'
-import MockDescMeta from 'ia-components/sandbox/v2mocks/desc-meta'
-import MockNav from 'ia-components/sandbox/v2mocks/nav'
+import MockDetailsPageContainer from '@internetarchive/ia-components/sandbox/v2mocks/details-page-container'
+import MockTheatreAudio from '@internetarchive/ia-components/sandbox/v2mocks/theatre-audio'
+import MockReviews from '@internetarchive/ia-components/sandbox/v2mocks/reviews-empty'
+import MockDescMeta from '@internetarchive/ia-components/sandbox/v2mocks/desc-meta'
+import MockNav from '@internetarchive/ia-components/sandbox/v2mocks/nav'
 
 // prototypes
-import Audio1 from 'ia-components/sandbox/theatres/audio-1/audio-1'
-import Audio1Br from 'ia-components/sandbox/theatres/audio-1/audio-1-br-nav-wav'
-import TheatreSwitcher from 'ia-components/sandbox/theatres/theatre-switcher'
+import Audio1 from '@internetarchive/ia-components/sandbox/theatres/audio-1/audio-1'
+import Audio1Br from '@internetarchive/ia-components/sandbox/theatres/audio-1/audio-1-br-nav-wav'
+import TheatreSwitcher from '@internetarchive/ia-components/sandbox/theatres/theatre-switcher'
 
-import RelatedAsList from 'ia-components/sandbox/related-as-list'
-import SimpleDescMeta from 'ia-components/sandbox/simple-desc-meta'
+import RelatedAsList from '@internetarchive/ia-components/sandbox/related-as-list'
+import SimpleDescMeta from '@internetarchive/ia-components/sandbox/simple-desc-meta'
 
 // other
 import { getUrlParameter } from '../../lib/helpers/url'
-import { Item } from 'ia-js-client'
+import { Item } from '@internetarchive/ia-js-client'
 
 
 let demoIdentifier = getUrlParameter('identifier') || "cd_point-of-departure_andrew-hill"


### PR DESCRIPTION
**Description**

> A fix to package resolve errors on trying to run the MockDetailsPageContainer component from the ia-prototype-apps/apps