### PR TITLE
Jwplayer round3

### DIFF
--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
  *
  * It will display photo if given, and will overlay the media player at the base of the photo.
  *
- * Development is in lock-step with Play8.js.
- * ANY changes to Play8.js may need to be addressed here also.
  */
 class ArchiveAudioPlayer extends Component {
   constructor(props) {
@@ -18,15 +16,25 @@ class ArchiveAudioPlayer extends Component {
 
     // expecting jwplayer to be globally ready
     this.state = {
+      paused: false,
       player: null,
       playerPlaylistIndex: null,
     };
 
     this.onPlaylistItemCB = this.onPlaylistItemCB.bind(this);
+    this.registerPlayerEventHandlers = this.registerPlayerEventHandlers.bind(this);
+    this.handlePause = this.handlePause.bind(this);
+    this.playTrack = this.playTrack.bind(this);
+    this.setURL = this.setURL.bind(this);
   }
 
+  /**
+   * Register jwplayer/play8 instance as component mounts on client
+   */
   componentDidMount() {
-    const { jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete } = this.props;
+    const {
+      jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete
+    } = this.props;
     const { jwplayerPlaylist, identifier } = jwplayerInfo;
     const waveformer = backgroundPhoto
       ? {}
@@ -39,82 +47,127 @@ class ArchiveAudioPlayer extends Component {
       hide_list: true,
       responsive: true,
       onPlaylistItem: this.onPlaylistItemCB,
+      onSetupComplete: (startPlaylistIdx) => {
+        /**
+         * Capture if player starts on track N+1
+         */
+        // if (startPlaylistIdx) {
+        this.setState({ playerPlaylistIndex: startPlaylistIdx }, () => {
+          this.props.jwplayerStartingPoint(startPlaylistIdx);
+        });
+        // }
+      }
     };
 
     if (window.Play && Play) {
       const compiledConfig = Object.assign({}, baseConfig, waveformer);
       const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
-      this.setState({ player });
+      this.setState({ player }, this.registerPlayerEventHandlers);
 
       if (onRegistrationComplete) {
         /**
          * Currently, this is where we support external ability to set URL
          * through Internet Archive's JWPlayer Wrapper
          */
-        const externallySyncURL = function externallySyncURL(jwplayerID, trackNumber) {
-          const playlistIndex = trackNumber - 1 || 0;
-          return Play(jwplayerID).playN(playlistIndex, true);
-        }.bind(null, jwplayerID);
-        onRegistrationComplete(externallySyncURL);
+        onRegistrationComplete(this.setURL);
       }
     }
   }
 
   /**
-   * Check if Track index has changed,
-   * if so, then play that track
+   * Check if track index has changed. If so, then play that track
    */
   componentDidUpdate(prevProps, prevState) {
-    const {
-      player,
-      playerPlaylistIndex,
-    } = this.state;
-    const {
-      playerPlaylistIndex: prevPlayIndex,
-    } = prevState;
-    const { jwplayerID, sourceData: { index = null } } = this.props;
+    const { sourceData: { index = null }, jwplayerID } = this.props;
+    const { sourceData: { index: prevIndex } } = prevProps;
 
-    const indexHasBeenSet = Number.isInteger(index);
-    if (!indexHasBeenSet)
-      return;
+    const { paused, playerPlaylistIndex } = this.state;
+    const { paused: prevPaused } = prevState;
 
-    // Is this a props change? (from parent / above; eg: clicking on tracklist title/button)
-    const propA = parseInt((
-      prevProps  &&  prevProps.sourceData  &&  prevProps.sourceData.index
-      ? prevProps.sourceData.index
-      : null), 10);
-    const propB = parseInt(this.props.sourceData.index, 10);
-    console.log('IAUX componentDidUpdate props change?', propA, '=>', propB);
+    const indexIsNumber = Number.isInteger(index);
 
-    // Is this a state change? (change from our class / we initiated; eg: jwplayer auto-advance)
-    const stateA = parseInt((prevState ? prevState.playerPlaylistIndex : null), 10)
-    const stateB = parseInt(this.state.playerPlaylistIndex, 10);
-    console.log('IAUX componentDidUpdate state change?', stateA, '=>', stateB);
+    if (!indexIsNumber) return;
 
-    // Tell jwplayer to change (or play if already selected) the wanted track
-    player.playN(propB !== propA ? propB : stateB);
+    if (index !== prevIndex && indexIsNumber) {
+      this.playTrack({ playerPlaylistIndex: index });
+    }
+
+    if (paused && prevPaused && index === playerPlaylistIndex) {
+      /**
+       * user Paused via player & then clicked on selected track item to restart
+       */
+      this.handlePause(false, () => jwplayer(jwplayerID).play());
+    }
   }
 
   /**
    * Event Handler that fires when JWPlayer starts a new track (eg: controlbar or auto-advance)
    */
   onPlaylistItemCB(jwplayer, event) {
-    console.log('IAUX: onPlaylistItemCB event, props', event, this.props);
+    const { index } = event;
+    const { playerPlaylistIndex } = this.state;
 
-    const playerPlaylistIndex = event.index;
-    this.setState({ playerPlaylistIndex },
-      () => {
-        console.log('IAUX: onPlaylistItemCB setState() applied', playerPlaylistIndex);
-        this.props.jwplayerPlaylistChange({ newTrackIndex: playerPlaylistIndex });
-      });
+    if (playerPlaylistIndex !== index) {
+      const { jwplayerPlaylistChange } = this.props;
+      jwplayerPlaylistChange({ newTrackIndex: index });
+    }
+  }
+
+  /**
+   * Signals to IA's jwplayer handler, Play8,
+   * that it's time to change the URL to match given track
+   *
+   * @param { number } trackNumber
+   */
+  setURL(trackNumber) {
+    const { player } = this.state;
+    const playlistIndex = trackNumber - 1 || 0;
+    return player.playN(playlistIndex, true);
+  }
+
+  /**
+   * This updates internal state & then tells jwplayer/Play8 to start playing track
+   *
+   * @param { Object } stateToUpdate
+   * @param { number } stateToUpdate.playerPlaylistIndex - Track index to play. *Required
+   * @param { * } stateToUpdate[param] - optional states to update
+   */
+  playTrack(stateToUpdate) {
+    const { playerPlaylistIndex } = stateToUpdate;
+    const { player } = this.state;
+    this.setState(stateToUpdate, () => {
+      player.playN(playerPlaylistIndex);
+    });
+  }
+
+  /**
+   * Captures Pause event and optional fires callbacks
+   *
+   * @param { boolean } paused
+   * @param { function } callback - optional
+   */
+  handlePause(paused, callback = null) {
+    this.setState({ paused }, callback);
+  }
+
+  /**
+   * Registers jwplayer event handlers
+   */
+  registerPlayerEventHandlers() {
+    const { player, paused } = this.state;
+    player.on('play', () => {
+      if (paused) {
+        this.handlePause(false);
+      }
+    });
+    player.on('pause', () => {
+      this.handlePause(true);
+    });
   }
 
 
   render() {
-    const {
-      jwplayerID,
-      backgroundPhoto
-    } = this.props;
+    const { jwplayerID } = this.props;
 
     return (
       <div className="ia-player-wrapper">
@@ -128,10 +181,8 @@ class ArchiveAudioPlayer extends Component {
 
 ArchiveAudioPlayer.defaultProps = {
   backgroundPhoto: '',
-  photoAltTag: '',
   jwplayerID: '',
   jwplayerPlaylistChange: null,
-  jwPlayerPlaylist: [],
   jwplayerInfo: {},
   sourceData: null,
   onRegistrationComplete: null,
@@ -139,12 +190,15 @@ ArchiveAudioPlayer.defaultProps = {
 
 ArchiveAudioPlayer.propTypes = {
   backgroundPhoto: PropTypes.string,
-  photoAltTag: PropTypes.string,
   jwplayerID: PropTypes.string,
   jwplayerPlaylistChange: PropTypes.func,
-  jwPlayerPlaylist: PropTypes.array,
-  jwplayerInfo: PropTypes.object,
-  sourceData: PropTypes.object,
+  jwplayerInfo: PropTypes.shape({
+    jwplayerPlaylist: PropTypes.array,
+    identifier: PropTypes.string
+  }),
+  sourceData: PropTypes.shape({
+    index: PropTypes.number
+  }),
   onRegistrationComplete: PropTypes.func,
 };
 

--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -83,7 +83,7 @@ class ArchiveAudioPlayer extends Component {
     if (!indexIsNumber) return;
 
     if (index !== prevIndex && indexIsNumber) {
-      this.playTrack({ playerPlaylistIndex: index });
+      this.playTrack({ playerPlaylistIndex: index - 1 || 0 });
     }
   }
 

--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -16,14 +16,11 @@ class ArchiveAudioPlayer extends Component {
 
     // expecting jwplayer to be globally ready
     this.state = {
-      paused: false,
       player: null,
       playerPlaylistIndex: null,
     };
 
     this.onPlaylistItemCB = this.onPlaylistItemCB.bind(this);
-    this.registerPlayerEventHandlers = this.registerPlayerEventHandlers.bind(this);
-    this.handlePause = this.handlePause.bind(this);
     this.playTrack = this.playTrack.bind(this);
     this.setURL = this.setURL.bind(this);
   }
@@ -62,7 +59,7 @@ class ArchiveAudioPlayer extends Component {
     if (window.Play && Play) {
       const compiledConfig = Object.assign({}, baseConfig, waveformer);
       const player = Play(jwplayerID, jwplayerPlaylist, compiledConfig);
-      this.setState({ player }, this.registerPlayerEventHandlers);
+      this.setState({ player });
 
       if (onRegistrationComplete) {
         /**
@@ -77,12 +74,9 @@ class ArchiveAudioPlayer extends Component {
   /**
    * Check if track index has changed. If so, then play that track
    */
-  componentDidUpdate(prevProps, prevState) {
-    const { sourceData: { index = null }, jwplayerID } = this.props;
+  componentDidUpdate(prevProps) {
+    const { sourceData: { index = null } } = this.props;
     const { sourceData: { index: prevIndex } } = prevProps;
-
-    const { paused, playerPlaylistIndex } = this.state;
-    const { paused: prevPaused } = prevState;
 
     const indexIsNumber = Number.isInteger(index);
 
@@ -90,13 +84,6 @@ class ArchiveAudioPlayer extends Component {
 
     if (index !== prevIndex && indexIsNumber) {
       this.playTrack({ playerPlaylistIndex: index });
-    }
-
-    if (paused && prevPaused && index === playerPlaylistIndex) {
-      /**
-       * user Paused via player & then clicked on selected track item to restart
-       */
-      this.handlePause(false, () => jwplayer(jwplayerID).play());
     }
   }
 
@@ -139,32 +126,6 @@ class ArchiveAudioPlayer extends Component {
       player.playN(playerPlaylistIndex);
     });
   }
-
-  /**
-   * Captures Pause event and optional fires callbacks
-   *
-   * @param { boolean } paused
-   * @param { function } callback - optional
-   */
-  handlePause(paused, callback = null) {
-    this.setState({ paused }, callback);
-  }
-
-  /**
-   * Registers jwplayer event handlers
-   */
-  registerPlayerEventHandlers() {
-    const { player, paused } = this.state;
-    player.on('play', () => {
-      if (paused) {
-        this.handlePause(false);
-      }
-    });
-    player.on('pause', () => {
-      this.handlePause(true);
-    });
-  }
-
 
   render() {
     const { jwplayerID } = this.props;

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -72,7 +72,6 @@ export default class TheatreAudioPlayer extends Component {
    */
   showMedia() {
     const { source, sourceData } = this.props;
-    const { mediaSource } = this.state;
     const isExternal = source === 'youtube' || source === 'spotify';
     let mediaElement = null;
     if (isExternal) {

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import ArchiveAudioPlayer from './archive-audio-jwplayer-wrapper';
 import ThirdPartyEmbeddedPlayer from './third-party-embed';
@@ -72,13 +72,9 @@ export default class TheatreAudioPlayer extends Component {
    */
   showMedia() {
     const { source, sourceData } = this.props;
+    const { mediaSource } = this.state;
     const isExternal = source === 'youtube' || source === 'spotify';
-    let mediaElement = (
-      <ArchiveAudioPlayer
-        {...this.props}
-        onRegistrationComplete={this.receiveURLSetter}
-      />
-    );
+    let mediaElement = null;
     if (isExternal) {
       // make iframe with URL
       const { urlSetterFN } = this.state;
@@ -94,7 +90,6 @@ export default class TheatreAudioPlayer extends Component {
         <ThirdPartyEmbeddedPlayer
           sourceURL={sourceURL}
           title={name}
-
         />
       );
       // updateURL
@@ -102,8 +97,18 @@ export default class TheatreAudioPlayer extends Component {
         urlSetterFN(trackNumber);
       }
     }
+    const archiveStyle = isExternal ? { visibility: 'hidden' } : { visibility: 'visible' };
 
-    return mediaElement;
+    return (
+      <Fragment>
+        <ArchiveAudioPlayer
+          {...this.props}
+          onRegistrationComplete={this.receiveURLSetter}
+          style={archiveStyle}
+        />
+        { mediaElement }
+      </Fragment>
+    );
   }
 
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -70,12 +70,14 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       albumData,
       tracklistToShow: [],
       channelToPlay: 'archive',
+      trackStartingPoint: null,
       trackSelected: null, /* 0 = album */
     };
 
     this.selectThisTrack = this.selectThisTrack.bind(this);
     this.onChannelSelect = this.onChannelSelect.bind(this);
     this.jwplayerPlaylistChange = this.jwplayerPlaylistChange.bind(this);
+    this.jwplayerStartingPoint = this.jwplayerStartingPoint.bind(this);
     this.getSelectableChannels = this.getSelectableChannels.bind(this);
     this.getAudioSourceInfoToPlay = this.getAudioSourceInfoToPlay.bind(this);
   }
@@ -134,6 +136,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     this.setState({ trackSelected: newTrackIndex + 1 });
   }
 
+  jwplayerStartingPoint(index) {
+    this.setState({ trackStartingPoint: index + 1 });
+  }
+
   /**
    * Callback every time user selects a track from the tracklist
    * @param { object } event - React synthetic event
@@ -179,7 +185,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
 
     // ia jw player only needs index
     audioSource = {
-      index: trackSelected - 1 || 0
+      index: trackSelected
     };
 
     return audioSource;
@@ -232,7 +238,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
   render() {
     const { jwplayerPlaylist, linerNotes } = this.props;
     const {
-      tracklistToShow, trackSelected, channelToPlay, albumData
+      tracklistToShow, trackSelected, channelToPlay, albumData, trackStartingPoint
     } = this.state;
     const {
       albumMetadaToDisplay,
@@ -261,6 +267,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display
 
+    const trackToHighlight = trackSelected === null && trackStartingPoint !== null ? trackStartingPoint : trackSelected;
     return (
       <div className="theatre__wrap audio-with-youtube-spotify">
         <section className="media-section">
@@ -282,6 +289,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             }}
             linerNotes={linerNotes}
             jwplayerPlaylistChange={this.jwplayerPlaylistChange}
+            jwplayerStartingPoint={this.jwplayerStartingPoint}
             jwplayerInfo={jwplayerInfo}
             jwplayerID={`jwplayer-${jwplayerID}`}
           />
@@ -307,7 +315,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             <TheatreTrackList
               tracks={tracklistToShow}
               onSelected={this.selectThisTrack}
-              selectedTrack={trackSelected}
+              selectedTrack={trackToHighlight} // trackStartingPoint
               albumName={title}
               displayTrackNumbers={isArchiveChannel}
               creator={origCreator[0] || creator}


### PR DESCRIPTION
**Description**
 
- Play8 `onSetupComplete` sends custom callback that signals what track jwplayer starts on
- only fires `PlayN` when user selects track or when track auto advances
- keeps player element on page so it matches the `Play` instance that it creates on first mount for the whole session