### PR TITLE
Music Player, liner notes: make sure search messaging displays

### DIFF
--- a/packages/ia-components/sandbox/audio-players/audio-player.less
+++ b/packages/ia-components/sandbox/audio-players/audio-player.less
@@ -41,6 +41,11 @@
       padding-top: 14%;
       height: 20rem;
     }
+
+    & .BRprogresspopup {
+      color: @3-gray;
+      text-align: center;
+    }
   }
 
   .tabs {


### PR DESCRIPTION
**Description**

Problem: The search feedback text is not showing up appropriately.
![Screen Shot 2019-06-07 at 3 51 54 PM](https://user-images.githubusercontent.com/7840857/59137586-50049a00-893d-11e9-97a8-7486649b7a45.png)

This is part of #172 


**Technical**

> What should be noted about the implementation?


**Testing**

- fix the CSS
![Screen Shot 2019-06-07 at 4 01 27 PM](https://user-images.githubusercontent.com/7840857/59137626-88a47380-893d-11e9-8450-8228a17d1b0b.png)
![Screen Shot 2019-06-07 at 4 01 04 PM](https://user-images.githubusercontent.com/7840857/59137627-88a47380-893d-11e9-80b1-922cf8b0504e.png)


Go to: https://www-isa.archive.org/details/cd_trail-of-memories-the-randy-travis-antholo_randy-travis-b.b.-king-george-jones-merle

click liner notes tab > search "Randy" > you will see text in progress bar like the photo