### PR TITLE
YouTube callbacks keeping instance internal state

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -272,7 +272,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    * @param { number } prevTrack- Track number of previously played video
    */
   youtubePlaylistChange(prevTrack, setURLOnly) {
-    const { tracklistToShow } = this.state;
+    const { tracklistToShow, trackSelected: currentTrack } = this.state;
     let trackSelected;
     if (setURLOnly) {
       trackSelected = tracklistToShow.find(t => t.trackNumber === prevTrack);
@@ -282,7 +282,9 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     // Find next track number in line
     if (trackSelected) {
       this.setState({ trackSelected: trackSelected.trackNumber }, () => {
-        this.updateURL();
+        if (currentTrack !== trackSelected.trackNumber) {
+          this.updateURL();
+        }
       });
     }
   }

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -281,7 +281,9 @@ class AudioPlayerWithYoutubeSpotify extends Component {
     }
     // Find next track number in line
     if (trackSelected) {
-      this.setState({ trackSelected: trackSelected.trackNumber }, this.updateURL);
+      this.setState({ trackSelected: trackSelected.trackNumber }, () => {
+        this.updateURL();
+      });
     }
   }
 


### PR DESCRIPTION
Problem:
Callbacks for pinging YouTube API & URL changer lost their instance component state
This caused extra firings of calls that were not necessary.
UI Symptom was an audible blip happening every few seconds during a YouTube video

Solution:
Pin callbacks to class state so that it can make the correct checks for tracks when they need to

**Test steps**

go to: https://www-isa.archive.org/details/cd_huangxiao/disc1/13.+%E9%BB%83%E5%B0%8F%E6%A5%A8+-+%E8%B3%9E%E5%91%B3%E6%9C%9F%E9%99%90.flac
- open dev tools to show console
- change to YouTube channel
- play track
- move youtube video scrubber around > `playN` from line 562 only fires once in console
- click any track on the track listing > `playN`  from line 562 only fires once in console
- click 1st track > use video scrubber to go to 1:50ish and wait for song to finish (2:17) > track highlight advances to 2nd track && `playN`  from line 562 only fires once in console

go to: https://www-isa.archive.org/details/cd_backstreet-boys_backstreet-boys
- open dev tools to show console
- change to YouTube channel
- play track
- move youtube video scrubber around > no `playN` from line 562 in console
- click any track on the track listing > `playN` from line 562only fires once in console
- move youtube video to almost the end of the track > let track finish > next video in queue plays && track listing auto advances to next item && `playN`  from line 562 only fires once in console