### PR TITLE
IAReactComponent add onClick handler that other components are expecting

### DIFF
--- a/packages/ia-components/sandbox/IAReactComponent.js
+++ b/packages/ia-components/sandbox/IAReactComponent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-const debug = require('debug')('ia-components:ConfigDetailsComponent');
+const debug = require('debug')('ia-components:IAReactComponent');
 
 export default class IAReactComponent extends React.Component {
     // Both dweb-archive.IAFakeReactComponent used with ReactFake and iaux.IAReactComponent used with React should work the same. (e.g. ParentTileImg works with both)
@@ -11,6 +11,16 @@ export default class IAReactComponent extends React.Component {
         this._isMounted = false;
         // In both React & ReactFake If you give a HTML tag ref={this.load} then it will call loadcallable with 'this' set to the component and pass the element as the only parameter
         this.load = (el) => this.loadcallable.call(this, el);
+        // By default 'onClick=this.onClick' will cause clicking to run the clickCallable routine, and then blocks/forwards event depending on return value, as it would for normal HTML
+        this.onClick = (ev) => {
+            if (this.clickCallable.call(this, ev)) {
+                return true; // Navigate to href if this comes from an anchor
+            } else {
+                ev.preventDefault();    // Prevent it going to the anchor (equivalent to "return false" in non-React
+                // ev.stopPropagation(); ev.nativeEvent.stopImmediatePropagation(); // Suggested alternatives which dont work
+                return false; // Stop the non-react version propogating
+            }
+        };
     }
 
     /* This was needed in the dweb because we don't know if the component was mounted, and had to set State in two different ways, for example


### PR DESCRIPTION
**Description**

Fix a bug where IAReactComponent base class wasn't updated and so lacks the onClick function causing DetailAnchors to go to archive.org. (Hard to spot, since visual effect is correct, just URL is wrong and fails offline)

**Technical**
No changes to base class other than adding this handler

**Testing**
Tested in dweb-mirror#iaux 

