### PR TITLE
JWPlayer Simplification

### DIFF
--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
  *
  * It will display photo if given, and will overlay the media player at the base of the photo.
  *
- * Development is in lock-step with Play8.js.
- * ANY changes to Play8.js may need to be addressed here also.
  */
 class ArchiveAudioPlayer extends Component {
   constructor(props) {
@@ -20,13 +18,29 @@ class ArchiveAudioPlayer extends Component {
     this.state = {
       player: null,
       playerPlaylistIndex: null,
+      startingAt: null,
+      startingAtCaptured: false,
+      initiatePlay: false,
+      paused: false,
     };
 
     this.onPlaylistItemCB = this.onPlaylistItemCB.bind(this);
+    this.registerPlayerEventHandlers = this.registerPlayerEventHandlers.bind(this);
+    this.checkIfPlayerStartsAtN = this.checkIfPlayerStartsAtN.bind(this);
+    this.upupdatePlayerStateWhenStartingAtN = this.updatePlayerStateWhenStartingAtN.bind(this);
+    this.playTrack = this.playTrack.bind(this);
+    this.initiatePlay = this.initiatePlay.bind(this);
+    this.handlePause = this.handlePause.bind(this);
+    this.setURL = this.setURL.bind(this);
   }
 
+  /**
+   * Register jwplayer/play8 instance as component mounts on client
+   */
   componentDidMount() {
-    const { jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete } = this.props;
+    const {
+      jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete
+    } = this.props;
     const { jwplayerPlaylist, identifier } = jwplayerInfo;
     const waveformer = backgroundPhoto
       ? {}
@@ -39,23 +53,31 @@ class ArchiveAudioPlayer extends Component {
       hide_list: true,
       responsive: true,
       onPlaylistItem: this.onPlaylistItemCB,
+      onSetupComplete: (startPlaylistIdx) => {
+        /**
+         * Capture if player starts on track N+1
+         */
+        if (startPlaylistIdx) {
+          this.setState({ startingAt: startPlaylistIdx });
+        }
+      }
     };
 
     if (window.Play && Play) {
       const compiledConfig = Object.assign({}, baseConfig, waveformer);
       const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
-      this.setState({ player });
+      this.setState({ player }, this.registerPlayerEventHandlers);
 
       if (onRegistrationComplete) {
         /**
          * Currently, this is where we support external ability to set URL
          * through Internet Archive's JWPlayer Wrapper
          */
-        const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
-          const playlistIndex = trackNumber - 1 || 0;
-          return Play(jwplayerID).playN(playlistIndex, true);
-        }.bind(null, jwplayerID);
-        onRegistrationComplete(externallySyncURL);
+        // const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
+        //   const playlistIndex = trackNumber - 1 || 0;
+        //   return Play(jwplayerID).playN(playlistIndex, true);
+        // }.bind(null, jwplayerID);
+        onRegistrationComplete(this.setURL);
       }
     }
   }
@@ -66,55 +88,178 @@ class ArchiveAudioPlayer extends Component {
    */
   componentDidUpdate(prevProps, prevState) {
     const {
-      player,
-      playerPlaylistIndex,
+      playerPlaylistIndex, initiatePlay, paused, startingAtCaptured
     } = this.state;
-    const {
-      playerPlaylistIndex: prevPlayIndex,
-    } = prevState;
-    const { jwplayerID, sourceData: { index = null } } = this.props;
+    const { startingAtCaptured: prevStartCaptured, paused: prevPaused } = prevState;
 
-    const indexHasBeenSet = Number.isInteger(index);
-    if (!indexHasBeenSet)
+    const { sourceData: { index = null }, jwplayerID } = this.props;
+    const { sourceData: { index: prevIndex } } = prevProps;
+
+    // if state index doesn't match props index, manually play
+    const indexIsNumber = Number.isInteger(index);
+
+    console.warn('UPDATE: this.state ', this.state);
+    console.warn('UPDDATE: prevState', prevState);
+
+    const jwplayerStartingOnACertainTrack = this.checkIfPlayerStartsAtN(index);
+
+    if (jwplayerStartingOnACertainTrack) {
+      const capturedFlagFlipped = !prevStartCaptured && startingAtCaptured;
+      const stateToUpdate = {
+        startingAtCaptured: indexIsNumber && !Number.isInteger(prevIndex),
+        capturedFlagFlipped
+      };
+      console.warn('jwplayerStartingOnACertainTrack', stateToUpdate);
+      this.updatePlayerStateWhenStartingAtN(stateToUpdate);
       return;
+    }
 
-    // Is this a props change? (from parent / above; eg: clicking on tracklist title/button)
-    const propA = parseInt((
-      prevProps  &&  prevProps.sourceData  &&  prevProps.sourceData.index
-      ? prevProps.sourceData.index
-      : null), 10);
-    const propB = parseInt(this.props.sourceData.index, 10);
-    console.log('IAUX componentDidUpdate props change?', propA, '=>', propB);
+    if (indexIsNumber && !initiatePlay) {
+      this.initiatePlay();
+      return;
+    }
 
-    // Is this a state change? (change from our class / we initiated; eg: jwplayer auto-advance)
-    const stateA = parseInt((prevState ? prevState.playerPlaylistIndex : null), 10)
-    const stateB = parseInt(this.state.playerPlaylistIndex, 10);
-    console.log('IAUX componentDidUpdate state change?', stateA, '=>', stateB);
+    const manuallyJumpToTrack = (playerPlaylistIndex !== index) && indexIsNumber && initiatePlay;
+    if (manuallyJumpToTrack) {
+      this.playTrack({ playerPlaylistIndex: index });
+      return;
+    }
 
-    // Tell jwplayer to change (or play if already selected) the wanted track
-    player.playN(propB !== propA ? propB : stateB);
+    if (paused && prevPaused && index === playerPlaylistIndex) {
+      /**
+       * user Paused via player & then clicked on selected track item to restart
+       */
+      this.handlePause(false, () => jwplayer(jwplayerID).play());
+    }
   }
 
   /**
    * Event Handler that fires when JWPlayer starts a new track (eg: controlbar or auto-advance)
    */
   onPlaylistItemCB(jwplayer, event) {
-    console.log('IAUX: onPlaylistItemCB event, props', event, this.props);
+    const { index } = event;
+    const { initiatePlay, startingAtCaptured } = this.state;
+    const jwplayerStartingOnACertainTrack = this.checkIfPlayerStartsAtN(index);
 
-    const playerPlaylistIndex = event.index;
-    this.setState({ playerPlaylistIndex },
-      () => {
-        console.log('IAUX: onPlaylistItemCB setState() applied', playerPlaylistIndex);
-        this.props.jwplayerPlaylistChange({ newTrackIndex: playerPlaylistIndex });
-      });
+    if (initiatePlay || (jwplayerStartingOnACertainTrack && !startingAtCaptured)) {
+      console.warn('onPlaylistItemCB', initiatePlay, jwplayerStartingOnACertainTrack);
+      const { jwplayerPlaylistChange } = this.props;
+      jwplayerPlaylistChange({ newTrackIndex: index });
+    }
   }
 
+  /**
+   * Signals to IA's jwplayer handler, Play8,
+   * that it's time to change the URL to match given track
+   *
+   * @param { number } trackNumber
+   */
+  setURL(trackNumber) {
+    const { player } = this.state;
+    const playlistIndex = trackNumber - 1 || 0;
+    console.log('IAUX SET URL PLAYN', playlistIndex);
+    return player.playN(playlistIndex, true);
+  }
+
+  /**
+   * Signal that player is ready to go
+   */
+  initiatePlay() {
+    this.setState({ initiatePlay: true });
+  }
+
+  /**
+   * Handle all the state management when the player starts on track N+1
+   *
+   * Flag: startingAtCaptured
+   * - this confirms that starting track number was received by top level controller
+   * - if we are at this point set, the flag
+   *
+   * Flag: capturedFlagFlipped
+   * - this confirms the point when `this.state.startingAtCaptured` internal flag has been set
+   * - if we are at this point, play the track
+   *
+   * @param { boolean } startingAtCaptured
+   * @param { boolean } capturedFlagFlipped
+   */
+  updatePlayerStateWhenStartingAtN({ startingAtCaptured, capturedFlagFlipped }) {
+    const { startingAt } = this.state;
+    const { sourceData: { index = null } } = this.props;
+
+    if (startingAtCaptured) {
+      this.setState({ startingAtCaptured });
+      return;
+    }
+
+    if (!capturedFlagFlipped && index === startingAt) {
+      this.playTrack({
+        playerPlaylistIndex: index,
+        initiatePlay: true
+      });
+    }
+  }
+
+  /**
+   * This updates internal state & then tells jwplayer/Play8 to start playing track
+   *
+   * @param { Object } stateToUpdate
+   * @param { number } stateToUpdate.playerPlaylistIndex - Track index to play. *Required
+   * @param { * } stateToUpdate[param] - optional states to update
+   */
+  playTrack(stateToUpdate) {
+    const { playerPlaylistIndex } = stateToUpdate;
+    const { player } = this.state;
+    console.warn('IAUX PLAYN StateTOUpdate', stateToUpdate);
+    this.setState(stateToUpdate, () => {
+      console.warn('IAUX PLAYN CALLBACK', playerPlaylistIndex);
+      player.playN(playerPlaylistIndex);
+    });
+  }
+
+  /**
+   * Captures Pause event and optional fires callbacks
+   *
+   * @param { boolean } paused
+   * @param { function } callback - optional
+   */
+  handlePause(paused, callback = null) {
+    this.setState({ paused }, callback);
+  }
+
+  /**
+   * Registers jwplayer event handlers
+   */
+  registerPlayerEventHandlers() {
+    const { player, initiatePlay, paused } = this.state;
+    player.on('play', () => {
+      if (!initiatePlay) {
+        this.initiatePlay();
+      }
+      if (paused) {
+        this.handlePause(false);
+      }
+    });
+    player.on('pause', () => {
+      this.handlePause(true);
+    });
+  }
+
+  /**
+   * Confirms whether or not jwplayer starts on track N+1
+   *
+   * @param { number|null } index
+   */
+  checkIfPlayerStartsAtN(index) {
+    const { initiatePlay, startingAt, playerPlaylistIndex } = this.state;
+
+    return !initiatePlay
+    && startingAt
+    && (index === startingAt)
+    && (playerPlaylistIndex === null);
+  }
 
   render() {
-    const {
-      jwplayerID,
-      backgroundPhoto
-    } = this.props;
+    const { jwplayerID } = this.props;
 
     return (
       <div className="ia-player-wrapper">
@@ -128,10 +273,8 @@ class ArchiveAudioPlayer extends Component {
 
 ArchiveAudioPlayer.defaultProps = {
   backgroundPhoto: '',
-  photoAltTag: '',
   jwplayerID: '',
   jwplayerPlaylistChange: null,
-  jwPlayerPlaylist: [],
   jwplayerInfo: {},
   sourceData: null,
   onRegistrationComplete: null,
@@ -139,12 +282,15 @@ ArchiveAudioPlayer.defaultProps = {
 
 ArchiveAudioPlayer.propTypes = {
   backgroundPhoto: PropTypes.string,
-  photoAltTag: PropTypes.string,
   jwplayerID: PropTypes.string,
   jwplayerPlaylistChange: PropTypes.func,
-  jwPlayerPlaylist: PropTypes.array,
-  jwplayerInfo: PropTypes.object,
-  sourceData: PropTypes.object,
+  jwplayerInfo: PropTypes.shape({
+    jwplayerPlaylist: PropTypes.array,
+    identifier: PropTypes.string
+  }),
+  sourceData: PropTypes.shape({
+    index: PropTypes.number
+  }),
   onRegistrationComplete: PropTypes.func,
 };
 

--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -26,7 +26,7 @@ class ArchiveAudioPlayer extends Component {
   }
 
   componentDidMount() {
-    const { jwplayerInfo, jwplayerID, backgroundPhoto } = this.props;
+    const { jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete } = this.props;
     const { jwplayerPlaylist, identifier } = jwplayerInfo;
     const waveformer = backgroundPhoto
       ? {}
@@ -45,6 +45,18 @@ class ArchiveAudioPlayer extends Component {
       const compiledConfig = Object.assign({}, baseConfig, waveformer);
       const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
       this.setState({ player });
+
+      if (onRegistrationComplete) {
+        /**
+         * Currently, this is where we support external ability to set URL
+         * through Internet Archive's JWPlayer Wrapper
+         */
+        const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
+          const playlistIndex = trackNumber - 1 || 0;
+          return Play(jwplayerID).playN(playlistIndex, true);
+        }.bind(null, jwplayerID);
+        onRegistrationComplete(externallySyncURL);
+      }
     }
   }
 

--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -174,6 +174,10 @@ class ArchiveAudioPlayer extends Component {
     const { startingAt } = this.state;
     const { sourceData: { index = null } } = this.props;
 
+    if (!startingAtCaptured && !capturedFlagFlipped) {
+      return;
+    }
+
     if (startingAtCaptured) {
       this.setState({ startingAtCaptured });
       return;

--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -16,22 +16,22 @@ class ArchiveAudioPlayer extends Component {
 
     // expecting jwplayer to be globally ready
     this.state = {
+      initiatePlay: false,
+      paused: false,
       player: null,
       playerPlaylistIndex: null,
       startingAt: null,
       startingAtCaptured: false,
-      initiatePlay: false,
-      paused: false,
     };
 
+    this.checkIfPlayerStartsAtN = this.checkIfPlayerStartsAtN.bind(this);
+    this.initiatePlay = this.initiatePlay.bind(this);
     this.onPlaylistItemCB = this.onPlaylistItemCB.bind(this);
     this.registerPlayerEventHandlers = this.registerPlayerEventHandlers.bind(this);
-    this.checkIfPlayerStartsAtN = this.checkIfPlayerStartsAtN.bind(this);
-    this.upupdatePlayerStateWhenStartingAtN = this.updatePlayerStateWhenStartingAtN.bind(this);
-    this.playTrack = this.playTrack.bind(this);
-    this.initiatePlay = this.initiatePlay.bind(this);
     this.handlePause = this.handlePause.bind(this);
+    this.playTrack = this.playTrack.bind(this);
     this.setURL = this.setURL.bind(this);
+    this.upupdatePlayerStateWhenStartingAtN = this.updatePlayerStateWhenStartingAtN.bind(this);
   }
 
   /**
@@ -73,18 +73,13 @@ class ArchiveAudioPlayer extends Component {
          * Currently, this is where we support external ability to set URL
          * through Internet Archive's JWPlayer Wrapper
          */
-        // const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
-        //   const playlistIndex = trackNumber - 1 || 0;
-        //   return Play(jwplayerID).playN(playlistIndex, true);
-        // }.bind(null, jwplayerID);
         onRegistrationComplete(this.setURL);
       }
     }
   }
 
   /**
-   * Check if Track index has changed,
-   * if so, then play that track
+   * Check if track index has changed. If so, then play that track
    */
   componentDidUpdate(prevProps, prevState) {
     const {
@@ -95,11 +90,7 @@ class ArchiveAudioPlayer extends Component {
     const { sourceData: { index = null }, jwplayerID } = this.props;
     const { sourceData: { index: prevIndex } } = prevProps;
 
-    // if state index doesn't match props index, manually play
     const indexIsNumber = Number.isInteger(index);
-
-    console.warn('UPDATE: this.state ', this.state);
-    console.warn('UPDDATE: prevState', prevState);
 
     const jwplayerStartingOnACertainTrack = this.checkIfPlayerStartsAtN(index);
 
@@ -109,7 +100,6 @@ class ArchiveAudioPlayer extends Component {
         startingAtCaptured: indexIsNumber && !Number.isInteger(prevIndex),
         capturedFlagFlipped
       };
-      console.warn('jwplayerStartingOnACertainTrack', stateToUpdate);
       this.updatePlayerStateWhenStartingAtN(stateToUpdate);
       return;
     }
@@ -142,7 +132,6 @@ class ArchiveAudioPlayer extends Component {
     const jwplayerStartingOnACertainTrack = this.checkIfPlayerStartsAtN(index);
 
     if (initiatePlay || (jwplayerStartingOnACertainTrack && !startingAtCaptured)) {
-      console.warn('onPlaylistItemCB', initiatePlay, jwplayerStartingOnACertainTrack);
       const { jwplayerPlaylistChange } = this.props;
       jwplayerPlaylistChange({ newTrackIndex: index });
     }
@@ -157,7 +146,6 @@ class ArchiveAudioPlayer extends Component {
   setURL(trackNumber) {
     const { player } = this.state;
     const playlistIndex = trackNumber - 1 || 0;
-    console.log('IAUX SET URL PLAYN', playlistIndex);
     return player.playN(playlistIndex, true);
   }
 
@@ -209,9 +197,7 @@ class ArchiveAudioPlayer extends Component {
   playTrack(stateToUpdate) {
     const { playerPlaylistIndex } = stateToUpdate;
     const { player } = this.state;
-    console.warn('IAUX PLAYN StateTOUpdate', stateToUpdate);
     this.setState(stateToUpdate, () => {
-      console.warn('IAUX PLAYN CALLBACK', playerPlaylistIndex);
       player.playN(playerPlaylistIndex);
     });
   }

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -77,7 +77,6 @@ export default class TheatreAudioPlayer extends Component {
       <ArchiveAudioPlayer
         {...this.props}
         onRegistrationComplete={this.receiveURLSetter}
-        needsURLSettingAccess
       />
     );
     if (isExternal) {

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import ArchiveAudioPlayer from './archive-audio-jwplayer-wrapper';
 import ThirdPartyEmbeddedPlayer from './third-party-embed';
@@ -73,12 +73,7 @@ export default class TheatreAudioPlayer extends Component {
   showMedia() {
     const { source, sourceData } = this.props;
     const isExternal = source === 'youtube' || source === 'spotify';
-    let mediaElement = (
-      <ArchiveAudioPlayer
-        {...this.props}
-        onRegistrationComplete={this.receiveURLSetter}
-      />
-    );
+    let mediaElement = null;
     if (isExternal) {
       // make iframe with URL
       const { urlSetterFN } = this.state;
@@ -94,7 +89,6 @@ export default class TheatreAudioPlayer extends Component {
         <ThirdPartyEmbeddedPlayer
           sourceURL={sourceURL}
           title={name}
-
         />
       );
       // updateURL
@@ -102,8 +96,18 @@ export default class TheatreAudioPlayer extends Component {
         urlSetterFN(trackNumber);
       }
     }
+    const archiveStyle = isExternal ? { visibility: 'hidden' } : { visibility: 'visible' };
 
-    return mediaElement;
+    return (
+      <Fragment>
+        <ArchiveAudioPlayer
+          {...this.props}
+          onRegistrationComplete={this.receiveURLSetter}
+          style={archiveStyle}
+        />
+        { mediaElement }
+      </Fragment>
+    );
   }
 
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -71,7 +71,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       tracklistToShow: [],
       channelToPlay: 'archive',
       trackSelected: null, /* 0 = album */
-      userEvent: false,
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
@@ -132,10 +131,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   jwplayerPlaylistChange(playlistItem) {
     const { newTrackIndex } = playlistItem;
-    this.setState({
-      trackSelected: newTrackIndex + 1,
-      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
-    });
+    this.setState({ trackSelected: newTrackIndex + 1 });
   }
 
   /**
@@ -147,7 +143,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const selectedTrackNumber = parseInt(selected.getAttribute('data-track-number'), 10);
 
     this.setState({
-      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
       trackSelected: Number.isInteger(selectedTrackNumber)
         ? selectedTrackNumber
         : 1
@@ -182,11 +177,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player needs index and "is user event?"
-    audioSource = {
-      userEvent: this.state.userEvent,
-      index: trackSelected - 1 || 0
-    };
+    // ia jw player needs index
+    audioSource = { index: trackSelected - 1 || 0 };
 
     return audioSource;
   }

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -71,6 +71,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       tracklistToShow: [],
       channelToPlay: 'archive',
       trackSelected: null, /* 0 = album */
+      userEvent: false,
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
@@ -131,7 +132,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   jwplayerPlaylistChange(playlistItem) {
     const { newTrackIndex } = playlistItem;
-    this.setState({ trackSelected: newTrackIndex + 1 });
+    this.setState({
+      trackSelected: newTrackIndex + 1,
+      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
+    });
   }
 
   /**
@@ -143,6 +147,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const selectedTrackNumber = parseInt(selected.getAttribute('data-track-number'), 10);
 
     this.setState({
+      userEvent: event  &&  event.nativeEvent  &&  event.nativeEvent instanceof MouseEvent,
       trackSelected: Number.isInteger(selectedTrackNumber)
         ? selectedTrackNumber
         : 1
@@ -177,8 +182,9 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player only needs index
+    // ia jw player needs index and "is user event?"
     audioSource = {
+      userEvent: this.state.userEvent,
       index: trackSelected - 1 || 0
     };
 
@@ -245,7 +251,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const {
       title,
       identifier,
-      collection,
       creator
     } = albumMetadaToDisplay;
     let audioPlayerChannelLabel;
@@ -258,7 +263,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const jwplayerInfo = {
       jwplayerPlaylist,
       identifier,
-      collection
     };
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -177,8 +177,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       return audioSource || {};
     }
 
-    // ia jw player needs index
-    audioSource = { index: trackSelected - 1 || 0 };
+    // ia jw player only needs index
+    audioSource = {
+      index: trackSelected - 1 || 0
+    };
 
     return audioSource;
   }


### PR DESCRIPTION
**Description**
This PR will remove the previously inserted hacks to "define" when JWPlayer/Play8 has loaded.

This PR is dependent on this MR going to master in Petabox: https://git.archive.org/ia/petabox/merge_requests/1237

By having the ability to tap into when `Play8`'s setup function, where it initially figures out which track to start on, we remove the direct dependency on `onPlaylistItem` as a setup event.

This allows for as many `onPlaylistItem` events to fire while Play8 handles audio UX that is distinct to the Internet Archive.

The React wrapper can still be mainly passive, meaning that it will take its cues from Play8, and will allow Play8 the flexibility to fire as many `onPlaylistItem` events it needs to get the audio UX correct👌 

**Technical**

Other technical points to note:
- Keeping the React component on screen at all times so the element tied to the Play8 Class instance is always around for the whole session.
  - This makes URL changing when on YouTube or Spotify channels more predictable.
- 


**Testing**

> What steps should the reviewer take to verify this PR resolves the issue?
Manual testing through the following flows listed in this doc: https://docs.google.com/spreadsheets/d/1LUD5KkjG7HRP0rMEy7VlzQIJ43hmi7wRZiD97hUX8N0/edit#gid=0

using `www-isa3`
ex: https://www-isa3.archive.org/details/cd_the-best-of-anita-baker_anita-baker-the-winans

this instance has `console.warns` throughout the wrapper functions to show lifecycle and event management

Unit tests to follow


### Main manual test flows are:
- go on to `/details/:id` > press Play triangle on the player > let player automatically move into next track > track list follows
- go on to `/details/:id` > press selected track 1 > let player play & automatically move to next track > track list follows

#### Start on any track other than 1
- go on to `/details/:id` > click on any track other than 1 > refresh page > URL should now be `/details/:id/:track` > that track is selected > click that selected track > player starts
- go on to `/details/:id` > click on any track other than 1 > refresh page > URL should now be `/details/:id/:track` > that track is selected > press PLAY on player > player starts > let player automatically go to next track > track list follows

#### Play/Pause management
- go on to `/details/:id` > start a track by clicking on PLAY triangle or selected track > PAUSE track on player > click highlighted track to restart play > track starts playing

