### PR TITLE
Paginator: keep page scroll fixed when autofocusing item

### DIFF
--- a/packages/ia-components/sandbox/pagination/pagination-with-flexbox.jsx
+++ b/packages/ia-components/sandbox/pagination/pagination-with-flexbox.jsx
@@ -126,10 +126,13 @@ class Paginator extends Component {
 
       let itemToView = null;
       if (scrollItemIntoView) {
-        // focus on item
+        // focus on item but keep page position
         itemToView = viewport.querySelector(itemInViewClass);
         if (itemToView) {
+          const currentX = window.pageXOffset;
+          const currentY = window.pageYOffset;
           itemToView.focus();
+          window.scrollTo(currentX, currentY);
         }
       }
       const viewportFlush = scrollItemIntoView


### PR DESCRIPTION
**Description**
When paginator is on a page, it will autofocus an item.  We should not be jumping to the autofocus.

**Technical**
When `element.focus()` is called, the browser will automatically jump to make that element viewable.
We need to preserve the User's scroll position.