### PR TITLE
Track listing artist update

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -296,7 +296,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
   render() {
     const { jwplayerPlaylist, linerNotes } = this.props;
     const {
-      tracklistToShow, trackSelected, channelToPlay, albumData, trackStartingPoint
+      tracklistToShow, channelToPlay, albumData, trackStartingPoint
     } = this.state;
     const {
       albumMetadaToDisplay,
@@ -324,7 +324,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     };
     const jwplayerID = identifier.replace(/[^a-zA-Z\d]/g, '');
     const displayChannelSelector = !!externalSources.length; // make it actual boolean so it won't display
-
     const audioSource = this.getAudioSourceInfoToPlay();
     const trackToHighlight = audioSource.trackNumber || audioSource.index || trackStartingPoint || null;
     const contentBoxTabs = {
@@ -381,7 +380,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
               selectedTrack={trackToHighlight} // trackStartingPoint
               albumName={title}
               displayTrackNumbers={isArchiveChannel}
-              creator={origCreator[0] || creator}
+              creator={origCreator || creator}
               dataEventCategory="Audio-Player"
             />
           </section>

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -187,6 +187,19 @@ class DataHydrator extends Component {
                   </button>
                 </td>
               </tr>
+              <tr>
+                <td>what CD compilation - all track artists names show</td>
+                <td>
+                <button
+                  type="button"
+                  className="btn btn-lg btn-primary"
+                  data-identifier="wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623"
+                  onClick={this.getItem}
+                >
+                wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623
+                </button>
+              </td>
+              </tr>
             </tbody>
           </table>
         </section>

--- a/packages/ia-components/sandbox/track-lists/track-list.jsx
+++ b/packages/ia-components/sandbox/track-lists/track-list.jsx
@@ -17,14 +17,17 @@ const parseTrackTitle = ({
   name = '',
   title = '',
   albumCreator,
+  albumName,
   creator = '',
   artist = '',
   isAlbum = false
 }) => {
   if (isAlbum) { return 'Full album'; }
-
+  const albumCreatorString = albumCreator.join(', ');
   const whichArtistVal = creator || artist;
-  const artistName = whichArtistVal !== albumCreator ? whichArtistVal : '';
+  /* this considers "Best of" albums */
+  const titleHasTrackArtist = albumName.includes(whichArtistVal);
+  const artistName = titleHasTrackArtist || (whichArtistVal === albumCreatorString) ? '' : whichArtistVal;
 
   if (title) {
     return (
@@ -49,11 +52,11 @@ const parseTrackTitle = ({
  */
 const trackButton = (props) => {
   const {
-    selected, onSelected, thisTrack, displayTrackNumbers, albumCreator
+    selected, onSelected, thisTrack, displayTrackNumbers, albumCreator, albumName
   } = props;
   const { trackNumber, length, formattedLength } = thisTrack;
   const key = `individual-track-${trackNumber}`;
-  const trackTitle = parseTrackTitle({ ...thisTrack, albumCreator });
+  const trackTitle = parseTrackTitle({ ...thisTrack, albumCreator, albumName });
   const displayNumber = parseInt(trackNumber, 10) || '-';
   const displayLength = formattedLength || length || '-- : --';
 
@@ -84,7 +87,7 @@ const trackButton = (props) => {
 class TheatreTrackList extends Component {
   render() {
     const {
-      selectedTrack, onSelected, tracks, displayTrackNumbers, creator: albumCreator
+      selectedTrack, onSelected, tracks, displayTrackNumbers, creator: albumCreator, albumName
     } = this.props;
 
     if (!tracks.length) return <p className="no-tracks">No tracks to display.</p>;
@@ -106,7 +109,7 @@ class TheatreTrackList extends Component {
               const { trackNumber } = thisTrack;
               const selected = trackNumber === trackNumberToHighlight;
               return trackButton({
-                thisTrack, onSelected, selected, displayTrackNumbers, albumCreator
+                thisTrack, onSelected, selected, displayTrackNumbers, albumCreator, albumName
               });
             })
           }
@@ -119,7 +122,8 @@ class TheatreTrackList extends Component {
 TheatreTrackList.defaultProps = {
   tracks: [],
   displayTrackNumbers: true,
-  creator: ''
+  creator: '',
+  albumName: '',
 };
 
 TheatreTrackList.propTypes = {
@@ -128,6 +132,7 @@ TheatreTrackList.propTypes = {
   tracks: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
   displayTrackNumbers: PropTypes.bool,
   creator: PropTypes.string,
+  albumName: PropTypes.string,
 };
 
 export default TheatreTrackList;


### PR DESCRIPTION
**Description**
Music Player - track artist update
Removes the dependency of the first artist being listed in the album creator list as the main artist.
This checks the following:
- Do not show track artist if it matches the album artist
- Do not show track artist if track artist mastches the album artist

**Technical**

> What should be noted about the implementation?

**Testing**
You can run storybook and check the examples to see updates.

**Evidence**

Compilations show ALL the artists in the track list:
![image](https://user-images.githubusercontent.com/7840857/61736091-2b705000-ad3a-11e9-833a-a15232e49e43.png)

Best of albums do not show main artist:
![image](https://user-images.githubusercontent.com/7840857/61736139-4642c480-ad3a-11e9-8786-308b4c980a60.png)

Classical compilations can vary, and we will err in the side of redundancy:
![image](https://user-images.githubusercontent.com/7840857/61736196-64a8c000-ad3a-11e9-89cc-f58c773b8bce.png)



