### PR TITLE
Creates Travis config and ESLint runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "10.15.3"
+
+script:
+  - npm run lint

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   },
   "name": "iaux",
   "license": "AGPL-3.0-only",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "devDependencies": {
     "eslint": "^5.12.0",
     "eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
Fixes #176

**Description**

Creates a Travis CI config file to run ESLint on any non-node_modules JS file in the repo. Reports failure in TravisCI console and passes a pass/fail message back to GitHub for rendering.

**Technical**

We may want to have a discussion on either limiting the linting to particular packages or to instead completely disable the checks on a per-file basis.

**Testing**

If you'd like, you can branch off of this one, make a commit, and push. Travis CI will run ESLint and display the results on https://travis-ci.com/internetarchive/iaux

**Evidence**

<img width="1312" alt="Screen Shot 2019-06-17 at 2 49 04 PM" src="https://user-images.githubusercontent.com/39553/59629204-51d61680-9110-11e9-994b-f5f59d9b9950.png">
