### PR TITLE
Multiple music player bug fixes (per commit)

### DIFF
--- a/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
@@ -13,12 +13,12 @@ import { includes } from 'lodash';
  * ytParams.hasTimestamp - boolean
  */
 export default (fullID) => {
-  const URNqueryStart = new RegExp(/\?\=/g);
+  const urnQueryStart = new RegExp(/\?\=/g);
   const suggestedQuality = 'default';
   const defaultStartSeconds = 0;
   let secondsRetrieved;
 
-  const videoIdPieces = fullID.split(URNqueryStart);
+  const videoIdPieces = fullID.split(urnQueryStart);
   const hasTimestamp = videoIdPieces.length > 1;
   const videoId = videoIdPieces[0];
 

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
  * and returns a body to feed into YouTube iFrame API
  *
  * @param { string } fullID
- * @return { object ) ytParams
+ * @return { object } ytParams
  * ytParams.videoId - string
  * ytParams.startSeconds - number
  * ytParams.suggestedQuality - 'default'

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
@@ -18,14 +18,15 @@ export default (fullID) => {
   let secondsRetrieved;
 
   const videoIdPieces = fullID.split(URNqueryStart);
-  const noTimestamp = videoIdPieces.length < 2;
+  const hasTimestamp = videoIdPieces.length > 1;
   const videoId = videoIdPieces[0];
 
-  if (noTimestamp) {
+  if (!hasTimestamp) {
     return {
       videoId,
       startSeconds: defaultStartSeconds,
       suggestedQuality,
+      hasTimestamp
     };
   }
 
@@ -44,6 +45,7 @@ export default (fullID) => {
     videoId,
     startSeconds,
     suggestedQuality,
+    hasTimestamp
   };
 
   return params;

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
@@ -1,0 +1,50 @@
+import { includes } from 'lodash';
+
+/**
+ * YouTube Params Parser
+ * Takes the given YouTube URN
+ * and returns a body to feed into YouTube iFrame API
+ *
+ * @param { string } fullID
+ * @return { object ) ytParams
+ * ytParams.videoId - string
+ * ytParams.startSeconds - number
+ * ytParams.suggestedQuality - 'default'
+ */
+export default (fullID) => {
+  const URNqueryStart = new RegExp(/\?\=/g);
+  const suggestedQuality = 'default';
+  const defaultStartSeconds = 0;
+  let secondsRetrieved;
+
+  const videoIdPieces = fullID.split(URNqueryStart);
+  const noTimestamp = videoIdPieces.length < 2;
+  const videoId = videoIdPieces[0];
+
+  if (noTimestamp) {
+    return {
+      videoId,
+      startSeconds: defaultStartSeconds,
+      suggestedQuality,
+    };
+  }
+
+  videoIdPieces.forEach((idPiece) => {
+    const hasTimeStamp = includes(idPiece, 't=');
+    if (hasTimeStamp) {
+      const secondsString = idPiece.substring(2);
+      secondsRetrieved = parseInt(secondsString, 10);
+    }
+  });
+
+  const startSeconds = Number.isInteger(secondsRetrieved)
+    ? secondsRetrieved
+    : defaultStartSeconds;
+  const params = {
+    videoId,
+    startSeconds,
+    suggestedQuality,
+  };
+
+  return params;
+};

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-params-parser.js
@@ -10,6 +10,7 @@ import { includes } from 'lodash';
  * ytParams.videoId - string
  * ytParams.startSeconds - number
  * ytParams.suggestedQuality - 'default'
+ * ytParams.hasTimestamp - boolean
  */
 export default (fullID) => {
   const URNqueryStart = new RegExp(/\?\=/g);

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -168,8 +168,8 @@ class YoutubePlayer extends Component {
     const { id: propsID } = this.props;
     const availableID = id || propsID;
     const params = youTubeParamsParser(availableID);
-    const { videoId, startSeconds } = params;
-    const sameVideo = includes(availableID, videoId);
+    const { videoId, startSeconds, hasTimestamp } = params;
+    const sameVideo = includes(availableID, videoId) && hasTimestamp;
     if (sameVideo) {
       player.seekTo(startSeconds);
     } else {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -201,6 +201,19 @@ class DataHydrator extends Component {
                 </td>
               </tr>
               <tr>
+                <td>Track names, multiple but same as album artist (should be omitted)</td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-primary"
+                    data-identifier="lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos"
+                    onClick={this.getItem}
+                  >
+                  lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos
+                  </button>
+                </td>
+              </tr>
+              <tr>
                 <td>3 column track list wide view pagination check</td>
                 <td>
                   <button

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -239,6 +239,19 @@ class DataHydrator extends Component {
                   </button>
                 </td>
               </tr>
+              <tr>
+                <td>Has 3rd party "Full Album". Clicking on Full Album should highlight full album</td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-primary"
+                    data-identifier="cd_aaliyah_aaliyah-static-from-playa-timbaland"
+                    onClick={this.getItem}
+                  >
+                  cd_aaliyah_aaliyah-static-from-playa-timbaland
+                  </button>
+                </td>
+              </tr>
             </tbody>
           </table>
         </section>

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -226,6 +226,19 @@ class DataHydrator extends Component {
                   </button>
                 </td>
               </tr>
+              <tr>
+                <td>Track time display, 60 seconds adds another minute. should display as 10:00</td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-lg btn-primary"
+                    data-identifier="wcd_borghild_die-warzau_mp3_320_1648819"
+                    onClick={this.getItem}
+                  >
+                  wcd_borghild_die-warzau_mp3_320_1648819
+                  </button>
+                </td>
+              </tr>
             </tbody>
           </table>
         </section>

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
@@ -6,9 +6,11 @@ const formatTime = (lengthInSeconds) => {
   if (!lengthInSeconds) return null;
   const lengthInMS = parseFloat(lengthInSeconds) * 1000;
   const minutes = Math.floor(lengthInMS / 60000);
-  const seconds = ((lengthInMS % 60000) / 1000).toFixed(0);
-  const secondsDisplay = (seconds < 10 ? '0' : '') + seconds;
-  return `${minutes}:${secondsDisplay}`;
+  const seconds = ((lengthInMS % 60000) / 1000).toFixed(0); // becomes a string, thanks JS math
+  const extraMinute = seconds === '60';
+  const secondsDisplay = extraMinute ? '00' : (seconds < 10 ? '0' : '') + seconds;
+  const minutesDisplay = extraMinute ? minutes + 1 : minutes;
+  return `${minutesDisplay}:${secondsDisplay}`;
 };
 
 /**

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/get-track-list-by-source.js
@@ -50,10 +50,10 @@ const getTrackListBySource = (albumData, sourceToPlay) => {
 
   if (externalSource) {
     const albumPlaceholder = {
-      trackNumber: 0,
       youtube: albumSpotifyYoutubeInfo.youtube || null,
       spotify: albumSpotifyYoutubeInfo.spotify || null,
-      isAlbum: true
+      isAlbum: true,
+      trackNumber: 0,
     };
     const tracksToReturn = [];
     const tracksWithExternalSource = tracks.reduce((allTracks = [albumPlaceholder], track, index) => {
@@ -68,7 +68,7 @@ const getTrackListBySource = (albumData, sourceToPlay) => {
       if (track.hasOwnProperty(sourceToPlay)) { allTracks.push(formattedTrack); }
       return allTracks;
     }, []);
-    if (albumSpotifyYoutubeInfo[sourceToPlay]) {
+    if (albumSpotifyYoutubeInfo.hasOwnProperty(sourceToPlay)) {
       tracksToReturn.push(albumPlaceholder);
     }
 

--- a/packages/ia-components/sandbox/track-lists/track-list.jsx
+++ b/packages/ia-components/sandbox/track-lists/track-list.jsx
@@ -23,7 +23,7 @@ const parseTrackTitle = ({
   isAlbum = false
 }) => {
   if (isAlbum) { return 'Full album'; }
-  const albumCreatorString = albumCreator.join(', ');
+  const albumCreatorString = albumCreator.join('; ');
   const whichArtistVal = creator || artist;
   /* this considers "Best of" albums */
   const titleHasTrackArtist = albumName.includes(whichArtistVal);

--- a/packages/ia-components/sandbox/track-lists/track-list.jsx
+++ b/packages/ia-components/sandbox/track-lists/track-list.jsx
@@ -57,7 +57,8 @@ const trackButton = (props) => {
   const { trackNumber, length, formattedLength } = thisTrack;
   const key = `individual-track-${trackNumber}`;
   const trackTitle = parseTrackTitle({ ...thisTrack, albumCreator, albumName });
-  const displayNumber = parseInt(trackNumber, 10) || '-';
+  const track = parseInt(trackNumber, 10);
+  const displayNumber = track > 0 ? track : '-';
   const displayLength = formattedLength || length || '-- : --';
 
   const trackButtonClass = `${selected ? 'selected ' : ''}track${!displayTrackNumbers ? ' no-track-number' : ''}`;


### PR DESCRIPTION
Fixes included in this PR:

#### Music Player, track list can highlight "Full Album" option
Problem:
Full Album is not highlighted when selected in 3rd party channel - `archive.org/details/cd_aaliyah_aaliyah-static-from-playa-timbaland`

Solution:
url 1: `https://www-isa.archive.org/details/cd_aaliyah_aaliyah-static-from-playa-timbaland/disc1/02.+Aaliyah%3B+Static+From+Playa+-+Loose+Rap.flac`
url 2: `https://www-isa.archive.org/details/cd_aaliyah_aaliyah-static-from-playa-timbaland`

QA notes:
- onload `/details/:id` OR `/details/:id/:track` > changing channels >
  - track 1 will be highlighted if its available in the channel
  - NO change to URL
- onload `/details/:id/:track` > change channel > select "Full Album" track 
  - URL will not change
- onload `/details/:id/:track` > change channel > select "Full Album" track > change channels 
  - channel that doesn't have a "Full Album" track option defers back to 1st available track, no URL change.
- normal track selection and autoadvance behavior will update the URL

#### Track list, time display - make sure computed 60 seconds adds a minute to the display
Problem:
displays 9:60 - `archive.org/details/wcd_borghild_die-warzau_mp3_320_1648819`

Solution:
displays 10:00 - `www-isa.archive.org/details/wcd_borghild_die-warzau_mp3_320_1648819`

#### Tack list, artist display - match delimiter (`;`) when comparing album artist[s] to track artist[s]
Problem:
displays all of the album artists - `archive.org/details/lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos`

Solution:
does not display any of them - `www-isa.archive.org/details/lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos`


#### YouTube fixes around full album videos with timestamps and double video loading
Problems:
can be experienced in: `https://archive.org/details/cd_aaliyah_aaliyah-static-from-playa-timbaland`
- On load and video play, the video loads twice
- An item with a FULL ALBUM option, the subsequent video tracks fail
- toggling back and forth from liner notes caused autoplay

Solutions:
- remove state setter anti-pattern in `shouldComponentUpdate`
  - this stopped the double load of the video
  - this also stopped the autoplay when toggling between liner notes
- create parser to check for the starting timestamp in a given YouTube ID
  - when an item has a FULL ALBUM option, the album tracks have the same videoID
    but have a timestamp in the URN
  - create a parser that retrieves this timestamp and feed it into player

QA notes:
can be seen here: `https://www-isa.archive.org/details/cd_aaliyah_aaliyah-static-from-playa-timbaland`
- clicking on `Full Album` highlights the track option
- toggling between liner notes does not trigger autoplay in YouTube videos
- no more double loading of video when starting YouTube player

Caveats: Since the video in reference is a full album, there is no end to the video. Example: click on track 3, video starts in track 3. when track 3 is done, it will just keep playing video, tracklist won't move.  This is the subsequent issue of how the player is implemented. Not a blocker, but an improvement.

Other items with 1:1 track/video references autoadvance smoothly. ie. `https://www-isa.archive.org/details/cd_nervous-records-new-york-album_various-artists-akema-deep-creed-faceman-g`