### PR TITLE
Paginator - 3 column wide view pages well

### DIFF
--- a/packages/ia-components/sandbox/pagination/utils/dom-dimensions.js
+++ b/packages/ia-components/sandbox/pagination/utils/dom-dimensions.js
@@ -138,7 +138,10 @@ export const calculateDimensions = (paginationContainer) => {
   );
 
   const columnsAreOdd = !!(numberOfColumns % 2);
-  const numberOfPages = columnsAreOdd
+  const widthCanAccept3Columns = clientWidth >= 1168;
+  const extraWideViewHasOverflow = widthCanAccept3Columns && (numberOfColumns > 3) && (numberOfColumns < 6);
+
+  const numberOfPages = columnsAreOdd || extraWideViewHasOverflow
     ? Math.ceil((scrollWidth / clientWidth).toFixed(1))
     : Math.round((scrollWidth / clientWidth).toFixed(1));
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -190,15 +190,28 @@ class DataHydrator extends Component {
               <tr>
                 <td>what CD compilation - all track artists names show</td>
                 <td>
-                <button
-                  type="button"
-                  className="btn btn-lg btn-primary"
-                  data-identifier="wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623"
-                  onClick={this.getItem}
-                >
-                wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623
-                </button>
-              </td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-primary"
+                    data-identifier="wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623"
+                    onClick={this.getItem}
+                  >
+                  wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>3 column track list wide view pagination check</td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-primary"
+                    data-identifier="illegal-art"
+                    onClick={this.getItem}
+                  >
+                  illegal-art
+                  </button>
+                </td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Page calculation can only do so much with JS math.
This case happens when, in extra wide view, the track listing columns are larger than 3 and less than 6.
The container's scrollWidth / containerWidth will not detect that other necessary page.

So we must make sure we have a case for it.

**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.

**Technical**

> What should be noted about the implementation?

**Testing & Evidence**

Load Storybook, go to music player example, click on pre-loaded id: illegal-art

BEFORE -- Paginator doesn't show up:
![image](https://user-images.githubusercontent.com/7840857/61754302-76ed2300-ad67-11e9-98a3-52b638ee785b.png)

AFTER -- Paginator shows up:
![image](https://user-images.githubusercontent.com/7840857/61754246-4c02cf00-ad67-11e9-9050-f702d0cbb0cf.png)

