### PR TITLE
Fix dweb dependency

### DIFF
--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -33,7 +33,6 @@
         "style-loader": "^0.23.1"
     },
     "dependencies": {
-        "@internetarchive/dweb-archivecontroller": "^0.1.57",
         "debug": "^4.1.1",
         "lodash": "^4.17.11",
         "prop-types": "^15.6.2",

--- a/packages/ia-components/sandbox/details/DetailsCollectionList.jsx
+++ b/packages/ia-components/sandbox/details/DetailsCollectionList.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ArchiveMember from '@internetarchive/dweb-archivecontroller/ArchiveMember.js';
 import IAReactComponent from '../IAReactComponent';
 import AnchorDetails from '../AnchorDetails';
 
@@ -20,9 +19,10 @@ export default class DetailsCollectionList extends IAReactComponent {
 
   loadcallable(unused_enclosingElement) {
     // expand a list of collections into a list of titles either through collectionTitles if supplied (e.g. from dweb gateway) or via a new Search query
+    const { ArchiveMemberExpand, collections } = this.props;
     if (!this.state.expansionTried) {
       this.state.expansionTried = true;
-      ArchiveMember.expand(this.props.collections.filter(k => !this.state.collectionTitles[k]), (err, res) => { // res = { id: AS(id) }
+      ArchiveMemberExpand(collections.filter(k => !this.state.collectionTitles[k]), (err, res) => { // res = { id: AS(id) }
         const collectionTitles = Object.assign({}, this.state.collectionTitles, Object.map(res, (k, v) => [k, v.title]));
         this.setState({ collectionTitles });
       });

--- a/packages/ia-components/sandbox/details/DetailsCollectionList.jsx
+++ b/packages/ia-components/sandbox/details/DetailsCollectionList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import ArchiveMember from '@internetarchive/dweb-archivecontroller/ArchiveMember.js';
 import IAReactComponent from '../IAReactComponent';
-import AnchorDetails from "../AnchorDetails";
-import ArchiveMember from "@internetarchive/dweb-archivecontroller/ArchiveMember.js";
+import AnchorDetails from '../AnchorDetails';
 
 /*
     List of collections on details page]
@@ -12,36 +12,40 @@ import ArchiveMember from "@internetarchive/dweb-archivecontroller/ArchiveMember
 
  */
 export default class DetailsCollectionList extends IAReactComponent {
+  constructor(props) {
+    super(props); // collections
+    this.state.collectionTitles = (typeof this.props.collectionTitles === 'undefined') ? {} : this.props.collectionTitles;
+    this.state.expansionTried = false;
+  }
 
-    constructor(props) {
-        super(props); //collections
-        this.state.collectionTitles = (typeof this.props.collectionTitles === "undefined") ? {} : this.props.collectionTitles;
-        this.state.expansionTried = false;
+  loadcallable(unused_enclosingElement) {
+    // expand a list of collections into a list of titles either through collectionTitles if supplied (e.g. from dweb gateway) or via a new Search query
+    if (!this.state.expansionTried) {
+      this.state.expansionTried = true;
+      ArchiveMember.expand(this.props.collections.filter(k => !this.state.collectionTitles[k]), (err, res) => { // res = { id: AS(id) }
+        const collectionTitles = Object.assign({}, this.state.collectionTitles, Object.map(res, (k, v) => [k, v.title]));
+        this.setState({ collectionTitles });
+      });
     }
-    loadcallable(unused_enclosingElement) {
-        //expand a list of collections into a list of titles either through collectionTitles if supplied (e.g. from dweb gateway) or via a new Search query
-        if (!this.state.expansionTried) {
-            this.state.expansionTried = true;
-            ArchiveMember.expand(this.props.collections.filter(k => !this.state.collectionTitles[k]), (err, res) => { // res = { id: AS(id) }
-                const collectionTitles = Object.assign({}, this.state.collectionTitles, Object.map(res, (k, v) => [k, v.title]));
-                this.setState({collectionTitles: collectionTitles});
-            });
-        }
-    }
+  }
 
-    render() { return (
-        <div className="boxy collection-list">
-            <section className="quick-down collection-list" ref={this.load}>
-                <h5 className="collection-title">IN COLLECTIONS</h5>
-                {this.props.collections.map(collection =>
-                    <div className="collection-item" key={collection}>
-                        <AnchorDetails identifier={collection} data-event-click-tracking={`CollectionList|${collection}`}
-                        >{this.state.collectionTitles[collection] || collection}</AnchorDetails>
-                    </div>
-                )}
-            </section>
-        </div>
-    ); }
+  render() {
+    return (
+      <div className="boxy collection-list">
+        <section className="quick-down collection-list" ref={this.load}>
+          <h5 className="collection-title">IN COLLECTIONS</h5>
+          {this.props.collections.map(collection => (
+            <div className="collection-item" key={collection}>
+              <AnchorDetails
+                identifier={collection}
+                data-event-click-tracking={`CollectionList|${collection}`}
+              >
+                {this.state.collectionTitles[collection] || collection}
+              </AnchorDetails>
+            </div>
+          ))}
+        </section>
+      </div>
+    );
+  }
 }
-
-


### PR DESCRIPTION
Recent integration of `dweb-controller` is breaking PETABOX build.

This fix:
- Lints `DetailsCollectionList` - [commit](https://github.com/internetarchive/iaux/commit/334d9df8fb2593740f7dbf3dab32ffdba43af39c)
- removes the `dweb-controller` dependency
- refactored `DetailsCollectionList` to remove dependency & to accept a new prop `ArchiveMemberExpand` - [commit](https://github.com/internetarchive/iaux/commit/ce1ba69f589fe63e56f39c4a28cfed100843b3db)

Note: Look at each commit to see individual changes


**Evidence**
Image of tests passing locally:
<img width="480" alt="Screen Shot 2019-05-17 at 12 32 21 PM" src="https://user-images.githubusercontent.com/7840857/57952080-fe6a7180-78a0-11e9-86fb-3de542c850c3.png">

