### PR TITLE
Add time delay for displaying error

### DIFF
--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -107,8 +107,8 @@ class YoutubePlayer extends Component {
   onPlayerError(event) {
     const { youtubePlaylistChange } = this.props;
     const { selectedTrack } = this.state;
-    // setTimeout() to display error message? (3s)
-    youtubePlaylistChange(selectedTrack);
+    // setTimeout() to display error message (3s)
+    setTimeout(() => { youtubePlaylistChange(selectedTrack); }, 3000);
   }
 
   render() {


### PR DESCRIPTION
**Description**
Subtask of #213

**Technical**
Uses setTimeout() to display the error for a longer time, before switching on to the next task.

**Evidence**
![Jun-28-2019 21-39-20](https://user-images.githubusercontent.com/30471843/60355985-72924c00-99ed-11e9-86a5-f6d46f0e6135.gif)