### PR TITLE
Music Player - updating onload management of track availability

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -165,7 +165,14 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     }
     const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
     const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
-    audioSource = find(tracklistToShow, track => track.trackNumber === trackToHighlight);
+
+    const trackInfo = find(tracklistToShow, (track) => {
+      const trackFound = track.trackNumber === trackToHighlight;
+      if (trackFound) {
+        return track;
+      }
+    });
+    audioSource = trackInfo || head(tracklistToShow);
 
     return audioSource || {};
   }
@@ -232,10 +239,15 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    * Callback every time YoutubePlayer changes track
    * @param { number } prevTrack- Track number of previously played video
    */
-  youtubePlaylistChange(prevTrack) {
+  youtubePlaylistChange(prevTrack, setURLOnly) {
     const { tracklistToShow } = this.state;
+    let trackSelected;
+    if (setURLOnly) {
+      trackSelected = tracklistToShow.find(t => t.trackNumber === prevTrack);
+    } else {
+      trackSelected = tracklistToShow.find(t => t.trackNumber >= prevTrack + 1);
+    }
     // Find next track number in line
-    const trackSelected = tracklistToShow.find(t => t.trackNumber >= prevTrack + 1);
     if (trackSelected) {
       this.setState({ trackSelected: trackSelected.trackNumber }, this.updateURL);
     }
@@ -313,8 +325,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display
 
-    const trackToHighlight = trackSelected === null && trackStartingPoint !== null ? trackStartingPoint : trackSelected;
     const audioSource = this.getAudioSourceInfoToPlay();
+    const trackToHighlight = audioSource.trackNumber || audioSource.index || trackStartingPoint || null;
     const contentBoxTabs = {
       player: getChannelLabelToDisplay({
         channel: channelToPlay,

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -163,8 +163,10 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       audioSource[channelToPlay] = albumSource;
       return audioSource;
     }
-    // If selected track not null find info for selcted track, else find for first track of list of selected channel
-    audioSource = trackSelected ? tracklistToShow.find(t => t.trackNumber === trackSelected) : tracklistToShow.find(t => t.trackNumber >= 1);
+    const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
+    const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
+    audioSource = find(tracklistToShow, track => track.trackNumber === trackToHighlight);
+
     return audioSource || {};
   }
 


### PR DESCRIPTION
**Description**
YouTube wrapper behavior fine tuning.
This PR ensures the following:
1) On page load, changing channels does not update track nor autoplay
2) On page load, changing channel to YouTube, clicking on the selected track plays the video

#1 & 2) Can be tested on:
`https://www-isa.archive.org/details/cd_backstreet-boys_backstreet-boys/disc1/03.+Backstreet+Boys+-+Get+Down+(You're+The+One+For+Me).flac`
&&
`https://www-isa.archive.org/details/cd_backstreet-boys_backstreet-boys`
Repro Steps:
- load page
- change channel to YouTube
- change channel back to Internet Archive
  - basically, any channel change on load should NOT pollute URL. should not autoplay YouTube.
- NOW, change back to YouTube
- click on highlighted track,
- video will play
