### PR TITLE
Adding @internetarchive/dweb-archivecontroller

### DIFF
--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -33,6 +33,7 @@
         "style-loader": "^0.23.1"
     },
     "dependencies": {
+        "@internetarchive/dweb-archivecontroller": "^0.1.57",
         "debug": "^4.1.1",
         "lodash": "^4.17.11",
         "prop-types": "^15.6.2",


### PR DESCRIPTION
**Description**
Dweb components rely on this controller import.

In order for build to pass in Petabox, this needs to be included.  I have conferred with @mitra42 and the tag is the most current for this import.

I've tested local Petabox container build and is finally successful with this update.