### PR TITLE
Music Player, JWPlayer: If there aren't any tracks, do not show or instantiate the player

### DIFF
--- a/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/sandbox/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -33,6 +33,8 @@ class ArchiveAudioPlayer extends Component {
       jwplayerInfo, jwplayerID, backgroundPhoto, onRegistrationComplete
     } = this.props;
     const { jwplayerPlaylist, identifier } = jwplayerInfo;
+    if (!jwplayerPlaylist.length) return;
+
     const waveformer = backgroundPhoto
       ? {}
       : { waveformer: 'jw-holder' };

--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -166,12 +166,11 @@ export default class TheatreAudioPlayer extends Component {
     // the JWplayer controls sit UNDER the album photo
     // while the other players overtake the whole content-window
     // We will have to accomodate the window's fixed height here.
-    const { backgroundPhoto } = this.props;
-    const jwplayerHeightNoWaveform = '4.4rem';
-    const jwplayerHeightYesWaveform = '14rem';
-    const mediaPlayerSectionStyle = backgroundPhoto
-      ? { height: jwplayerHeightNoWaveform }
-      : { height: jwplayerHeightYesWaveform };
+    const { backgroundPhoto, hasTracks } = this.props;
+    let mediaPlayerClass = '';
+    if (hasTracks) {
+      mediaPlayerClass = backgroundPhoto ? 'no-waveform' : 'with-waveform';
+    }
 
     return (
       <section className="theatre__audio-player">
@@ -179,7 +178,7 @@ export default class TheatreAudioPlayer extends Component {
           <div className="album-cover">
             {drawBackgroundPhoto(this.props)}
           </div>
-          <div className="media-player" style={mediaPlayerSectionStyle}>
+          <div className={`media-player ${mediaPlayerClass}`}>
             {this.showMedia()}
             {this.showLinerNotes()}
           </div>
@@ -197,6 +196,7 @@ TheatreAudioPlayer.defaultProps = {
   photoAltTag: '',
   urlExtensions: '',
   linerNotes: null,
+  hasTracks: false,
 };
 
 TheatreAudioPlayer.propTypes = {
@@ -215,4 +215,5 @@ TheatreAudioPlayer.propTypes = {
   photoAltTag: PropTypes.string,
   customSourceLabels: PropTypes.object,
   linerNotes: PropTypes.object,
+  hasTracks: PropTypes.bool,
 };

--- a/packages/ia-components/sandbox/audio-players/audio-player.less
+++ b/packages/ia-components/sandbox/audio-players/audio-player.less
@@ -47,6 +47,16 @@
       color: @3-gray;
       text-align: center;
     }
+
+    .media-player {
+      height: 0;
+      &.with-waveform {
+        height: 14rem;
+      }
+      &.no-waveform {
+        height: 4.4rem;
+      }
+    }
   }
 
   .tabs {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -340,6 +340,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             jwplayerInfo={jwplayerInfo}
             jwplayerID={`jwplayer-${jwplayerID}`}
             onRegistrationComplete={this.receiveURLSetter}
+            hasTracks={!!tracklistToShow.length}
           />
         </section>
         <div className="grid-right">


### PR DESCRIPTION
**Description**
Adding Handling for JWPlayer when there are no tracks to play.
Closes #214 
This is a part of https://webarchive.jira.com/browse/WEBDEV-2331

**Technical**

- extract inline styling and add it to css
- add a new prop into `<AudioPlayerMain/>`: `hasTracks`
  - to signify which class the audio player needs
- In `<ArchiveJWPlayerWrapper>`, do not instantiate JWPlayer/Play8 if there aren't any tracks

**Testing & Evidence**

#### Audio Item without tracks: https://www-isa.archive.org/details/lp_the-classic-jazz-quartet_the-classic-jazz-quartet
![image](https://user-images.githubusercontent.com/7840857/60361260-a0967280-9992-11e9-9a4f-0d76ca807423.png)

#### Audio Item with tracks: https://www-isa.archive.org/details/cd_nervous-records-new-york-album_various-artists-akema-deep-creed-faceman-g
![image](https://user-images.githubusercontent.com/7840857/60361340-cae83000-9992-11e9-9cea-418139c5f4f7.png)

