### PR TITLE
Youtube full album handler & Overall Flow Management

### DIFF
--- a/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/sandbox/audio-players/audio-player-main.jsx
@@ -63,7 +63,7 @@ export default class TheatreAudioPlayer extends Component {
    * Render function - Choose player according to `source
    */
   showMedia() {
-    const { source, sourceData } = this.props;
+    const { source, sourceData, playlist } = this.props;
     const isExternal = source === 'youtube' || source === 'spotify';
     let mediaElement = null;
     const externalSourceDetails = sourceData[source] || {};
@@ -76,8 +76,8 @@ export default class TheatreAudioPlayer extends Component {
         <YoutubePlayer
           selectedTrack={trackNumber}
           id={id}
+          playlist={playlist}
           {...this.props}
-
         />
       );
     } else if (source === 'spotify') {
@@ -165,8 +165,9 @@ export default class TheatreAudioPlayer extends Component {
     // the JWplayer controls sit UNDER the album photo
     // while the other players overtake the whole content-window
     // We will have to accomodate the window's fixed height here.
-    const { backgroundPhoto, hasTracks } = this.props;
+    const { backgroundPhoto, playlist } = this.props;
     let mediaPlayerClass = '';
+    const hasTracks = !!playlist.length;
     if (hasTracks) {
       mediaPlayerClass = backgroundPhoto ? 'no-waveform' : 'with-waveform';
     }
@@ -195,7 +196,6 @@ TheatreAudioPlayer.defaultProps = {
   photoAltTag: '',
   urlExtensions: '',
   linerNotes: null,
-  hasTracks: false,
 };
 
 TheatreAudioPlayer.propTypes = {
@@ -214,5 +214,5 @@ TheatreAudioPlayer.propTypes = {
   photoAltTag: PropTypes.string,
   customSourceLabels: PropTypes.object,
   linerNotes: PropTypes.object,
-  hasTracks: PropTypes.bool,
+  playlist: PropTypes.array.isRequired,
 };

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-full-album-registry.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-full-album-registry.js
@@ -5,15 +5,11 @@ import youTubeParamsParser from './youtube-params-parser';
  * - all IDs are the same
  * - has timestamp
  * it will create a dictonary { trackNumber: {videoID, timestamp} }
- *
- *
- *
- *
+ * @return { object | null } dictionary
  */
 export default (playlist) => {
   let mainVideoID = '';
-  const directory = playlist.reduce((acc, track, index) => {
-    const dir = acc || {};
+  const directory = playlist.reduce((dir, track) => {
     const thisTrack = track.youtube || track;
     const { trackNumber } = track;
     const isAlbum = trackNumber === 0;
@@ -23,13 +19,13 @@ export default (playlist) => {
     }
     const fullVideoSegment = mainVideoID === videoId;
     if (fullVideoSegment) {
-      dir[trackNumber] = {
+      dir.push({
         videoId,
         startSeconds,
         trackNumber,
-      };
+      });
     }
     return dir;
-  }, {});
-  return Object.keys(directory).length ? directory : null;
+  }, []);
+  return directory.length ? directory : null;
 };

--- a/packages/ia-components/sandbox/audio-players/utils/youtube-full-album-registry.js
+++ b/packages/ia-components/sandbox/audio-players/utils/youtube-full-album-registry.js
@@ -1,0 +1,35 @@
+import youTubeParamsParser from './youtube-params-parser';
+/**
+ * YouTube Full Album Registry
+ * checks playlist and if:
+ * - all IDs are the same
+ * - has timestamp
+ * it will create a dictonary { trackNumber: {videoID, timestamp} }
+ *
+ *
+ *
+ *
+ */
+export default (playlist) => {
+  let mainVideoID = '';
+  const directory = playlist.reduce((acc, track, index) => {
+    const dir = acc || {};
+    const thisTrack = track.youtube || track;
+    const { trackNumber } = track;
+    const isAlbum = trackNumber === 0;
+    const { videoId, startSeconds } = youTubeParamsParser(thisTrack.id);
+    if (isAlbum) {
+      mainVideoID = videoId;
+    }
+    const fullVideoSegment = mainVideoID === videoId;
+    if (fullVideoSegment) {
+      dir[trackNumber] = {
+        videoId,
+        startSeconds,
+        trackNumber,
+      };
+    }
+    return dir;
+  }, {});
+  return Object.keys(directory).length ? directory : null;
+};

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -142,9 +142,8 @@ class YoutubePlayer extends Component {
     };
 
     if (videoStartedPlaying) {
-      videoTimePoller();
       // least disruptive in full video playing experience
-      const interval = 5000;
+      const interval = 800;
       if (!this.fullAlbumVideoPoller) {
         this.fullAlbumVideoPoller = setInterval(videoTimePoller, interval);
       }

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -93,6 +93,7 @@ class YoutubePlayer extends Component {
    */
   componentWillUnmount() {
     clearInterval(this.fullAlbumVideoPoller);
+    this.fullAlbumVideoPoller = null;
     clearTimeout(this.timer);
   }
 
@@ -142,8 +143,10 @@ class YoutubePlayer extends Component {
 
     if (videoStartedPlaying) {
       videoTimePoller();
+      // least disruptive in full video playing experience
+      const interval = 5000;
       if (!this.fullAlbumVideoPoller) {
-        this.fullAlbumVideoPoller = setInterval(videoTimePoller, 5000);
+        this.fullAlbumVideoPoller = setInterval(videoTimePoller, interval);
       }
     }
   }
@@ -202,11 +205,13 @@ class YoutubePlayer extends Component {
       const currentTrack = capturedTrack || selectedTrack;
       this.setState({ videoStartedPlaying: false }, () => youtubePlaylistChange(currentTrack));
       clearInterval(this.fullAlbumVideoPoller);
+      this.fullAlbumVideoPoller = null;
     }
 
     if (data === YT.PlayerState.PAUSED) {
       this.setState({ videoStartedPlaying: false });
       clearInterval(this.fullAlbumVideoPoller);
+      this.fullAlbumVideoPoller = null;
     }
 
     if (data === YT.PlayerState.PLAYING) {
@@ -272,6 +277,9 @@ class YoutubePlayer extends Component {
     const sameTrack = trackToPlay.trackNumber === currentTrack.trackNumber;
     if (!sameTrack) {
       player.seekTo(startSeconds);
+      if (playerState === YT.PlayerState.PAUSED) {
+        player.playVideo();
+      }
     }
   }
 

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { includes } from 'lodash';
+import { chain, includes } from 'lodash';
 import youTubeParamsParser from './utils/youtube-params-parser';
+import youTubeFullAlbumRegistry from './utils/youtube-full-album-registry';
 
 /**
  * YoutubePlayer
@@ -15,9 +16,13 @@ class YoutubePlayer extends Component {
   constructor(props) {
     super(props);
 
+    const { playlist } = props;
+    const fullAlbumDetails = youTubeFullAlbumRegistry(playlist);
     this.timer = null;
+    this.fullAlbumVideoPoller = null;
 
     this.state = {
+      fullAlbumDetails,
       player: null,
       playerAnchor: React.createRef(),
       selectedTrack: null,
@@ -30,7 +35,9 @@ class YoutubePlayer extends Component {
       'onPlayerStateChange',
       'onPlayerReady',
       'onPlayerError',
-      'playVideo'
+      'playVideo',
+      'availableVideoId',
+      'syncVideoWithPlayer'
     ].forEach((item) => {
       this[item] = this[item].bind(this);
     });
@@ -79,6 +86,54 @@ class YoutubePlayer extends Component {
   }
 
   /**
+   * Remove timer & interval
+   */
+  componentWillUnmount() {
+    clearInterval(this.fullAlbumVideoPoller);
+    clearTimeout(this.timer);
+  }
+
+  /**
+   * Gets available YouTube ID
+   * checks between captured ID (state) & incoming ID (props)
+   * when there isn't a captured ID, it means the player has loaded & user has not selected a video
+   */
+  availableVideoId() {
+    const { id: stateID } = this.state;
+    const { id: propsID } = this.props;
+    const availableID = stateID || propsID;
+    return availableID;
+  }
+
+  /**
+   * Syncs Full Album Video with Audio Player
+   * - pings YouTube's API to check timestamp
+   * - finds current track position
+   * - sends that to the callback
+   */
+  syncVideoWithPlayer() {
+    const { fullAlbumDetails, player, videoStartedPlaying } = this.state;
+    const { youtubePlaylistChange } = this.props;
+    const setURLOnly = true;
+
+    const videoTimePoller = () => {
+      const elapsedTime = player.getCurrentTime();
+      const currentTrack = chain(fullAlbumDetails)
+        .filter(track => track.startSeconds < elapsedTime)
+        .last()
+        .value();
+
+      const { trackNumber } = currentTrack;
+      youtubePlaylistChange(trackNumber, setURLOnly);
+    };
+
+    if (videoStartedPlaying) {
+      videoTimePoller();
+      this.fullAlbumVideoPoller = setInterval(videoTimePoller, 5000);
+    }
+  }
+
+  /**
    * Load youtube iframe API asyncronously
    * Prevent user interaction with tracklist
    */
@@ -95,9 +150,8 @@ class YoutubePlayer extends Component {
    * Update player
    */
   loadPlayer() {
-    const { id, playerAnchor } = this.state;
-    const { id: propsID } = this.props;
-    const availableID = id || propsID;
+    const { playerAnchor } = this.state;
+    const availableID = this.availableVideoId();
     const videoParams = youTubeParamsParser(availableID);
     const defaultParams = {
       height: '600',
@@ -105,7 +159,8 @@ class YoutubePlayer extends Component {
       playerVars: {
         fs: 1,
         rel: 0,
-        enablejsapi: 1
+        enablejsapi: 1,
+        origin: location.origin,
       },
       events: {
         onReady: this.onPlayerReady,
@@ -124,18 +179,23 @@ class YoutubePlayer extends Component {
    * Call youtubePlaylistChange to switch to next track number
    */
   onPlayerStateChange(event) {
-    const { youtubePlaylistChange } = this.props;
-    const { selectedTrack, videoStartedPlaying } = this.state;
+    const { youtubePlaylistChange, selectedTrack } = this.props;
+    const { selectedTrack: capturedTrack, videoStartedPlaying, fullAlbumDetails } = this.state;
 
     if (event.data === YT.PlayerState.ENDED) {
-      this.setState({ videoStartedPlaying: false }, () => youtubePlaylistChange(selectedTrack));
+      const currentTrack = capturedTrack || selectedTrack;
+      this.setState({ videoStartedPlaying: false }, () => youtubePlaylistChange(currentTrack));
+      clearInterval(this.fullAlbumVideoPoller);
     }
+
     if (event.data === YT.PlayerState.PLAYING) {
+      const setURLOnly = true;
       if (!videoStartedPlaying) {
-        const setURLOnly = true;
-        this.setState({ videoStartedPlaying: true }, () => {
-          youtubePlaylistChange(selectedTrack, setURLOnly);
-        });
+        this.setState({ videoStartedPlaying: true }, () => youtubePlaylistChange(selectedTrack, setURLOnly));
+      }
+
+      if (fullAlbumDetails) {
+        this.syncVideoWithPlayer();
       }
     }
   }
@@ -164,15 +224,15 @@ class YoutubePlayer extends Component {
    * Gather all the correct settings and call YouTube player api to play the video
    */
   playVideo() {
-    const { id, player } = this.state;
-    const { id: propsID } = this.props;
-    const availableID = id || propsID;
+    const { player } = this.state;
+    const availableID = this.availableVideoId();
     const params = youTubeParamsParser(availableID);
     const { videoId, startSeconds, hasTimestamp } = params;
     const sameVideo = includes(availableID, videoId) && hasTimestamp;
     if (sameVideo) {
       player.seekTo(startSeconds);
     } else {
+      clearInterval(this.fullAlbumVideoPoller);
       player.loadVideoById(params);
     }
   }
@@ -191,6 +251,7 @@ YoutubePlayer.propTypes = {
   selectedTrack: PropTypes.number.isRequired,
   id: PropTypes.string.isRequired,
   youtubePlaylistChange: PropTypes.func.isRequired,
+  playlist: PropTypes.string.isRequired,
 };
 
 export default YoutubePlayer;

--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -76,10 +76,12 @@ class YoutubePlayer extends Component {
    * Load video of passed id and default resolution
    */
   componentDidUpdate(prevProps) {
+    const { selectedTrack: capturedTrack, fullAlbumDetails } = this.state;
     const { id, selectedTrack } = this.props;
     const trackChanged = id !== prevProps.id;
-
-    if (trackChanged) {
+    const playerNotStarted = capturedTrack === null;
+    const captureSelected = playerNotStarted && id && !fullAlbumDetails;
+    if (trackChanged || captureSelected) {
       clearTimeout(this.timer);
       this.setState({ id, selectedTrack }, this.playVideo);
     }
@@ -129,7 +131,9 @@ class YoutubePlayer extends Component {
 
     if (videoStartedPlaying) {
       videoTimePoller();
-      this.fullAlbumVideoPoller = setInterval(videoTimePoller, 5000);
+      if (!this.fullAlbumVideoPoller) {
+        this.fullAlbumVideoPoller = setInterval(videoTimePoller, 5000);
+      }
     }
   }
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -383,7 +383,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             jwplayerInfo={jwplayerInfo}
             jwplayerID={`jwplayer-${jwplayerID}`}
             onRegistrationComplete={this.receiveURLSetter}
-            hasTracks={!!tracklistToShow.length}
+            playlist={tracklistToShow}
           />
         </section>
         <div className="grid-right">

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -164,15 +164,18 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     // it's youtube or spotify
     const { albumSpotifyYoutubeInfo } = albumData;
     const albumSource = albumSpotifyYoutubeInfo[channelToPlay] || null;
-    if (isAlbum && albumSpotifyYoutubeInfo.hasOwnProperty(channelToPlay)) {
+    const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
+    const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
+    const firstItem = head(tracklistToShow);
+    const serveAlbum = isAlbum || ((trackStartingPoint === 1) && firstItem.trackNumber === 0);
+
+    if (serveAlbum && albumSpotifyYoutubeInfo.hasOwnProperty(channelToPlay)) {
       audioSource = {
         trackNumber: 0,
         [channelToPlay]: albumSource,
       };
       return audioSource;
     }
-    const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
-    const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
 
     const trackInfo = find(tracklistToShow, (track) => {
       const trackFound = track.trackNumber === trackToHighlight;

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -164,18 +164,15 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     // it's youtube or spotify
     const { albumSpotifyYoutubeInfo } = albumData;
     const albumSource = albumSpotifyYoutubeInfo[channelToPlay] || null;
-    const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
-    const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
-    const firstItem = head(tracklistToShow);
-    const serveAlbum = isAlbum || ((trackStartingPoint === 1) && firstItem.trackNumber === 0);
-
-    if (serveAlbum && albumSpotifyYoutubeInfo.hasOwnProperty(channelToPlay)) {
+    if (isAlbum && albumSpotifyYoutubeInfo.hasOwnProperty(channelToPlay)) {
       audioSource = {
         trackNumber: 0,
         [channelToPlay]: albumSource,
       };
       return audioSource;
     }
+    const playerLoadingOnCertainTrack = trackSelected === null && trackStartingPoint !== null;
+    const trackToHighlight = playerLoadingOnCertainTrack ? trackStartingPoint : trackSelected;
 
     const trackInfo = find(tracklistToShow, (track) => {
       const trackFound = track.trackNumber === trackToHighlight;


### PR DESCRIPTION
**Description**
When a full album is available, IA segments each track using timestamps on that full album video.

This extends our current YouTube player to handle this issue.

BONUS! - updates to jwplayer wrapper to make a better experience.

**Technical**

- New file: `youtube-full-album-parser.js` checks the youtube playlist and creates a dictionary of params to pass to the YouTube API.  If not, it returns null.

**Testing**

Go to item with a full album: `https://www-isa.archive.org/details/wcd_unresolved-childhood_screw-32_flac_lossless_29945541/Screw+32+-++Unresolved+Childhood+Issues+(1995)+%5BFLAC%5D/03+-+Old+Idea+New+Head.flac`
- onload, playing video directly OR clicking on highlighted track OR clicking on unhighlighted track should start autoadvance.
- track list adapts to changes on video's scrubber

Go to item without a full album: `https://www-isa.archive.org/details/cd_the-remixes_mariah-carey-bone-crusher-busta-rhymes-da/disc1/01.01.+Mariah+Carey+-+My+All+(Morales+_My_+club+mix).flac`
- onload, clicking selected track plays video
- when a video ends, it autoadvances to the next track

JWPLAYER UPDATES:
when we hooked up YouTube, we our jwplayer experience was no longer optimum.
- update: on channel change, track no longer autoplays

