### PR TITLE
Music Player: view model creator now supports .wma files

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
@@ -37,7 +37,7 @@ const archiveDefaultAlbumParser = ({ fileDirectoryPrefix, files }) => {
     let flattenedImportantRelatedFiles = null;
     const externalIdentifiers = currentFile['external-identifier'] || null;
     const isOriginal = source === 'original';
-    const isAudioFile = currentFileName.match(/(mp3|ogg|flac|m4a)$/g);
+    const isAudioFile = currentFileName.match(/(mp3|ogg|flac|m4a|wma)$/g);
     const isItemImageFile = isOriginal && currentFileName.match(/(png|jpg|jpeg)$/gi);
 
     // skip unneeded files

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -65,7 +65,7 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
    * & only return the files we are interested in
    */
   const slimFiles = reduce(fileNames, (neededFiles = [], fileName) => {
-    const neededExtensions = /(mp3|ogg|flac|m4a|jpg|png|jpeg)$/gi;
+    const neededExtensions = /(mp3|ogg|flac|m4a|jpg|png|jpeg|wma)$/gi;
     const isNeededFile = fileName.match(neededExtensions);
     const file = allFiles[fileName];
     file.name = fileName.slice(1, fileName.length);


### PR DESCRIPTION
**Description**
Problem, Music Player not displaying tracks from album with tracks that have `.wma` extensions
Fixes: #183 

**Technical**

update view model creator to include these

**Testing & Evidence**

> What steps should the reviewer take to verify this PR resolves the issue?
![image](https://user-images.githubusercontent.com/7840857/59120633-c2a85200-890a-11e9-87b5-c401c974ad38.png)

run storybook > go to audio player story > add in custom ID to check: /miscellaneous-music-donations-no-acoustid - the player should load with files

