### PR TITLE
Handle bug in ImageDweb when React calls the ref= without an element

### DIFF
--- a/packages/ia-components/sandbox/details/AnchorDownload.jsx
+++ b/packages/ia-components/sandbox/details/AnchorDownload.jsx
@@ -72,7 +72,8 @@ class AnchorDownload extends IAReactComponent {
     AnchorDownload.urlparms.forEach(k => usp.append(k, this.props[k]));
     this.state.url.search = usp; // Note this copies, not updatable
     // Copy any parameters not specified in AnchorDownload.urlparms to anchorProps for inclusion in the <a>
-    this.state.anchorProps = ObjectFilter(this.props, (k, unusedV) => !AnchorDownload.urlparms.includes(k));
+    this.state.anchorProps = ObjectFilter(this.props,
+      (k, unusedV) => (!AnchorDownload.urlparms.includes(k) && !["disconnected"].includes(k)));
   }
 
   clickCallable(ev) {

--- a/packages/ia-components/sandbox/details/AnchorSearch.jsx
+++ b/packages/ia-components/sandbox/details/AnchorSearch.jsx
@@ -12,7 +12,7 @@ const debug = require('debug')('ia-components:AnchorSearch');
  * On render we split props between the Anchor and the URL and build the URL.
  *
  * On click - behavior varies between Dweb and IAUX
- *      Dweb:   Navigate via the Nav.nav_search function
+ *      Dweb:   Navigate via the Nav.navSearch function
  *      !Dweb:  normal Anchor behavior to go to the href
  *
  * Technical:
@@ -20,7 +20,7 @@ const debug = require('debug')('ia-components:AnchorSearch');
  *
  * <AnchorSearch
  *  query       Object { field: value}   OR string (value can be Array, in which case it is OR-ed
- *  reload      if set, passed to Nav.nav_search as an opt TODO implement this
+ *  reload      if set, passed to Nav.navSearch as an opt TODO implement this
  *  TODO implement maybe: sort        passed to URL as a parameter
  *  Any other properties are passed to the <a />
  *
@@ -46,15 +46,25 @@ function queryFrom(query) {
 // End of DUPLICATEDCODE#0003
 
 class AnchorSearch extends IAReactComponent {
-  /*
-    !Dweb: no onClick unless want analytics
-    Dweb:  onClick={this.click}
-    */
+  /**
+   * Render an Anchor that navigates to a search
+   *
+   * <AnchorSearch
+   *  query   string in form can pass to URL or object like {collection: foo, title: bar} or string like 'collection:"foo" AND title:"bar"'
+   *  field,value pair to turn into a query field=value
+   *  sort
+   *  reload  Force a reload of query if supported (Dweb only)
+   *
+   *  Behavior:
+   *    on Dweb - click handler fires and calls navSearch
+   *    not on Dweb:  URL embedded in anchor, onClick can be passed if want analytics
+   */
+
   constructor(props) {
-    super(props); // { query, field, sort, value, reload }
+    super(props); // { query || field & value, sort, reload }
     this.setState({
       query: this.props.query || ObjectFromEntries([[this.props.field, this.props.value]]),
-      urlProps: ObjectFilter(this.props, (k, unusedV) => AnchorSearch.urlparms.includes(k)),
+      urlProps: ObjectFilter(this.props, (k, unusedV) => AnchorSearch.urlparms.includes(k)),  //sort, reload, query
       anchorProps: ObjectFilter(this.props, (k, unusedV) => (!AnchorSearch.urlparms.includes(k) && !['children'].includes(k)))
     });
   }
@@ -62,9 +72,9 @@ class AnchorSearch extends IAReactComponent {
   clickCallable(unusedEvent) {
     // Note this is only called in dweb; !Dweb has a director href
     debug('Clicking on link to search: %s', this.state.query);
-    DwebArchive.Nav.nav_search(
-      { query: this.state.query, sort: this.props.sort },
-      { noCache: this.props.reload, wanthistory: !this.props.reload });
+    DwebArchive.Nav.navSearch(
+      this.state.query,
+      { noCache: this.props.reload, wanthistory: !this.props.reload, sort: this.props.sort });
     return false; // Dont propagate event
   }
 

--- a/packages/ia-components/sandbox/details/Image.jsx
+++ b/packages/ia-components/sandbox/details/Image.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { ObjectFilter } from '../../util';
 import IAReactComponent from '../IAReactComponent';
 import { AnchorDownload } from './AnchorDownload';
-
 const debug = require('debug')('Image Components');
 
 /**
@@ -15,6 +14,7 @@ const debug = require('debug')('Image Components');
  *    OR
  *      src     as in <img>
  *    alt     as in <img>
+ *    imgname optional name used for alt tag and mime type when rendering via blob
  * />
  * <ImageMainTheatre
  *  source  [ArchiveFile]  // Single ArchiveFile but in an array
@@ -32,35 +32,37 @@ class ImageDweb extends IAReactComponent {
   // Image that can, but doesnt have to be loaded via Dweb
 
   constructor(props) {
-    super(props); // { source, src, alt }
+    super(props);
     this.setState({
+      src: this.props.url,
       notImgProps: ObjectFilter(this.props, (k, unusedV) => ImageDweb.specificParms.includes(k)),
       imgProps: ObjectFilter(this.props, (k, unusedV) => (!ImageDweb.specificParms.includes(k) && !['children'].includes(k)))
     });
-  }
-
-  loadcallable(enclosingspan) { // Defined as a closure so that can access identifier
-    // Its unclear why, but sometimes React calls this with enclosingspan === null, which is meaningless as missign the <img> to
-    // load into, skipping doesnt seem to be an issue and maybe its timing and element has already gone away?
-    if (enclosingspan) {
-      // TODO this may move to a method on the source (e.g. on ArchiveFile)
+    if (DwebArchive) {
+      //TODO imgname might be obsolete and unused (check dweb-archive and iaux)
       const name = this.props.imgname || (this.props.source && this.props.source.metadata.name);
-      DwebArchive.loadImg(enclosingspan, name, this.props.source || this.props.src, (err, unusedEl) => {
-        if (err) {
-          debug('Fail to load %s: %s', name, err.message);
-        } else {
-          AJS.tiler(); // Make it redraw after img size known TODO see where/if this is needed
-        }
-      });
+      DwebArchive.getImageURI(name, this.props.source || this.props.src, (err, url) => {
+        if (!err) this.setState({src: url});
+      })
     }
   }
 
+  componentDidMount() {
+    //DwebArchive.page = this;
+    super.componentDidMount();
+    this.componentDidMountOrUpdate()
+  }
+
+  componentDidUpdate() {
+    super.componentDidUpdate();
+    this.componentDidMountOrUpdate()
+  }
+  componentDidMountOrUpdate() {
+    AJS.tiler();
+  }
   render() {
-    // noinspection HtmlRequiredAltAttribute
     return (
-      typeof DwebArchive !== 'undefined'
-        ? <img ref={this.load} {...this.state.imgProps} />
-        : <img {...this.state.imgProps} src={this.props.src} />
+      <img {...this.state.imgProps} src={this.state.src} />
     );
   }
 }

--- a/packages/ia-components/sandbox/details/Image.jsx
+++ b/packages/ia-components/sandbox/details/Image.jsx
@@ -39,17 +39,20 @@ class ImageDweb extends IAReactComponent {
     });
   }
 
-
   loadcallable(enclosingspan) { // Defined as a closure so that can access identifier
-    // TODO this may move to a method on the source (e.g. on ArchiveFile)
-    const name = this.props.imgname || (this.props.source && this.props.source.metadata.name);
-    DwebArchive.loadImg(enclosingspan, name , this.props.source || this.props.src, (err, unusedEl) => {
-      if (err) {
-        debug('Fail to load %s: %s', name, err.message);
-      } else {
-        AJS.tiler(); // Make it redraw after img size known TODO see where/if this is needed
-      }
-    });
+    // Its unclear why, but sometimes React calls this with enclosingspan === null, which is meaningless as missign the <img> to
+    // load into, skipping doesnt seem to be an issue and maybe its timing and element has already gone away?
+    if (enclosingspan) {
+      // TODO this may move to a method on the source (e.g. on ArchiveFile)
+      const name = this.props.imgname || (this.props.source && this.props.source.metadata.name);
+      DwebArchive.loadImg(enclosingspan, name, this.props.source || this.props.src, (err, unusedEl) => {
+        if (err) {
+          debug('Fail to load %s: %s', name, err.message);
+        } else {
+          AJS.tiler(); // Make it redraw after img size known TODO see where/if this is needed
+        }
+      });
+    }
   }
 
   render() {

--- a/packages/ia-components/sandbox/details/NavWrap.jsx
+++ b/packages/ia-components/sandbox/details/NavWrap.jsx
@@ -67,7 +67,7 @@ class NavSearchLI extends IAReactComponent {
 
   onSubmit(event) {
       // TODO-IAUX this is dweb-archive only, needs a version that works in raw IAUX
-      debug('Search submitted');
+      debug('Search submitted %s',this.state.value);
     // noinspection JSUnresolvedFunction,JSUnresolvedVariable
     Nav.navSearch(this.state.value, {wanthistory: true});
       event.preventDefault();
@@ -308,7 +308,7 @@ class DwebNavButtons extends IAReactComponent {
 }
 
 class DwebNavDIV extends IAReactComponent {
-  /*
+  /**
    * <DwebNavDIV
    *    item= {             // ArchiveItem
    *      itemid: identifier,
@@ -316,10 +316,11 @@ class DwebNavDIV extends IAReactComponent {
    *      sort:   string,
    *      downloaded: { ... }, passed to CrawlConfig
    *      crawl: object (optional) passed as props to CrawlConfig
-   *      mirror2gateway: bool
    *      canSave: bool   true if can save
    *    }
-   *    transportStatuses: [{name, status}]
+   *   transportStatuses=[{name: STRING, status: INT} Status of connected transports
+   *   mirror2gateway=BOOL  True if connected to a mirror that can see its upstream gateway
+   *   disconnected=BOOL    True if disconnected from upstream (so disable UI dependent on upstream)
    * />
    * Renders: A navigation row with the DwebStatusDIV (transport status buttons), CrawlConfig and DwebNavButtons
    * OnClick: See those subcomponents
@@ -414,10 +415,11 @@ class DwebStatusDIV extends IAReactComponent {
 class NavWrap extends IAReactComponent {
   /*
    * <NavWrap
-   *    item = ArchiveItem  passed to DwebNavDIV (optional if not on Dweb)
-   *    transportStatuses = [{name, status}*]
-   *    mirror2gateway bool
-   *    canSave=BOOL        True if can save
+   *   item = ArchiveItem  passed to DwebNavDIV (optional if not on Dweb)
+   *   canSave=BOOL        True if can save
+   *   transportStatuses=[{name: STRING, status: INT} Status of connected transports
+   *   mirror2gateway=BOOL  True if connected to a mirror that can see its upstream gateway
+   *   disconnected=BOOL    True if disconnected from upstream (so disable UI dependent on upstream)
    * />
    * Behavior
    *   On Render: Renders the head of a details or search page including NavDwebDIV, NavBrandLI NavSearchLI NavUploadLI NavAboutsUL DwebNavDIV

--- a/packages/ia-components/sandbox/details/NavWrap.jsx
+++ b/packages/ia-components/sandbox/details/NavWrap.jsx
@@ -56,7 +56,7 @@ class NavSearchLI extends IAReactComponent {
   /** <NavSearchLI/>
    * Behavior:
    *   Renders: an <LI/> with a form and search icon as used on the Details page
-   *   On submit: Calls Nav.nav_search - this makes it Dweb only, if someone else uses it then a non-dweb version of onSubmit will be required
+   *   On submit: Calls Nav.navSearch - this makes it Dweb only, if someone else uses it then a non-dweb version of onSubmit will be required
    */
 
   constructor(props) {
@@ -69,7 +69,7 @@ class NavSearchLI extends IAReactComponent {
       // TODO-IAUX this is dweb-archive only, needs a version that works in raw IAUX
       debug('Search submitted');
     // noinspection JSUnresolvedFunction,JSUnresolvedVariable
-    Nav.nav_search(this.state.value, {wanthistory: true});
+    Nav.navSearch(this.state.value, {wanthistory: true});
       event.preventDefault();
   }
 

--- a/packages/ia-components/sandbox/tiles/TileComponent.jsx
+++ b/packages/ia-components/sandbox/tiles/TileComponent.jsx
@@ -113,8 +113,9 @@ export default class TileComponent extends IAReactComponent {
           ? (
             <AnchorDetails className="stealth" tabIndex="-1" identifier={this.state.collection0}>
               <div className="item-parent">
+                {/*archive.org uses a background image on the div but that makes it hard to intercept*/}
                 <div className="item-parent-img">
-                  <ImageDweb src={this.state.parentimageurl} alt={this.state.collection0} imgname= '__ia_thumb.jpg'/>
+                  <ImageDweb className="item-parent-img" src={this.state.parentimageurl} alt={this.state.collection0} imgname= '__ia_thumb.jpg'/>
                 </div>
                 <div className="item-parent-ttl">{this.state.collection0title}</div>
               </div>

--- a/packages/ia-components/util.js
+++ b/packages/ia-components/util.js
@@ -72,7 +72,7 @@ field: of _formatarr to check
 value: value to check for,
 first:  true to return first match or undefined, false for array
 
-formats("format", "VBR MP3", {first: true}.downloadable
+formats("format", "VBR MP3", {first: true}).downloadable
 
 TODO expand to other formats - see mimetypes list from petabox
 TODO fill in missing fields, esp format fiel
@@ -189,6 +189,7 @@ const _formatarr = [
     {format: undefined, ext: '.hqx', type: 'application', mimetype: 'application/mac-binhex40', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.htc', type: 'text', mimetype: 'text/x-component', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.ico', type: 'image', mimetype: 'image/x-icon', playable: undefined, downloadable: undefined },
+    {format: undefined, ext: '.ico', type: 'image', mimetype: 'image/vnd.microsoft.icon', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.img', type: 'application', mimetype: 'application/octet-stream', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.jad', type: 'text', mimetype: 'text/vnd.sun.j2me.app-descriptor', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.jar', type: 'application', mimetype: 'application/java-archive', playable: undefined, downloadable: undefined },
@@ -197,9 +198,10 @@ const _formatarr = [
     {format: undefined, ext: '.jnlp', type: 'application', mimetype: 'application/x-java-jnlp-file', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.jpeg', type: 'image', mimetype: 'image/jpeg', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.jpg', type: 'image', mimetype: 'image/jpeg', playable: undefined, downloadable: undefined },
-    {format: undefined, ext: '.js', type: 'application', mimetype: 'application/x-javascript', playable: undefined, downloadable: undefined },
+    {format: undefined, ext: '.js', type: 'application', mimetype: 'application/javascript', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.kar', type: 'audio', mimetype: 'audio/midi', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.log', type: 'text', mimetype: 'text/plain', playable: undefined, downloadable: undefined },
+    {format: undefined, ext: '.mathml', type: 'text', mimetype: 'text/mathml', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.mid', type: 'audio', mimetype: 'audio/midi', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.midi', type: 'audio', mimetype: 'audio/midi', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.mml', type: 'text', mimetype: 'text/mathml', playable: undefined, downloadable: undefined },
@@ -212,7 +214,7 @@ const _formatarr = [
     {format: undefined, ext: '.pdf', type: 'application', mimetype: 'application/pdf', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.pem', type: 'application', mimetype: 'application/x-x509-ca-cert', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.pl', type: 'application', mimetype: 'application/x-perl', playable: undefined, downloadable: undefined },
-    {format: undefined, ext:'.pl', type: 'text', mimetype: 'text/x-perl', playable: undefined, downloadable: undefined },
+    {format: undefined, ext: '.pl', type: 'text', mimetype: 'text/x-perl', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.png', type: 'image', mimetype: 'image/png', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.prc', type: 'application', mimetype: 'application/x-pilot', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.ps', type: 'application', mimetype: 'application/postscript', playable: undefined, downloadable: undefined },
@@ -349,6 +351,7 @@ const _formatarr = [
     {format: undefined, ext:'.gsf', type: 'application', mimetype: 'application/x-font', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.gsm', type: 'audio', mimetype: 'audio/x-gsm', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.gtar', type: 'application', mimetype: 'application/x-gtar', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.gz', type: 'application', mimetype: 'application/x-gzip', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.h', type: 'text', mimetype: 'text/x-chdr', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.h++', type: 'text', mimetype: 'text/x-c++hdr', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.hdf', type: 'application', mimetype: 'application/x-hdf', playable: undefined, downloadable: undefined },
@@ -398,11 +401,16 @@ const _formatarr = [
     {format: undefined, ext:'.lzh', type: 'application', mimetype: 'application/x-lzh', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.lzx', type: 'application', mimetype: 'application/x-lzx', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.m3u', type: 'audio', mimetype: 'audio/x-mpegurl', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.m4b', type: 'audio', mimetype: 'audio/mp4', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.m4p', type: 'audio', mimetype: 'audio/mp4', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.m4v', type: 'video', mimetype: 'video/x-m4v', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.maker', type: 'application', mimetype: 'application/x-maker', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.man', type: 'application', mimetype: 'application/x-troff-man', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.manifest', type: 'text', mimetype: 'text/cache-manifest', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.markdown', type: 'text', mimetype: 'text/x-markdown', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mcif', type: 'chemical', mimetype: 'chemical/x-mmcif', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mcm', type: 'chemical', mimetype: 'chemical/x-macmolecule', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.md', type: 'text', mimetype: 'text/x-markdown', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mdb', type: 'application', mimetype: 'application/msaccess', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.me', type: 'application', mimetype: 'application/x-troff-me', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mesh', type: 'model', mimetype: 'model/mesh', playable: undefined, downloadable: undefined },
@@ -421,6 +429,7 @@ const _formatarr = [
     {format: undefined, ext:'.movie', type: 'video', mimetype: 'video/x-sgi-movie', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mp2', type: 'audio', mimetype: 'audio/mpeg', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mp4', type: 'video', mimetype: 'video/mp4', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.mp4v', type: 'video', mimetype: 'video/mp4', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mpc', type: 'chemical', mimetype: 'chemical/x-mopac-input', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mpe', type: 'video', mimetype: 'video/mpeg', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.mpeg4', type: 'video', mimetype: 'video/mp4', playable: undefined, downloadable: undefined },
@@ -565,6 +574,7 @@ const _formatarr = [
     {format: undefined, ext:'.t', type: 'application', mimetype: 'application/x-troff', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.tar', type: 'application', mimetype: 'application/x-tar', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.taz', type: 'application', mimetype: 'application/x-gtar', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.tbz', type: 'application', mimetype: 'application/x-bzip-compressed-tar', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.tcl', type: 'text', mimetype: 'text/x-tcl', playable: undefined, downloadable: undefined },
     {format: undefined, ext: '.tcl', type: 'application', mimetype: 'application/x-tcl', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.tex', type: 'text', mimetype: 'text/x-tex', playable: undefined, downloadable: undefined },
@@ -593,7 +603,7 @@ const _formatarr = [
     {format: undefined, ext:'.vrml', type: 'x-world', mimetype: 'x-world/x-vrml', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.vsd', type: 'application', mimetype: 'application/vnd.visio', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.wad', type: 'application', mimetype: 'application/x-doom', playable: undefined, downloadable: undefined },
-    {format: undefined, ext:'.wav', type: 'audio', mimetype: 'audio/x-wav', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.wav', type: 'audio', mimetype: 'audio/wav', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.wax', type: 'audio', mimetype: 'audio/x-ms-wax', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.wbxml', type: 'application', mimetype: 'application/vnd.wap.wbxml', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.weba', type: 'audio', mimetype: 'audio/weba', playable: undefined, downloadable: undefined },
@@ -625,6 +635,7 @@ const _formatarr = [
     {format: undefined, ext:'.xul', type: 'application', mimetype: 'application/vnd.mozilla.xul+xml', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.xwd', type: 'image', mimetype: 'image/x-xwindowdump', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.xyz', type: 'chemical', mimetype: 'chemical/x-xyz', playable: undefined, downloadable: undefined },
+    {format: undefined, ext:'.yaml', type: 'text', mimetype: 'text/yaml', playable: undefined, downloadable: undefined },
     {format: undefined, ext:'.zmt', type: 'chemical', mimetype: 'chemical/x-mopac-input', playable: undefined, downloadable: undefined },
 ];
 /* petabox/www/common/FormatGetter.inc has these items, not sure if useful


### PR DESCRIPTION
**Description**
Handle bug in ImageDweb when React calls the ref= without an element

**Technical**
React seems to occasionally call its ref= function with the element set to null, handles that for Image Dweb. 

**Testing**

**Evidence**
