### PR TITLE
have the general player UI simply update on play8.js "onPlaylistItem(…

### DIFF
--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -26,7 +26,7 @@ class ArchiveAudioPlayer extends Component {
   }
 
   componentDidMount() {
-    const { jwplayerInfo, jwplayerID, backgroundPhoto } = this.props;
+    const { jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete } = this.props;
     const { jwplayerPlaylist, identifier } = jwplayerInfo;
     const waveformer = backgroundPhoto
       ? {}
@@ -45,6 +45,18 @@ class ArchiveAudioPlayer extends Component {
       const compiledConfig = Object.assign({}, baseConfig, waveformer);
       const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
       this.setState({ player });
+
+      if (onRegistrationComplete) {
+        /**
+         * Currently, this is where we support external ability to set URL
+         * through Internet Archive's JWPlayer Wrapper
+         */
+        const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
+          const playlistIndex = trackNumber - 1 || 0;
+          return Play(jwplayerID).playN(playlistIndex, true);
+        }.bind(null, jwplayerID);
+        onRegistrationComplete(externallySyncURL);
+      }
     }
   }
 

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -77,7 +77,6 @@ export default class TheatreAudioPlayer extends Component {
       <ArchiveAudioPlayer
         {...this.props}
         onRegistrationComplete={this.receiveURLSetter}
-        needsURLSettingAccess
       />
     );
     if (isExternal) {

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import ArchiveAudioPlayer from './archive-audio-jwplayer-wrapper';
 import ThirdPartyEmbeddedPlayer from './third-party-embed';
@@ -73,12 +73,7 @@ export default class TheatreAudioPlayer extends Component {
   showMedia() {
     const { source, sourceData } = this.props;
     const isExternal = source === 'youtube' || source === 'spotify';
-    let mediaElement = (
-      <ArchiveAudioPlayer
-        {...this.props}
-        onRegistrationComplete={this.receiveURLSetter}
-      />
-    );
+    let mediaElement = null;
     if (isExternal) {
       // make iframe with URL
       const { urlSetterFN } = this.state;
@@ -94,7 +89,6 @@ export default class TheatreAudioPlayer extends Component {
         <ThirdPartyEmbeddedPlayer
           sourceURL={sourceURL}
           title={name}
-
         />
       );
       // updateURL
@@ -102,8 +96,18 @@ export default class TheatreAudioPlayer extends Component {
         urlSetterFN(trackNumber);
       }
     }
+    const archiveStyle = isExternal ? { visibility: 'hidden' } : { visibility: 'visible' };
 
-    return mediaElement;
+    return (
+      <Fragment>
+        <ArchiveAudioPlayer
+          {...this.props}
+          onRegistrationComplete={this.receiveURLSetter}
+          style={archiveStyle}
+        />
+        { mediaElement }
+      </Fragment>
+    );
   }
 
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -71,7 +71,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       tracklistToShow: [],
       channelToPlay: 'archive',
       trackSelected: null, /* 0 = album */
-      userEvent: false,
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
@@ -132,10 +131,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   jwplayerPlaylistChange(playlistItem) {
     const { newTrackIndex } = playlistItem;
-    this.setState({
-      trackSelected: newTrackIndex + 1,
-      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
-    });
+    this.setState({ trackSelected: newTrackIndex + 1 });
   }
 
   /**
@@ -147,7 +143,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const selectedTrackNumber = parseInt(selected.getAttribute('data-track-number'), 10);
 
     this.setState({
-      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
       trackSelected: Number.isInteger(selectedTrackNumber)
         ? selectedTrackNumber
         : 1
@@ -182,11 +177,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player needs index and "is user event?"
-    audioSource = {
-      userEvent: this.state.userEvent,
-      index: trackSelected - 1 || 0
-    };
+    // ia jw player needs index
+    audioSource = { index: trackSelected - 1 || 0 };
 
     return audioSource;
   }

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -70,12 +70,14 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       albumData,
       tracklistToShow: [],
       channelToPlay: 'archive',
+      trackStartingPoint: null,
       trackSelected: null, /* 0 = album */
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
     this.onChannelSelect = this.onChannelSelect.bind(this);
     this.jwplayerPlaylistChange = this.jwplayerPlaylistChange.bind(this);
+    this.jwplayerStartingPoint = this.jwplayerStartingPoint.bind(this);
     this.getSelectableChannels = this.getSelectableChannels.bind(this);
     this.getAudioSourceInfoToPlay = this.getAudioSourceInfoToPlay.bind(this);
   }
@@ -134,6 +136,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     this.setState({ trackSelected: newTrackIndex + 1 });
   }
 
