### PR TITLE
Check track before sending to youtube wrapper or spotify

### DIFF
--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -71,8 +71,7 @@ export default class TheatreAudioPlayer extends Component {
       urlPrefix = '', id = '', urlExtensions = '', name = ''
     } = externalSourceDetails;
     if (source === 'youtube') {
-      const { id = '' } = externalSourceDetails;
-      const { trackNumber = 1 } = sourceData;
+      const { trackNumber } = sourceData;
       mediaElement = (
         <YoutubePlayer
           selectedTrack={trackNumber}
@@ -80,7 +79,7 @@ export default class TheatreAudioPlayer extends Component {
           {...this.props}
 
         />
-      ); // don't send all props send only youtubePlaylistChange
+      );
     } else if (source === 'spotify') {
       const sourceURL = `${urlPrefix}${id}${urlExtensions}`;
       mediaElement = (

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -161,6 +161,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     if (isAlbum) {
       audioSource = {};
       audioSource[channelToPlay] = albumSource;
+      return audioSource;
     }
     // If selected track not null find info for selcted track, else find for first track of list of selected channel
     audioSource = trackSelected ? tracklistToShow.find(t => t.trackNumber === trackSelected) : tracklistToShow.find(t => t.trackNumber >= 1);

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -162,9 +162,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       audioSource = {};
       audioSource[channelToPlay] = albumSource;
     }
-    const trackToHighlight = trackSelected === null && trackStartingPoint !== null ? trackStartingPoint : trackSelected;
-    audioSource = find(tracklistToShow, track => track.trackNumber === trackToHighlight);
-
+    // If selected track not null find info for selcted track, else find for first track of list of selected channel
+    audioSource = trackSelected ? tracklistToShow.find(t => t.trackNumber === trackSelected) : tracklistToShow.find(t => t.trackNumber >= 1);
     return audioSource || {};
   }
 


### PR DESCRIPTION
**Description**

Closes #230

Verifies a track number's presence in the youtube/spotify channel before sending it to their respective wrapper, if not present sends the next track in order.
