### PR TITLE
Clear timeout when new track selected

### DIFF
--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -15,6 +15,7 @@ class YoutubePlayer extends Component {
     super(props);
 
     const { selectedTrack, id } = props;
+    this.timer = null;
 
     this.state = {
       player: null,
@@ -56,7 +57,7 @@ class YoutubePlayer extends Component {
     const { id } = this.state;
     const trackChanged = id !== nextProps.id;
     if (trackChanged) {
-      clearTimeout(window.timer);
+      clearTimeout(this.timer);
       this.setState({
         id: nextProps.id,
         selectedTrack: nextProps.selectedTrack
@@ -137,7 +138,7 @@ class YoutubePlayer extends Component {
   onPlayerError(event) {
     const { youtubePlaylistChange } = this.props;
     const { selectedTrack } = this.state;
-    window.timer = setTimeout(() => { youtubePlaylistChange(selectedTrack); }, 3000);
+    this.timer = setTimeout(() => { youtubePlaylistChange(selectedTrack); }, 3000);
   }
 
   render() {

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -14,7 +14,7 @@ class YoutubePlayer extends Component {
   constructor(props) {
     super(props);
 
-    const { selectedTrack, id } = props
+    const { selectedTrack, id } = props;
 
     this.state = {
       player: null,
@@ -56,6 +56,7 @@ class YoutubePlayer extends Component {
     const { id } = this.state;
     const trackChanged = id !== nextProps.id;
     if (trackChanged) {
+      clearTimeout(window.timer);
       this.setState({
         id: nextProps.id,
         selectedTrack: nextProps.selectedTrack
@@ -136,7 +137,7 @@ class YoutubePlayer extends Component {
   onPlayerError(event) {
     const { youtubePlaylistChange } = this.props;
     const { selectedTrack } = this.state;
-    setTimeout(() => { youtubePlaylistChange(selectedTrack); }, 3000);
+    window.timer = setTimeout(() => { youtubePlaylistChange(selectedTrack); }, 3000);
   }
 
   render() {


### PR DESCRIPTION
**Description**

Closes #223  

Clears timeout to prevent it from running when the next track is selected.