+  jwplayerStartingPoint(index) {
+    this.setState({ trackStartingPoint: index + 1 });
+  }
+
   /**
    * Callback every time user selects a track from the tracklist
    * @param { object } event - React synthetic event
@@ -179,7 +185,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
 
     // ia jw player only needs index
     audioSource = {
-      index: trackSelected - 1 || 0
+      index: trackSelected
     };
 
     return audioSource;
@@ -232,7 +238,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
   render() {
     const { jwplayerPlaylist, linerNotes } = this.props;
     const {
-      tracklistToShow, trackSelected, channelToPlay, albumData
+      tracklistToShow, trackSelected, channelToPlay, albumData, trackStartingPoint
     } = this.state;
     const {
       albumMetadaToDisplay,
@@ -261,6 +267,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display
 
+    const trackToHighlight = trackSelected === null && trackStartingPoint !== null ? trackStartingPoint : trackSelected;
     return (
       <div className="theatre__wrap audio-with-youtube-spotify">
         <section className="media-section">
@@ -282,6 +289,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             }}
             linerNotes={linerNotes}
             jwplayerPlaylistChange={this.jwplayerPlaylistChange}
+            jwplayerStartingPoint={this.jwplayerStartingPoint}
             jwplayerInfo={jwplayerInfo}
             jwplayerID={`jwplayer-${jwplayerID}`}
           />
@@ -307,7 +315,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             <TheatreTrackList
               tracks={tracklistToShow}
               onSelected={this.selectThisTrack}
-              selectedTrack={trackSelected}
+              selectedTrack={trackToHighlight} // trackStartingPoint
               albumName={title}
               displayTrackNumbers={isArchiveChannel}
               creator={origCreator[0] || creator}

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -71,6 +71,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       tracklistToShow: [],
       channelToPlay: 'archive',
       trackSelected: null, /* 0 = album */
+      userEvent: false,
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
@@ -131,7 +132,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   jwplayerPlaylistChange(playlistItem) {
     const { newTrackIndex } = playlistItem;
-    this.setState({ trackSelected: newTrackIndex + 1 });
+    this.setState({
+      trackSelected: newTrackIndex + 1,
+      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
+    });
   }
 
   /**
@@ -143,6 +147,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const selectedTrackNumber = parseInt(selected.getAttribute('data-track-number'), 10);
 
     this.setState({
+      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
       trackSelected: Number.isInteger(selectedTrackNumber)
         ? selectedTrackNumber
         : 1
@@ -177,8 +182,9 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player only needs index
+    // ia jw player needs index and "is user event?"
     audioSource = {
+      userEvent: this.state.userEvent,
       index: trackSelected - 1 || 0
     };
 
@@ -245,7 +251,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const {
       title,
       identifier,
-      collection,
       creator
     } = albumMetadaToDisplay;
     let audioPlayerChannelLabel;
@@ -258,7 +263,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const jwplayerInfo = {
       jwplayerPlaylist,
       identifier,
-      collection
     };
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -177,8 +177,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player needs index
-    audioSource = { index: trackSelected - 1 || 0 };
+    // ia jw player only needs index
+    audioSource = {
+      index: trackSelected - 1 || 0
+    };
 
     return audioSource;
   }


### PR DESCRIPTION
…)" callbacks.  the only other call needed is "Play.playN()" for when the UI receives a user click on a playlist track.  the rest can just change/reflect if/as props and state change in the react model.  this simplifies the interaction greatly, and allows a lot of code state tracking to go away.  untangled an infin loop between IAUX player and play8 by only invoking "Play.playN()" when it is a user click/mouse event from the UI track list

**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.
hotfix/refactor
This closes #207 

**Technical**

> What should be noted about the implementation?
* complicated stack overflow gone!  :D 
* repeated events OK / NBD
* should future-proof us nicely as `Play().PlayN()` is used everywhere and receiving `onPlaylistItem()` callbacks is used/relied on elsewhere.





**Testing**

> 
What steps should the reviewer take to verify this PR resolves the issue?

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
![cold-to-playing](https://user-images.githubusercontent.com/1376440/59491996-c7a25f80-8e3c-11e9-929b-8ffd5542999f.jpg)
