### PR TITLE
YouTube player, reduce direct pings to jwplayer to set url when track autoadvances happens

### DIFF
--- a/packages/ia-components/sandbox/audio-players/youtube-player.jsx
+++ b/packages/ia-components/sandbox/audio-players/youtube-player.jsx
@@ -130,7 +130,7 @@ class YoutubePlayer extends Component {
    * - finds current track position
    * - sends that to the callback
    */
-  syncVideoWithPlayer() {
+  syncVideoWithPlayer(selectedTrack) {
     const { videoStartedPlaying } = this.state;
     const { youtubePlaylistChange } = this.props;
     const setURLOnly = true;
@@ -138,7 +138,9 @@ class YoutubePlayer extends Component {
     const videoTimePoller = () => {
       const { currentTrack } = this.checkTimeAndTrack();
       const { trackNumber } = currentTrack;
-      youtubePlaylistChange(trackNumber, setURLOnly);
+      if (selectedTrack !== trackNumber) {
+        youtubePlaylistChange(trackNumber, setURLOnly);
+      }
     };
 
     if (videoStartedPlaying) {
@@ -220,7 +222,7 @@ class YoutubePlayer extends Component {
       }
 
       if (fullAlbumDetails) {
-        this.syncVideoWithPlayer();
+        this.syncVideoWithPlayer(selectedTrack);
       }
     }
   }


### PR DESCRIPTION
Problem:
At times, you can hear blips when playing a long YouTube video

Solution:
reduce time number of times calls to change the url happen

**Testing**
go to: `https://www-isa.archive.org/details/cd_dark-side-of-the-moon_pink-floyd/disc1/05.+Pink+Floyd+-+Money.flac` > go to YouTube channel > play track > turn volume off > should not hear any blips