### PR TITLE
Stop autoplaying the youtube player after changing channels

### DIFF
--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -126,7 +126,6 @@ class YoutubePlayer extends Component {
    */
   onPlayerReady(event) {
     document.querySelector('.audio-track-list').setAttribute('style', 'pointer-events: auto');
-    event.target.playVideo();
   }
 
   /**


### PR DESCRIPTION
**Description**

Closes #222 

Stops automatically playing the youtube player after changing channels.

![Jul-02-2019 23-26-47](https://user-images.githubusercontent.com/30471843/60535081-ed76a200-9d20-11e9-9df1-4a1bebb1f7ca.gif)