### PR TITLE
Example Component: readding into index.js, removing experimental `classProperties` usage

### DIFF
--- a/packages/ia-components/index.js
+++ b/packages/ia-components/index.js
@@ -3,10 +3,7 @@
  */
 
 // live
-//Next line fails webpack - complains Support for the experimental syntax 'classProperties' isn't currently enabled
-//If it is needed then please document how to add it to something using this index.js from another package
-//or import directory
-//export { default as IAUXExampleComponent } from './live/example-react-component/index';
+export { default as IAUXExampleComponent } from './live/example-react-component/index';
 
 // sandbox
 export { default as HorizontalRadioGroup } from './sandbox/selectors/horizontal-radio-group/horizontal-radio-group';

--- a/packages/ia-components/live/example-react-component/index.js
+++ b/packages/ia-components/live/example-react-component/index.js
@@ -1,8 +1,7 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 
 export default class IAUXExampleComponent extends Component {
-  static displayName = "IAUXExampleComponent"
-  render () {
+  render() {
     const { children } = this.props;
     return (
       <div className="example-react-component">
@@ -15,6 +14,6 @@ export default class IAUXExampleComponent extends Component {
           </div>
         }
       </div>
-    )
+    );
   }
 }


### PR DESCRIPTION
Petabox builds are failing without this import.
Imports are failing DWEB usage of IAUX.
To simplify, we are removing this line.
