### PR TITLE
IA JWPlayer Wrapper: update config to add `responsive` flag

### DIFF
--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -115,7 +115,7 @@ class ArchiveAudioPlayer extends Component {
       collection,
       hide_list: true,
       onReady: this.onReady,
-      responsive: true
+      responsive: true,
     };
 
     if (window.Play && Play) {

--- a/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/theatres/components/audio-player/players_by_type/archive-audio-jwplayer-wrapper.jsx
@@ -100,7 +100,7 @@ class ArchiveAudioPlayer extends Component {
     const { jwplayerPlaylist, identifier, collection } = jwplayerInfo;
     const waveformer = backgroundPhoto
       ? {}
-      : { waveformer: 'jw-holder', responsive: true };
+      : { waveformer: 'jw-holder' };
     // We are using IA custom global Player class to instatiate the player
     const baseConfig = {
       start: 0,
@@ -114,7 +114,8 @@ class ArchiveAudioPlayer extends Component {
       identifier,
       collection,
       hide_list: true,
-      onReady: this.onReady
+      onReady: this.onReady,
+      responsive: true
     };
 
     if (window.Play && Play) {


### PR DESCRIPTION
This will allow for IA's JWPlayer Wrapper to properly setup
Significance:
Now on /details/<audioItem> load, the first track doesn't append to the URL
