### PR TITLE
Fix scope issue in liner notes scaling

### DIFF
--- a/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
+++ b/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
@@ -20,6 +20,8 @@ export default class BookReaderWrapper extends Component {
 
   componentDidMount() {
     const { options } = this.props;
+
+    const originalGetPageURI = BookReader.prototype.getPageURI;
     const defaultOptions = {
       el: `#${this.BookReaderRef.current.id}`,
       mobileNavFullscreenOnly: true,
@@ -33,18 +35,13 @@ export default class BookReaderWrapper extends Component {
       searchInsideUrl: '/fulltext/inside.php',
       initialSearchTerm: null,
       imagesBaseURL: '/bookreader/BookReader/images/',
-      getPageURI: (index, reduce, rotate) => {
-        if ('undefined' == typeof(reduce))
-          reduce = 1;
-        if ('undefined' == typeof(rotate))
-          rotate = 0;
-        let uri = BookReader.prototype.getPageURI.call(this, index, reduce, rotate);
-        uri = uri + (uri.indexOf('?') > -1 ? '&' : '?');
-        uri = uri + 'scale=' + reduce + '&rotate=' + rotate;
+      getPageURI: (index, reduce = 1, rotate = 0) => {
+        let uri = originalGetPageURI.call(br, index, reduce, rotate);
+        uri += (uri.indexOf('?') > -1 ? '&' : '?');
+        uri = `${uri}scale=${reduce}&rotate=${rotate}`;
         return uri;
       },
     };
-
     const fullOptions = {
       ...defaultOptions,
       ...options,


### PR DESCRIPTION
Problem: The `this` in the `getPageURL` function was lost in Reactland.
Solution: pass in the `br` instance that was created

**Testing**

go to: https://www-isa.archive.org/details/cd_the-best-of-anita-baker_anita-baker-the-winans
and LP : https://www-isa.archive.org/details/lp_the-classic-jazz-quartet_the-classic-jazz-quartet

Liner notes should display.  This is especially for a fix for the LPs where the original sizes are massive.

**Evidence**
![image](https://user-images.githubusercontent.com/7840857/60356364-9fab1400-9985-11e9-962f-5211c0f2950c.png)

