### PR TITLE
Music Player - formalize file extension validator

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
@@ -1,6 +1,6 @@
 import { endsWith, filter } from 'lodash';
 import gatherYoutubeAndSpotifyInfo from './youtube-spotify-parser';
-
+import { isValidAudioFile, isValidImageFile } from './utils';
 
 /**
  * Internet Archive Default Album Data Parser
@@ -37,8 +37,8 @@ const archiveDefaultAlbumParser = ({ fileDirectoryPrefix, files }) => {
     let flattenedImportantRelatedFiles = null;
     const externalIdentifiers = currentFile['external-identifier'] || null;
     const isOriginal = source === 'original';
-    const isAudioFile = currentFileName.match(/(mp3|ogg|flac|m4a|wma)$/g);
-    const isItemImageFile = isOriginal && currentFileName.match(/(png|jpg|jpeg)$/gi);
+    const isAudioFile = isValidAudioFile(currentFileName);
+    const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
 
     // skip unneeded files
     if (!isOriginal && !isAudioFile) return neededItems;

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-lp-album-parser.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-lp-album-parser.js
@@ -1,6 +1,6 @@
 import { endsWith, filter } from 'lodash';
-
 import gatherYoutubeAndSpotifyInfo from './youtube-spotify-parser';
+import { isValidAudioFile, isValidImageFile } from './utils';
 
 /**
  * Internet Archive LP Album Data Parser
@@ -39,8 +39,8 @@ const archiveLPAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) =>
     const isOriginal = source === 'original';
     const isMainTrackItem = original.match(`${itemIdentifier}_segments.`);
     const fileToSkip = `${itemIdentifier}.mp3`; // phantom audio file to map to full album
-    const isAudioFile = currentFileName.match(/(mp3|ogg|flac|m4a)$/g);
-    const isItemImageFile = isOriginal && currentFileName.match(/(png|jpg|jpeg)$/gi);
+    const isAudioFile = isValidAudioFile(currentFileName);
+    const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
     // skip unneeded files
     if ((!isOriginal && !isAudioFile) || (fileToSkip === currentFileName)) return neededItems;
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -8,6 +8,7 @@ import {
 import archiveDefaultAlbumParser from './archive-default-album-parser';
 import archiveLPAlbumParser from './archive-lp-album-parser';
 import gatherYoutubeAndSpotifyInfo from './youtube-spotify-parser';
+import { isValidAudioFile } from './utils';
 
 /**
  * Stringify Album details
@@ -65,8 +66,7 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
    * & only return the files we are interested in
    */
   const slimFiles = reduce(fileNames, (neededFiles = [], fileName) => {
-    const neededExtensions = /(mp3|ogg|flac|m4a|jpg|png|jpeg|wma)$/gi;
-    const isNeededFile = fileName.match(neededExtensions);
+    const isNeededFile = isValidAudioFile(fileName);
     const file = allFiles[fileName];
     file.name = fileName.slice(1, fileName.length);
     if (isNeededFile) {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/utils.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/utils.js
@@ -1,0 +1,17 @@
+/**
+ * isValidAudioFile
+ * checks string for valid extension
+ *
+ * @param {string } trackName
+ * @returns { boolean }
+ */
+export const isValidAudioFile = (trackName = '') => !!trackName.match(/(mp3|ogg|flac|m4a|wma|aiff|aac|aa|ra|ram|shn|wav|wave)$/g);
+
+/**
+ * isValidImageFile
+ * checks string for valid extension
+ *
+ * @param {string } imageName
+ * @returns { boolean }
+ */
+export const isValidImageFile = (imageName = '') => !!imageName.match(/(png|jpg|jpeg)$/gi);

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/utils.test.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/utils.test.js
@@ -1,0 +1,62 @@
+import { isValidAudioFile, isValidImageFile } from './utils';
+
+describe('Music Player Util - General', () => {
+  describe('Returns true when correct music file extension is valid', () => {
+    test('non-whitelisted extension', () => {
+      expect(isValidAudioFile('track-title.doc')).toBe(false);
+    });
+    test('.mp3', () => {
+      expect(isValidAudioFile('track-title.mp3')).toBe(true);
+    });
+    test('.ogg', () => {
+      expect(isValidAudioFile('track-title.ogg')).toBe(true);
+    });
+    test('.flac', () => {
+      expect(isValidAudioFile('track-title.flac')).toBe(true);
+    });
+    test('.m4a', () => {
+      expect(isValidAudioFile('track-title.m4a')).toBe(true);
+    });
+    test('.wma', () => {
+      expect(isValidAudioFile('track-title.wma')).toBe(true);
+    });
+    test('.aiff', () => {
+      expect(isValidAudioFile('track-title.aiff')).toBe(true);
+    });
+    test('.aac', () => {
+      expect(isValidAudioFile('track-title.aac')).toBe(true);
+    });
+    test('.aa', () => {
+      expect(isValidAudioFile('track-title.aa')).toBe(true);
+    });
+    test('.ra', () => {
+      expect(isValidAudioFile('track-title.ra')).toBe(true);
+    });
+    test('.ram', () => {
+      expect(isValidAudioFile('track-title.ram')).toBe(true);
+    });
+    test('.shn', () => {
+      expect(isValidAudioFile('track-title.shn')).toBe(true);
+    });
+    test('.wav', () => {
+      expect(isValidAudioFile('track-title.wav')).toBe(true);
+    });
+    test('.wave', () => {
+      expect(isValidAudioFile('track-title.wave')).toBe(true);
+    });
+  });
+  describe('Returns true when correct image file extension is valid', () => {
+    test('non-whitelisted extension', () => {
+      expect(isValidAudioFile('image-title.doc')).toBe(false);
+    });
+    test('.png', () => {
+      expect(isValidImageFile('image-title.png')).toBe(true);
+    });
+    test('.jpg', () => {
+      expect(isValidImageFile('image-title.jpg')).toBe(true);
+    });
+    test('.jpeg', () => {
+      expect(isValidImageFile('image-title.jpeg')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION

WEBDEV-2608

**Description**

In music player, where we parse the data, extend to validate the major audio file extensions

**Technical**

Create a utils.js file to house the validators for sharing across files

**Testing**
Currently on-site, it does not show all of the tracks
archive.org/details/cd_bbc-radio-1967-1971_soft-machine

Go to:
https://www-isa.archive.org/details/cd_bbc-radio-1967-1971_soft-machine
Confirm that all the tracks show.

