### PR TITLE
Audio player files parser update

### DIFF
--- a/packages/ia-components/sandbox/data-for-stories/album-private-with-spotify-youtube.js
+++ b/packages/ia-components/sandbox/data-for-stories/album-private-with-spotify-youtube.js
@@ -86,821 +86,556 @@ const linerNotes = {
   }
 };
 
+
 const itemInfo = {
-  server: 'ia600103.us.archive.org',
+  created: 1568406250,
+  d1: 'ia600103.us.archive.org',
+  d2: 'ia800103.us.archive.org',
   dir: '/16/items/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul',
+  files: [{
+    name: '__ia_thumb.jpg', source: 'original', mtime: '1530533494', size: '13007', format: 'JPEG Thumb', rotation: '0', md5: 'a21459bc4e2e7bec054ba62d6a74e978', crc32: '7d1f7811', sha1: '49c1897299aedf533badf137205ea2c5fa8782d9'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul.pdf', source: 'derivative', format: 'Text PDF', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz', mtime: '1510664666', size: '10486635', md5: '909bb837a391d97b093123c8e65fa03e', crc32: '216c390a', sha1: 'c41b56b1a8bffee9bf384263c4f89eaf1aca7a95'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz', source: 'derivative', format: 'Abbyy GZ', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_jp2.zip', mtime: '1510664395', size: '521284', md5: '6983645d2d8b5fb2dc77585f96e10bc4', crc32: 'd125ab27', sha1: '26228c0add83487c4170bfe7e1a0e6202f959abe'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.txt', source: 'derivative', format: 'DjVuTXT', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml', mtime: '1510664468', size: '36233', md5: '4fe53972df4bff6bdaf09cdbd3907a13', crc32: '0e941be9', sha1: '031dd3d779858cd8d2cf207d417e23080af9e616'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml', source: 'derivative', format: 'Djvu XML', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz', mtime: '1510664442', size: '399233', md5: '8a8476d631b1d2cad8f5fd93b44c5a50', crc32: '4fd48917', sha1: 'dfd31a1059e126535b4d4e938d4c5915819d2e96'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_files.xml', source: 'original', format: 'Metadata', md5: '9b5fc1609436853013f44935d16423c9'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_images.zip', source: 'original', mtime: '1510658535', size: '281226853', md5: '1a746677e0c6eb853fe6010a3a1389aa', crc32: 'de838840', sha1: '9768be2ececa893a54f0f14f5352d3df8980bd7e', format: 'Generic Raw Book Zip', private: 'true'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_itemimage.png', source: 'original', mtime: '1510658540', size: '731313', md5: '2cd8341c95ca937ce7f5865f4162b344', crc32: 'e3236fab', sha1: '1cc5a875eca715de5417aa5301f4318bb157e7bb', format: 'Item Image'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_jp2.zip', source: 'derivative', format: 'Single Page Processed JP2 ZIP', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_images.zip', mtime: '1510663687', size: '16442232', md5: '4f2dd9141f8e0041c8c3e4d73eade0ff', crc32: '48800a71', sha1: 'c2646121af00316d05e8ca6422d5a604bf3d8ce1'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_meta.sqlite', source: 'original', mtime: '1510661684', size: '73728', format: 'Metadata', md5: '065d59d79deb8b5662f3011244524778', crc32: 'ad3510a3', sha1: 'a866c4d12727d4d68053d3a8a700f1202f3bad16'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_meta.xml', source: 'original', mtime: '1559084939', size: '4843', format: 'Metadata', md5: 'f0f7cae74ca9399b4b350049060952bb', crc32: '57b67c88', sha1: '00b9048de0f6de47b75a881a4aeeac0a5013b557'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_reviews.xml', source: 'original', mtime: '1533844806', size: '587', md5: '1e947a7784a580ef323af7796ccf062d', crc32: '1f3dbd40', sha1: '54954cc9b73335c018ae0244f56b03558eba1ee5', format: 'Metadata'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_scandata.json', source: 'original', mtime: '1510658545', size: '224040', md5: 'f2e02f2b3a2e8b2e37118ccb8821c559', crc32: '94f2886d', sha1: 'ee23b248e7ea88977421e2e8b54acd1d7fabddc5', format: 'Scandata JSON', private: 'true'
+  }, {
+    name: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_scandata.xml', source: 'derivative', format: 'Scandata', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml', mtime: '1510664467', size: '4760', md5: '1ce519a034f2e11135608e46cedf1a76', crc32: '86c22866', sha1: 'cc46f9bcd3626732c60055cf85fbd2f91f1e635a'
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663724', size: '23672', md5: '2d62085edd86e4f90516d75934645aff', crc32: '46532c1b', sha1: 'ba6b66cd23be07cecbf36db5f9aaa8fab5ce0670'
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life.flac', source: 'original', mtime: '1510661196', size: '11076392', md5: 'f9bb53b79851b621e986c4c2db2f7c24', crc32: '46e1e9b0', sha1: 'f2cdd7039262199b494476e70798711b28e50e50', format: 'Flac', length: '152.43', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '1', album: 'The Essential Willie Nelson', title: 'Night Life', 'external-identifier': ['urn:acoustid:13ed3700-7bda-4877-a2a1-d7e4630dd882', 'urn:mb_recording_id:1865ddbb-b8ba-4b3a-b12d-52b0a5297ab7', 'urn:spotify:track:5UeDQvUkdJuK3QVcri2jZ9', 'urn:youtube:69w7A8qb-SU'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Night Life', track: '1', album: 'The Essential Willie Nelson', bitrate: '133', length: '02:32', format: 'VBR MP3', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510662051', size: '2650624', md5: 'd38fdf12c65b4d4f3a40876e00225040', crc32: '659b6041', sha1: '4efb5861f0eae5a35e842497d05f9d9668e3933c', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663065', size: '12551', md5: '6356323b3f8cae8623cd27775afc7d63', crc32: '55070dec', sha1: '1cb4efffb02ff37d47050327480b8e378d7d7bd8'
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Night Life', track: '1', album: 'The Essential Willie Nelson', bitrate: '108', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510662255', size: '514560', md5: '6beff838f9805e0e53d661cdc7f58325', crc32: '447db8a5', sha1: 'ac10d01321a3aba6d359657b7a849b01735769e8', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.01. Willie Nelson - Night Life_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663474', size: '284561', md5: '0ce5ab9d2afe51938666d93d33e030e1', crc32: '1ebf9a8c', sha1: '4237468f3bcb86cffe182ecdda28167803c3ab08'
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510664181', size: '21680', md5: 'dcb09d734ff55d52a80e77e73618beee', crc32: '7c2d6a5b', sha1: '18dcc02f04ac0914b8cdd5a1b0747e119883c40d'
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', source: 'original', mtime: '1510660072', size: '15743992', md5: 'cb684f2a12c96b6590f5119b888e4505', crc32: '96a5e7b5', sha1: 'fc90ead09468d75887547ddcc4ad202b33b7d735', format: 'Flac', length: '144.71', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '2', album: 'The Essential Willie Nelson', title: 'Hello Walls', 'external-identifier': ['urn:acoustid:f0a1a191-115f-41e0-bf39-430fb7811165', 'urn:mb_recording_id:38e3036a-68de-4ca9-b577-5b86137f3e39', 'urn:spotify:track:275SxfFiepqWJeKXvNlGKq'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Hello Walls', track: '2', album: 'The Essential Willie Nelson', bitrate: '184', length: '02:24', format: 'VBR MP3', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662401', size: '3445760', md5: '8d6a01bdb384a125b7d5b3742f53a812', crc32: 'd160e68a', sha1: 'fd1e98cd17007fc9a4b25ef2240b780fc8c942dc', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662927', size: '12530', md5: '35048d8617296b65aaec96a6aac07bd2', crc32: 'ce9c1c99', sha1: 'd9a3416c446f7b3476fd5675c27cce708f339f49'
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Hello Walls', track: '2', album: 'The Essential Willie Nelson', bitrate: '158', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662057', size: '702976', md5: 'dc065c9ef43d764c1f3129471c5b3e2b', crc32: '274b5f0f', sha1: 'f3b0827450963842f554719248349b97e1047f57', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.02. Willie Nelson - Hello Walls_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510663520', size: '298042', md5: 'd7b53e1c4fa848bb5d63edfb0d8d29ed', crc32: '5fbe1905', sha1: 'e0952809f7cb1617a7d3a190f9117f97cc6a98dd'
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663927', size: '21952', md5: '668c2af15921d87a2a247c7e0c7c4537', crc32: '5edfb104', sha1: 'ba476dad7f745d6d7ceab9ad23db8c82f8f8bace'
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy.flac', source: 'original', mtime: '1510660079', size: '17858502', md5: 'fe36fe14ef07581a914428c838310bcc', crc32: '8d2eb6e6', sha1: '031a61f92711aa891dd44f5857c6c9623607de70', format: 'Flac', length: '172.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '3', album: 'The Essential Willie Nelson', title: 'Crazy', 'external-identifier': ['urn:acoustid:b00ec726-148c-4389-b4a2-717ee49d45b7', 'urn:mb_recording_id:a68b9249-86f1-42e9-9b60-df04a49fe230', 'urn:spotify:track:0xqtcLB45iKNfHroi5y1em'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Crazy', track: '3', album: 'The Essential Willie Nelson', bitrate: '176', length: '02:52', format: 'VBR MP3', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510662859', size: '3899904', md5: 'ffee2a19f1d090ef91f69cbc22d97e1a', crc32: 'b97ced01', sha1: '09b8133e7f67cf674535eee2df4b8c976075294d', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663022', size: '12825', md5: '13abab1737d348080412875dc8beb056', crc32: '43ec12fc', sha1: '9e3c45712cb1707be224534d245bf52c7809a3d2'
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Crazy', track: '3', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510661950', size: '668160', md5: '9b1d1d98c338d8ef3a3decfb050e8ab5', crc32: 'be090614', sha1: '161e74fcc103f449e9fbf32442642fa89d42701f', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.03. Willie Nelson - Crazy_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663528', size: '283473', md5: 'a2f351a7e575e19f1e00ee2b3f585104', crc32: '26df5da2', sha1: '0e4c17d69b0f0f290e4509a293c5340a9d5829bb'
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663825', size: '24624', md5: '798f7d7b4ba0bc3c6d097655a9f19a6b', crc32: 'c8d8f880', sha1: '1848b47a536b9fceb8f881ab8affa7a12640c4e8'
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', source: 'original', mtime: '1510660095', size: '18536530', md5: 'a26636bfa6885338845d2dc4c394de1a', crc32: 'c88d2e03', sha1: '58e353eb94cbd45d1b100f29690fbbb173f70b7c', format: 'Flac', length: '183', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '4', album: 'The Essential Willie Nelson', title: 'Funny How Time Slips Away', 'external-identifier': ['urn:acoustid:6936c03a-96bd-49af-8e80-6dd6cf884161', 'urn:mb_recording_id:a8580492-9df6-4690-9ffe-1abe6ecb6e46', 'urn:spotify:track:6Sr2e5J7WnRJ7sLpUpyie9'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Funny How Time Slips Away', track: '4', album: 'The Essential Willie Nelson', bitrate: '175', length: '03:03', format: 'VBR MP3', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510662580', size: '4119552', md5: '3a81db9205d03f484f9981bb39f36001', crc32: 'db059fac', sha1: 'a3a403d00e3ed54f977d3633168ad05f6131080f', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663363', size: '12312', md5: '516bf955df2e0ecd46a7be1845194c4d', crc32: '837268dd', sha1: 'c73dfc1cd98947c4e1a69d6983e69fe82f79d36b'
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Funny How Time Slips Away', track: '4', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510662712', size: '668672', md5: '083ceaf86ecdf1a49ec3cd9f373fd98e', crc32: 'ba6b0dfd', sha1: '0fd3b7ec133c71e7d5b7cd2acf120dd117739316', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663493', size: '274751', md5: '9ff5a8394ba1dd5707fa26a8d64a537c', crc32: 'baaf167a', sha1: '074261453367bd67efeada6c55b03a9fc6e3129b'
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510664218', size: '25744', md5: 'c4e72f029408b245fe3d236248eb51fa', crc32: 'ffc11a62', sha1: 'f614c94715048f950ceacef9d0dfee7fa3c38500'
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', source: 'original', mtime: '1510660114', size: '15098908', md5: '247a3bd87cb96c2134ac7d5c119c2743', crc32: '12c70717', sha1: '731937b1396a09951cc86e8a24bbf1d761168923', format: 'Flac', length: '152.53', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '5', album: 'The Essential Willie Nelson', title: 'I Never Cared for You', 'external-identifier': ['urn:acoustid:e11149ee-7819-4b8e-b017-d6df957e3345', 'urn:mb_recording_id:cc050cd0-b814-4aa0-93ce-e34d3ce14771', 'urn:spotify:track:4c8uCy3cc92cbGTmVD9oS7', 'urn:youtube:hEr23gTL0JA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'I Never Cared for You', track: '5', album: 'The Essential Willie Nelson', bitrate: '207', length: '02:32', format: 'VBR MP3', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510661983', size: '4049408', md5: 'dfcc8e587bff32068ba2aff11ef62f22', crc32: '87958603', sha1: 'c37c96611944323548d97a8e41a10d8fcf866e3c', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510662984', size: '11872', md5: 'c5679c64bc04e72c36cf1e9c319b60c4', crc32: 'b4dbb6a8', sha1: 'f61e83cd870817fd56367db3868770ddf7854579'
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'I Never Cared for You', track: '5', album: 'The Essential Willie Nelson', bitrate: '180', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510662655', size: '786432', md5: '9c687c87221f417e57ce2a3ac13e7e35', crc32: 'e584c231', sha1: '854eb35c461df7689620793a2c214be24dc36b20', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.05. Willie Nelson - I Never Cared for You_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510663517', size: '324128', md5: 'db6700f9dd4aa124b45a2a0a49a5e66f', crc32: '76d63834', sha1: '9d51b47e8a8695371461ac5f55b8b2fcbb7dcfce'
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over.afpk", source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510664037', size: '23200', md5: '2242cc9260c65d4ddd0381e53a6ddbb6', crc32: 'f23d296d', sha1: '56d0830d994c6331b042d21b29de3665cb972380'
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over.flac", source: 'original', mtime: '1510661233', size: '16281998', md5: '00af9c03b91d94054ea4e04d3f96564a', crc32: 'a14acb5e', sha1: 'd3206ecd4a0fc053a41c1a02b38a5e199e1c5ba2', format: 'Flac', length: '149.8', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '6', album: 'The Essential Willie Nelson', title: "The Party's Over", 'external-identifier': ['urn:acoustid:e031ebab-e7c8-4a1a-b481-d2e34abc32e7', 'urn:mb_recording_id:8dae4e64-2413-4c28-8e40-43986a2fee82', 'urn:spotify:track:3A9jxTBQFZ2p5AjaMhJu6y', 'urn:youtube:QoQZ0qmf-mk'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over.mp3", source: 'derivative', creator: 'Willie Nelson', title: "The Party's Over", track: '6', album: 'The Essential Willie Nelson', bitrate: '195', length: '02:29', format: 'VBR MP3', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510662249', size: '3755008', md5: 'e13019a367d1c4e302c40bd649679e8e', crc32: '7a8b85cd', sha1: 'aedd8635b00090a80e49d7d58d93d27cc5d20b69', height: '0', width: '0', private: 'true'
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over.png", source: 'derivative', format: 'PNG', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510663147', size: '12894', md5: '2f1b0e0089614c46792ff753f01c1e66', crc32: 'a113f9d1', sha1: '3322338c52637d666070a0f298a8c45e5edc5dd7'
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over_sample.mp3", source: 'derivative', creator: 'Willie Nelson', title: "The Party's Over", track: '6', album: 'The Essential Willie Nelson', bitrate: '166', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510662564', size: '733696', md5: 'f22e4de4135ef4d0a029c519d6164190', crc32: '7a7d1984', sha1: '8724d12dc53a0724ee38f6ac9beee5b2999d3b53', height: '0', width: '0'
+  }, {
+    name: "disc1\/01.06. Willie Nelson - The Party's Over_spectrogram.png", source: 'derivative', format: 'Spectrogram', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510663490', size: '308439', md5: 'd5dc4306fe44166607426ac5ec62d7e3', crc32: '96f20655', sha1: 'a32ab03374a57db933bd37257bfbbcfbd3442a7a'
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510664001', size: '20392', md5: '8e10a9669a1be0621c418d0c5aca3632', crc32: '4d7d5c03', sha1: '3d735b340c57a23dc95fc1779de36755aa0a1523'
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times.flac', source: 'original', mtime: '1510660992', size: '14111627', md5: 'ce14f7e70527b151c8fa4bbd2b25658f', crc32: '15c1ae49', sha1: '589fd2a621830b271c1215408a5a49b22f764d68', format: 'Flac', length: '148.07', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '7', album: 'The Essential Willie Nelson', title: 'Good Times', 'external-identifier': ['urn:acoustid:b2303076-0168-4006-ad84-193e1c7d68a7', 'urn:mb_recording_id:33d1efe7-c026-426a-9077-4224239fefd9', 'urn:spotify:track:1kvft1Zif8xbTX14zxdYef', 'urn:youtube:ETZ7J7MSKGM'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Good Times', track: '7', album: 'The Essential Willie Nelson', bitrate: '200', length: '02:28', format: 'VBR MP3', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510662414', size: '3814400', md5: '610873a8fafad01285d45638a52230f9', crc32: 'b29b060a', sha1: '2363ea936dabe7a2c1810994242859b3b60d642f', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510663270', size: '13482', md5: '76df0a61493e6bac0837f04c42189e0a', crc32: '17b1d157', sha1: '25bc9cb9fa15b614888deee244b59308f277f93e'
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Good Times', track: '7', album: 'The Essential Willie Nelson', bitrate: '178', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510662700', size: '779264', md5: 'f82b584dcf82c3eaa4559f896f1a772f', crc32: 'ed8251cf', sha1: '111db290f5a8baf2491303d31a04e177bc67cd6e', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.07. Willie Nelson - Good Times_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510663447', size: '296523', md5: '4cc879b6a6362823c492317eb3be6a62', crc32: 'b385fe11', sha1: 'e898c06fb191264e5de4241dca979d11e33abe43'
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510664016', size: '37592', md5: 'faf00338a9ca9d9570c253570f86c52e', crc32: '61b6d594', sha1: '640dbd94a1b647d536948b62b8fef01434acba22'
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', source: 'original', mtime: '1510660975', size: '23284478', md5: 'b0d241b0421489e8aeef50ce32adfe43', crc32: 'ac8da23f', sha1: '19fde60424a9e1532d33a9ab9140fb777687a172', format: 'Flac', length: '229.09', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '8', album: 'The Essential Willie Nelson', title: 'Me and Paul', 'external-identifier': ['urn:acoustid:5077d27a-99fe-42a5-8399-4acbf538aa16', 'urn:mb_recording_id:8d42f6c3-4204-4ca3-9ca1-1b53978c777e', 'urn:spotify:track:4vcDnnuHUmombz20IRkzRO', 'urn:youtube:4uSFw165Qk0'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Me and Paul', track: '8', album: 'The Essential Willie Nelson', bitrate: '205', length: '03:49', format: 'VBR MP3', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510662323', size: '5992448', md5: '27cb6a1614f9736b862dd481b3113798', crc32: '266b2894', sha1: '706c773a3cea8c6b09474358ccb55e8dde2f7fb4', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510663037', size: '12008', md5: '805895f6d3574f8bcde27bff1a49fc82', crc32: '75eee56f', sha1: 'd415a307420353b7a5884b38e85fd43f360ecf0b'
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Me and Paul', track: '8', album: 'The Essential Willie Nelson', bitrate: '174', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510662641', size: '763392', md5: '7ba3dfbec2ae5479368c7c9a3ab0e7a3', crc32: '76473a8a', sha1: '4f1c3222f972cbec2d9ac6eca6bc2d9e2e24f159', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.08. Willie Nelson - Me and Paul_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510663482', size: '309073', md5: 'a95fa8ac4725331b07cef247d8c80103', crc32: '9603a9dc', sha1: 'ac850983e9ba32fb134ddea80d3be0ea71479075'
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510664028', size: '30624', md5: '9bd7c71376c2d9714650e03cfc610082', crc32: 'cb965c4f', sha1: '4ff01b0cae430e804d1098dc3e7a590414a435b3'
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', source: 'original', mtime: '1510661664', size: '17577936', md5: '54caa5bf7538e43bf18038568e491ea8', crc32: 'a988b49e', sha1: 'a5c1aad618c2aec6abc34df9e871dd5ee77f69f6', format: 'Flac', length: '159.71', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '9', album: 'The Essential Willie Nelson', title: 'Shotgun Willie', 'external-identifier': ['urn:acoustid:cb115b18-519a-4229-8119-0b419e82c008', 'urn:mb_recording_id:e3a1580c-2bee-4c9b-843b-46a9d6263f2f', 'urn:spotify:track:7fMOzTcT7U5A9hVCwCfWgD', 'urn:youtube:eK-7k8MHvnE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Shotgun Willie', track: '9', album: 'The Essential Willie Nelson', bitrate: '199', length: '02:39', format: 'VBR MP3', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510662269', size: '4082688', md5: '2091d3a2636ed27c49cc7e2eb7e2628f', crc32: '6e88d14b', sha1: 'aa7950b6f428851cbe90d9f4b93b843eb71c294d', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510663118', size: '12689', md5: 'cdd144071cc39fbd1fbee6eac070be9d', crc32: 'aca1e12a', sha1: '306f0dea007649c681bd9f9da3205741a7b32c51'
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Shotgun Willie', track: '9', album: 'The Essential Willie Nelson', bitrate: '164', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510662649', size: '726016', md5: '1fc170a37ed4abc55e3987a2fa20f6bc', crc32: '3000b2eb', sha1: 'b034e85f4403581542a5eda2246155ea7fae7d89', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.09. Willie Nelson - Shotgun Willie_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510663560', size: '314258', md5: '9dd9fa2a0ee724878a9577eacb0040c1', crc32: '5eccc3e9', sha1: '805199cbad0e95464fa356bddbfa48384cf5d25b'
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510664060', size: '33296', md5: '3af27d3452a1e5674c1d80b6003633cb', crc32: '851eb75e', sha1: '5b6a1ac32663715fed1fdd58e219f34de5daf2ed'
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', source: 'original', mtime: '1510660590', size: '19482374', md5: 'e51844070b1df97c3f93525cc60123b8', crc32: '48644720', sha1: '2b3da29aeff675a23ecbf8317910e9cd804ab233', format: 'Flac', length: '169.73', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '10', album: 'The Essential Willie Nelson', title: 'Bloody Mary Morning', 'external-identifier': ['urn:acoustid:2197beee-d06e-491f-ab46-fcf8d8bc6d4e', 'urn:mb_recording_id:0c505681-80e9-483e-8954-a532f260dc9f', 'urn:spotify:track:5paRS95sOPkOVQlmUIUF4B', 'urn:youtube:NbrB4B5FoBQ'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Bloody Mary Morning', track: '10', album: 'The Essential Willie Nelson', bitrate: '212', length: '02:49', format: 'VBR MP3', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510662747', size: '4600832', md5: '926bed5523d91b902cc4ad9ce50d9c8f', crc32: '58e385c9', sha1: '17e6765463e454524837ac5c3be607e0dd74c5f4', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510663079', size: '11827', md5: '33e9eee821826ad84ef5c37fa1b57181', crc32: '26e32a69', sha1: 'c46518154ee814790a650091fe901d4d78a2df0a'
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Bloody Mary Morning', track: '10', album: 'The Essential Willie Nelson', bitrate: '172', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510662126', size: '755712', md5: '61282b7468ec9b82f61c1182b4b33127', crc32: '0a78e32c', sha1: '76cf573e74c083bd2822eb1cbe399dc7d9ee4153', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510663598', size: '320633', md5: 'b54489133bf420c9f5fd501d41cfd248', crc32: '4740b8c4', sha1: '11fa23b984cf439bd189fab9b92cae6f4864b0f3'
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510664070', size: '19168', md5: '8e98c3cc103e801e83295911b073db69', crc32: 'fb476877', sha1: '0ca6daecf4045cd7ce1d7ca8a6553c7ae783ca0d'
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', source: 'original', mtime: '1510660119', size: '11083146', md5: 'b4095a5c24cad7e2487c9cbf87b6e7d6', crc32: '6847d14f', sha1: '4ead2b4df28306514790d7da5a3e0872f03cd10f', format: 'Flac', length: '141.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '11', album: 'The Essential Willie Nelson', title: 'Blue Eyes Crying in the Rain', 'external-identifier': ['urn:acoustid:dda238da-08a4-4ed7-b0b5-2230c772523b', 'urn:mb_recording_id:1e0ff41e-80bc-4812-a57c-1735bf814d57', 'urn:spotify:track:2uRVPeQbsEpRQD0DKr1WTo', 'urn:youtube:crgtWomWg90'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Blue Eyes Crying in the Rain', track: '11', album: 'The Essential Willie Nelson', bitrate: '177', length: '02:21', format: 'VBR MP3', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510662281', size: '3236352', md5: '15b5c672983a34c462979cb04ddbebc8', crc32: '43c09e59', sha1: '0ed797d19d03a7b3a844f7b2f6762e2917f76106', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510663431', size: '12697', md5: '73aaff795bec66525aa59583d73afa2e', crc32: '29452325', sha1: '6290abd0a653f13573ad2fc75ff76626f3f6bdc8'
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Blue Eyes Crying in the Rain', track: '11', album: 'The Essential Willie Nelson', bitrate: '136', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510662811', size: '622080', md5: '85508c85913681587c68224b1746eae8', crc32: 'f6df935a', sha1: '960a5550bd72ab9d6be1c96129090338a5a34a93', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510663542', size: '312649', md5: '297039c4081828ba86d1dd70c3bfd2e6', crc32: 'dd2e832a', sha1: 'eb26f178f141a064ab546a7fcf7fe3e07382de5e'
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663992', size: '32568', md5: '3deb31c0d75781d8164551959db9341c', crc32: '727daf42', sha1: '4cc5a48b96a6c9df51497b6b2593e34581b978b0'
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', source: 'original', mtime: '1510660089', size: '19312085', md5: '477c4cb1aff3a2c0f9b4d767c87e2e8e', crc32: 'bbee9cd8', sha1: '4c50a18c72bbcfb6ba0d6e05e1538defe44fbcd8', format: 'Flac', length: '179.07', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Waylon Jennings', track: '12', album: 'The Essential Willie Nelson', title: 'Good Hearted Woman', 'external-identifier': ['urn:acoustid:3433cd9a-c797-4388-a2ca-aa1ee22337f5', 'urn:mb_recording_id:13a2f394-e61b-4b84-8bd5-42c1551b3115', 'urn:spotify:track:3CqLvQ9fPOLtLIKb7r5ti6', 'urn:youtube:swRJeMsk21g'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.mp3', source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: 'Good Hearted Woman', track: '12', album: 'The Essential Willie Nelson', bitrate: '187', length: '02:59', format: 'VBR MP3', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510662303', size: '4304896', md5: 'b436bbb6a068ddf555ba56e9c16e38a5', crc32: '73311228', sha1: '48e9be3c9f72c880a5b0eb235261219dd69f41e3', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663352', size: '12255', md5: '2c01646835822aa47151087fe5ff4fa2', crc32: '408c1daa', sha1: 'f73c983cde501f4a7a73a472d62e756e91d1581e'
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: 'Good Hearted Woman', track: '12', album: 'The Essential Willie Nelson', bitrate: '151', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510662062', size: '676864', md5: '107b9f2cc977c4d472d466da98016ae3', crc32: '5230701f', sha1: '33cb606dc97945ff2c6ed02c752eef1d8def82ea', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663563', size: '319121', md5: '0abf080bedf6ef109d877c434d59ec77', crc32: 'eee8af97', sha1: '1cca3aa23ff471967c6af1b7e8fcf9f08a391776'
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.afpk", source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510664081', size: '25680', md5: 'f9388cb5046482f64f7c426eb4d5a3b5', crc32: '53236901', sha1: '43ca264e9b5f6604380ff86705a988b7bb276dc1'
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", source: 'original', mtime: '1510660108', size: '13714638', md5: '5cd5600105a44c8bc25e5e1606e27b7f', crc32: '42b88a71', sha1: '0fbba2190d38e9828538dbc430e1cefb1fd204f9', format: 'Flac', length: '126.69', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '13', album: 'The Essential Willie Nelson', title: "If You've Got the Money I've Got the Time", 'external-identifier': ['urn:acoustid:25dd90cb-1fa4-4e98-88d8-49d9d6119645', 'urn:mb_recording_id:acd8fda3-4097-4666-a32b-de814b4dfd14', 'urn:spotify:track:7aVapcvsbFYYmcQvhkc8Rc', 'urn:youtube:KeoYaaojdCE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.mp3", source: 'derivative', creator: 'Willie Nelson', title: "If You've Got the Money I've Got the Time", track: '13', album: 'The Essential Willie Nelson', bitrate: '200', length: '02:06', format: 'VBR MP3', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510662335', size: '3270656', md5: '1b0c54078f6b435e7fd80320e5c477d8', crc32: 'b7745bed', sha1: 'cf6dafca07889b1dee65ec6d0d2e225469e0f36d', height: '0', width: '0', private: 'true'
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.png", source: 'derivative', format: 'PNG', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510663443', size: '10814', md5: '66409704f9c71db8f4d47a6d24c865d4', crc32: '89b3c4ff', sha1: '15120367ee102283ef6295bc5e4a859705e0a350'
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time_sample.mp3", source: 'derivative', creator: 'Willie Nelson', title: "If You've Got the Money I've Got the Time", track: '13', album: 'The Essential Willie Nelson', bitrate: '145', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510662151', size: '655872', md5: '3f5cc30c0dcf2e1fe2dc80e4d5339a53', crc32: '0263a7b6', sha1: '62ceeb65e23a7112201323902bee2b70001f8d7e', height: '0', width: '0'
+  }, {
+    name: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time_spectrogram.png", source: 'derivative', format: 'Spectrogram', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510663587', size: '324451', md5: 'b1043e2da665409cb01f9d41773e4880', crc32: 'c64aaab7', sha1: '927e4a609f9ab68c61575d08a1374729f37ab411'
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510664111', size: '53776', md5: 'e0e1e193516f4e6f007ad08a7c91b9fa', crc32: '73fb327b', sha1: '62a9a74b853968f6e443ad61243319ef7fb422b3'
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', source: 'original', mtime: '1510661203', size: '28313862', md5: 'f2717ab887f16bc7abe684ba9fa4a156', crc32: 'd17232db', sha1: 'dfd440ef021436bfa8bf25c4b2e32f79bfd87cbf', format: 'Flac', length: '280.91', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '14', album: 'The Essential Willie Nelson', title: 'Uncloudy Day', 'external-identifier': ['urn:acoustid:f67a8d30-d780-47df-9207-318c13cb3549', 'urn:mb_recording_id:990c34ea-e7a9-4a5b-9633-23c71d1c8e17', 'urn:spotify:track:7GZRUcgcXtUWkUwnx7SLkz', 'urn:youtube:w1-DHepnVLs'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Uncloudy Day', track: '14', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:40', format: 'VBR MP3', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662363', size: '7104512', md5: 'fc7b64e31be85f661c4d62f9ed5019b1', crc32: '215f8a32', sha1: 'e240c636aba5374617ca5bee28de451ea584e290', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662974', size: '11787', md5: '507142e801428fbd6865b00dae84f165', crc32: '4671d1d7', sha1: 'b0da5301711f347625383435076ed5e8bf5ed1ff'
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Uncloudy Day', track: '14', album: 'The Essential Willie Nelson', bitrate: '169', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662674', size: '742912', md5: '713e38c2cc554b82faf32623857b28c5', crc32: '281c4a23', sha1: '0fd0a1c6541a556c521dd03b0b91b574bb7c7a08', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.14. Willie Nelson - Uncloudy Day_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510663514', size: '289360', md5: 'da47ab0080f446e0fd8e723dda9f3fac', crc32: '00a0666a', sha1: 'f97f9d1cee6bc34f64eff0607c90da84c24a4504'
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.afpk", source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510664048', size: '25216', md5: '58856b390cdd0df71c60fc78bf8dda5b', crc32: 'cdfcf169', sha1: '7ae1be2399adad93afbd23e7f3a0a7d49491adf6'
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", source: 'original', mtime: '1510660147', size: '16360575', md5: '5b1161b2ed5c7a56e1eadf92928fd2f3', crc32: '719db41f', sha1: '09a42e73084b863d55a8779f4aaf8d8730aa72f6', format: 'Flac', length: '152.96', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Waylon Jennings', track: '15', album: 'The Essential Willie Nelson', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", 'external-identifier': ['urn:acoustid:3f76466e-c967-4f46-9ecb-7555d3a71d61', 'urn:mb_recording_id:b5512c53-cd1e-4273-ac7a-96f28785b403', 'urn:spotify:track:1gKSpFpX3poa17WIAyFVsp', 'urn:youtube:RePtDvh4Yq4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.mp3", source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", track: '15', album: 'The Essential Willie Nelson', bitrate: '181', length: '02:32', format: 'VBR MP3', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510662502', size: '3575808', md5: '8daa23631f83867e0e73612395d7c56e', crc32: 'c002e25e', sha1: '008b6a61f0554ce4b9d0e4508ef3e522202822ce', height: '0', width: '0', private: 'true'
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.png", source: 'derivative', format: 'PNG', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510663405', size: '11135', md5: 'b4fb2b898d7b6253ede2ac23d1fd7f31', crc32: 'cf455854', sha1: '6bff8cea184c76af82ade5fc7b06e209cfa36c45'
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys_sample.mp3", source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", track: '15', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510662725', size: '682496', md5: '72f2d718003e602508de2e54203684c1', crc32: '559df7e2', sha1: 'a6fcc7922e90ec5e69ebf086b1a9902a1b555a16', height: '0', width: '0'
+  }, {
+    name: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys_spectrogram.png", source: 'derivative', format: 'Spectrogram', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510663534', size: '320341', md5: '55ba1678423c0d610fb2f588cedc6e50', crc32: 'd7ae860e', sha1: 'd6b632a950f1c7932a4beb5615ed122e43e0b52c'
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663704', size: '34816', md5: '8536b9b442844f0ad5e6adf65336032a', crc32: '84a9b965', sha1: '9daac02e6c1d825fe6fb7ffdeef6fc4e925b091d'
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', source: 'original', mtime: '1510661226', size: '23816391', md5: '63b1fb42fe2bf6e5157182c413695714', crc32: 'c02d6d1f', sha1: '4b8f38280d0cb3e7517273ec8da3be25c7e8abfd', format: 'Flac', length: '261.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '16', album: 'The Essential Willie Nelson', title: 'Georgia on My Mind', 'external-identifier': ['urn:acoustid:5f92e364-4eff-47c4-acdd-b9727a6e662f', 'urn:mb_recording_id:57866fe0-3d43-48f3-8704-c15c6c3114e5', 'urn:spotify:track:1HhXBDM4vhNiOiSU9BBBug', 'urn:youtube:FNlw0IDFKDA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Georgia on My Mind', track: '16', album: 'The Essential Willie Nelson', bitrate: '183', length: '04:21', format: 'VBR MP3', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510662539', size: '6099968', md5: 'c70a0edb54ed4ca885acca0a75d4df6d', crc32: '04e87270', sha1: 'fa1f50973ed272e9bf2360d1e5246a36bade05d6', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663246', size: '12332', md5: 'a6b1cc45013b28ff478c1fd4c31ad8ef', crc32: '1c2db7ca', sha1: '2b73322d0b88be8158160681a266fd1a8a6627d8'
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Georgia on My Mind', track: '16', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510662688', size: '668160', md5: '609d221d8705225147eb19fbddae36d1', crc32: '59d48864', sha1: '8eda3c0021ae33972812394bb848b43d242ec397', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.16. Willie Nelson - Georgia on My Mind_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663584', size: '325048', md5: '06c41fd96e4296b13c86ae837c934fea', crc32: '09ab0d1c', sha1: 'b9c1c96d2c1999dc74ebe7efc4a3605b3db2a5f9'
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510664096', size: '27528', md5: 'd7a7eb66240ae1bc910bfc6aff59b481', crc32: '87cad81e', sha1: 'c4ffbb1f8784ee0f75e68ed0657d718dcd3bd94e'
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', source: 'original', mtime: '1510660968', size: '21122389', md5: '589acb5f967afdca0043428d374cb5e9', crc32: '03c61d2b', sha1: '4d42f6bca98fb25f4f0b559c90e8367d253f722d', format: 'Flac', length: '215.17', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '17', album: 'The Essential Willie Nelson', title: 'Blue Skies', 'external-identifier': ['urn:acoustid:03ac4ca8-b529-4852-99de-4ba6f9992e7e', 'urn:mb_recording_id:5950b1b1-6f01-4d5a-9953-a6dee35b808d', 'urn:spotify:track:4dEPl3NXfpv1p9Z9MaHneO', 'urn:youtube:sGZDwxnjG1g'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Blue Skies', track: '17', album: 'The Essential Willie Nelson', bitrate: '190', length: '03:35', format: 'VBR MP3', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510662387', size: '5209600', md5: 'f1e0e312ca0b1646338a46ec0c5e1df5', crc32: '77e156b7', sha1: 'edec5a8cb7dafbb1cb401c63954e3613558c2ce9', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510663198', size: '13135', md5: 'd738da0fe353b7cfbc57b5d90822e6f8', crc32: '56c6dfb6', sha1: '4744a1cfbbb2a935a132009140426be078aa7407'
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Blue Skies', track: '17', album: 'The Essential Willie Nelson', bitrate: '153', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510662011', size: '684032', md5: '25fd153807ea8d5b4d1980ac4faa0bc7', crc32: 'bccc0343', sha1: 'b6f2575077c046be90203e88f4889ef244908867', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.17. Willie Nelson - Blue Skies_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510663450', size: '310948', md5: '35a04ccd277cca01f9e906596056c8da', crc32: '5d7116a1', sha1: 'b8bc5a2b0e5c3c1182830d107cacb915a33a3d52'
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663803', size: '34952', md5: '59e4d8aa952fe151104d43478d8de23a', crc32: 'd6ba968e', sha1: '7b674526252263f1bc6565f0a96300f551d13cec'
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me.flac', source: 'original', mtime: '1510660140', size: '23594146', md5: '493a0f0a0d1d6e1411cff3bd02ba272f', crc32: '4493586c', sha1: 'f60f10ee839f6a854789a971c640808219ce7f81', format: 'Flac', length: '234.87', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '18', album: 'The Essential Willie Nelson', title: 'All of Me', 'external-identifier': ['urn:acoustid:b3720789-2e26-486b-a906-e773bc0f7f16', 'urn:mb_recording_id:92990a9f-5e08-4a20-afcd-d287e68023cc', 'urn:spotify:track:4BuCqXf9foFZBn8ZCIv8gh', 'urn:youtube:X1ZSZUSrXc8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'All of Me', track: '18', album: 'The Essential Willie Nelson', bitrate: '187', length: '03:54', format: 'VBR MP3', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510662433', size: '5609472', md5: 'af98653ca34ecf36e48ae4fb6e861168', crc32: '05dd02cd', sha1: '92f0b5f9a65143898adddf55fff8f9db1fff4908', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663013', size: '11957', md5: 'fc13ad7b6e65b102bb4853ae224fcfb7', crc32: 'db965955', sha1: 'b7810967d2b00675ab7cd36c086e9a68128e6df0'
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'All of Me', track: '18', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510662661', size: '681472', md5: '139e1a8360507e06bb836ac11bdbf146', crc32: '3aab6440', sha1: 'f014e505f6dac8a2b2cdcd489b8eafa5c69a5b53', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.18. Willie Nelson - All of Me_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663571', size: '307403', md5: '81c281d88ddf9a76919c7bf4b1a69a6e', crc32: 'fb00ad4d', sha1: 'e4c29d6fce65d2697ebbb938bcf8d631a2d92bda'
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663814', size: '37544', md5: '72547f03faf518d5837e112608321be0', crc32: '6fd32c66', sha1: '04a2b4696c42c0200dfbf236080b62f91209b534'
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', source: 'original', mtime: '1510660133', size: '22190389', md5: 'f775d9b7b01349099dcf0d8c84b8d7b2', crc32: '74815452', sha1: 'c9eebad69de4a7a2fd71dbace5a7028126f3c3b5', format: 'Flac', length: '183.09', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Leon Russell', track: '19', album: 'The Essential Willie Nelson', title: 'Heartbreak Hotel', 'external-identifier': ['urn:acoustid:bd5d5e1f-d40a-43c3-b657-f60ae5ffcb91', 'urn:mb_recording_id:827b3c8e-20ad-4cd1-ae46-b63d2ec33d16', 'urn:spotify:track:6nhoh9rZfdtXKtK6tssNKU', 'urn:youtube:jcSEaVyaUaA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.mp3', source: 'derivative', creator: 'Willie Nelson; Leon Russell', title: 'Heartbreak Hotel', track: '19', album: 'The Essential Willie Nelson', bitrate: '187', length: '03:03', format: 'VBR MP3', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510662119', size: '4384768', md5: '256490470d421788f8eeee613656b56f', crc32: 'cdc43565', sha1: 'a1233583036b5f1825357e4dbc1f4be1100e73c9', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663299', size: '7710', md5: 'b17b70a3f76b911095af5e32c34ce631', crc32: 'ca3adb32', sha1: '1d61fd9e0ce7daaf5e1284662cc1438d0039f5bf'
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Leon Russell', title: 'Heartbreak Hotel', track: '19', album: 'The Essential Willie Nelson', bitrate: '147', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510662824', size: '661504', md5: 'bdecc8f30e3f967b17e15c2a42f4eda4', crc32: 'b5fbf0f8', sha1: 'cb9cee4b060e434b6fc260efe41aaee4983289be', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663556', size: '305715', md5: '768848de9fedc3ba203782f8fcd1ea9f', crc32: 'a87edf53', sha1: '70c1985dc888d07d6b24e9564c8810315913dddb'
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663717', size: '34376', md5: '3f1a5c64e9219573e83ee44add2a7cbd', crc32: 'ea2ff30b', sha1: '09453a4f2b2b59f7f95f7292ab38de0d089f15ea'
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', source: 'original', mtime: '1510660156', size: '23153392', md5: '5825e367b2df7c0bfbdcf9b6e608c652', crc32: '12022ad7', sha1: 'f636c09ef5f3199d8dc3e61c7064dde13924c8ab', format: 'Flac', length: '241.53', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '20', album: 'The Essential Willie Nelson', title: 'Help Me Make It Through the Night', 'external-identifier': ['urn:acoustid:ccb90091-a7ac-4801-8ad3-408b87a578ca', 'urn:mb_recording_id:8dd83700-727d-4507-a686-1ddb0d62185b', 'urn:spotify:track:69iVsk096xmrKtcrU2mVnj', 'urn:youtube:1bCDWLSrlI4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Help Me Make It Through the Night', track: '20', album: 'The Essential Willie Nelson', bitrate: '191', length: '04:01', format: 'VBR MP3', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510662146', size: '5892608', md5: '6a9de37d62e641243d6249c46a5ef1d7', crc32: 'b318ad01', sha1: '634faea42464fa29b640239a51fb8c0c63467c39', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.png', source: 'derivative', format: 'PNG', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663093', size: '13270', md5: '6deac301814893037b327402e787d321', crc32: 'd0de9e3e', sha1: '84a9808da0681437935c92525468ba02b3aa1b1e'
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Help Me Make It Through the Night', track: '20', album: 'The Essential Willie Nelson', bitrate: '142', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510662818', size: '643584', md5: 'f3fb44e4979e8a2652690568a458bba9', crc32: '75395c22', sha1: 'ef955cc6a360c61f0cfccd4f0d8e716ea4e9d4f8', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663549', size: '331562', md5: '20cde540c4d671db8c4fc355f06a740d', crc32: '10aec794', sha1: '22a4da35b35ec8ffd1718ae5cdeef57aec5f21f0'
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live).afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663980', size: '45424', md5: '93448d31d3e99819b8fcdfba14f76cee', crc32: 'a823c52a', sha1: '8be489646399624bcf3288b67cc970d425108b43'
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', source: 'original', mtime: '1510660584', size: '24671629', md5: '46e16d72d571d32aa8d5c0fc6b04ea80', crc32: 'de0830bf', sha1: '43dd4144dd4e2ff50930ad8150a55a7847aa9c54', format: 'Flac', length: '211.44', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '21', album: 'The Essential Willie Nelson', title: 'Whiskey River (live)', 'external-identifier': ['urn:acoustid:aa846e11-bd40-4eae-8b47-dd5ae0d42de7', 'urn:mb_recording_id:5a43f1a9-18b4-4e7b-acbb-fdd8783ba598', 'urn:spotify:track:0EHDEzu14gcx4Z3hOYVpTn', 'urn:youtube:w53dvztwQY4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live).mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Whiskey River (live)', track: '21', album: 'The Essential Willie Nelson', bitrate: '179', length: '03:31', format: 'VBR MP3', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510662169', size: '4835840', md5: '6afce16f787857ee1e95fa925fcfbf95', crc32: '30587f62', sha1: 'fa4b371e82814645c8b3ccd9ef6897c69d7af1af', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live).png', source: 'derivative', format: 'PNG', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663001', size: '11612', md5: 'd7996f325a42e6b34bd6b50aaf23b4f4', crc32: '3aca5e0f', sha1: 'ee52e92889d29ff30588f24dd1726f35e9c0f57c'
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live)_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Whiskey River (live)', track: '21', album: 'The Essential Willie Nelson', bitrate: '136', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510661869', size: '622080', md5: 'd2ea89b7963e2442dbc279ac366b7d5c', crc32: 'f6df4448', sha1: 'e68c98d365cb79f4f823dca40921c0b58818836c', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.21. Willie Nelson - Whiskey River (live)_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663472', size: '302840', md5: '9047bd3dfc0066128ae8dcd1e408d9d6', crc32: '69449590', sha1: '9039d1139f40a9aa6fc6956a62a85434d5f1ec2e'
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663851', size: '45408', md5: '682533fa956fb12220eae01935fd399b', crc32: 'e6d61ca8', sha1: 'fbabf117ba31735851cb33214c4c1b51b62f727d'
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', source: 'original', mtime: '1510661646', size: '23733419', md5: 'dd4b4233b176dd7a344fc9a02a77c2de', crc32: '7b58317a', sha1: 'a97e3dd7b1c870435b1e3575a496aa057a824bdb', format: 'Flac', length: '205.33', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '22', album: 'The Essential Willie Nelson', title: 'Stay a Little Longer (live)', 'external-identifier': ['urn:acoustid:73e95b96-87e7-4905-a538-25bf123c7292', 'urn:mb_recording_id:7abc5bc6-3da2-4c01-8dde-87cbf055b948', 'urn:spotify:track:1Y2XmNnjyrH087OVy05knW', 'urn:youtube:FHZorrDDX4A'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Stay a Little Longer (live)', track: '22', album: 'The Essential Willie Nelson', bitrate: '180', length: '03:25', format: 'VBR MP3', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510662195', size: '4737536', md5: '9bad6a152e7c7bf80aab90f630605088', crc32: 'fec50a73', sha1: 'f51ba204010e7bdcec4a09e6e70b46161d712768', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).png', source: 'derivative', format: 'PNG', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663285', size: '10306', md5: '1de1dde0ab2ccf30b9dd2474cfbeba62', crc32: '7dc24235', sha1: 'eca4b015661338ed5d37184be1faa32f4ebf9288'
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live)_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Stay a Little Longer (live)', track: '22', album: 'The Essential Willie Nelson', bitrate: '140', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510662341', size: '636416', md5: '72ea57170a49c6a64c28d5c8f619e7aa', crc32: '9451ea50', sha1: '0ddf3990f43afa18d81e781d2f2376007e91ab9d', height: '0', width: '0'
+  }, {
+    name: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live)_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663538', size: '302413', md5: '815fe6ec2094b3a55a769aa4d99c5eca', crc32: '25ba1ac2', sha1: 'c0d805cb664848bc10daa830fdcd202de8fb31b2'
+  }, {
+    name: 'disc1\/Willie Nelson - The Essential Willie Nelson.cue', source: 'original', mtime: '1510661651', size: '4743', md5: '0a55debd30330e98854e8f96db5f1b43', crc32: '79a66d34', sha1: 'e35585a6e1c3fd7c75feb13bb4318d8144575469', format: 'Cue Sheet', private: 'true'
+  }, {
+    name: 'disc1\/Willie Nelson - The Essential Willie Nelson.log', source: 'original', mtime: '1510660083', size: '9039', md5: 'a1b3946eb2f84ef758b0631020ebc063', crc32: '24592e31', sha1: '82dde236fde123c35ef65d956f422d86eb5e9182', format: 'Log', private: 'true'
+  }, {
+    name: 'disc1\/Willie Nelson - The Essential Willie Nelson.m3u', source: 'original', mtime: '1510660124', size: '4252', md5: 'e0596e6c0903dd9c390890beeb11158f', crc32: '99d38346', sha1: 'd9757891b060bc9f129b6a11d468fab167add8f6', format: 'M3U', private: 'true'
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510663878', size: '24232', md5: 'b67bf21f62e89d77fd6f4dfef7792bda', crc32: 'aea25d94', sha1: 'a490b48ed962d379b34e4ba7b107a6ec28c550d1'
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', source: 'original', mtime: '1510659242', size: '18629435', md5: '51ef101da69c243395f5951b40ac7984', crc32: '549e2c21', sha1: '3b88ef85d6ba6e8f1f35a13abd4fb2cb572d082b', format: 'Flac', length: '186.49', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '1', album: 'The Essential Willie Nelson', title: 'My Heroes Have Always Been Cowboys', 'external-identifier': ['urn:acoustid:4272300d-ccde-4f06-b9f7-9c7327fe9b24', 'urn:mb_recording_id:b9374fc0-604c-400f-8e9c-568ab18ede5d', 'urn:spotify:track:0dlNwpfDzFIKdtuJSnHbzK', 'urn:youtube:vFDq0VMV-Vc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'My Heroes Have Always Been Cowboys', track: '1', album: 'The Essential Willie Nelson', bitrate: '175', length: '03:06', format: 'VBR MP3', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662598', size: '4191744', md5: '6b7a3e0df90e5fcd8a8a74984a1a9528', crc32: '1360bebb', sha1: '7be1a217df17af6f1fbc4e847bcd0d1c33415197', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662950', size: '12902', md5: 'bdd5072dcd614d4b60e02b0ced4b8326', crc32: '88978d8f', sha1: 'b75815ebc7764b2320e933402cb779e3c812ae6d'
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'My Heroes Have Always Been Cowboys', track: '1', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662718', size: '650240', md5: 'f4e74bb3e38f7bf24dda2440b76e4940', crc32: 'a836cd9e', sha1: 'bff298bf1b4506c342eda36479c264d362fe47bc', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510663501', size: '311306', md5: 'b54e63254d80a5c70f4a1b9f4a234d40', crc32: 'baa365a8', sha1: '513d5e0185342ffafba15603308a7e2183d7c0a4'
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510664125', size: '42088', md5: '7e9336f06b0e31741d3b75f66895182b', crc32: '214c5358', sha1: '73445d834023cdd1ba1671f270f25b16456ff140'
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', source: 'original', mtime: '1510659156', size: '23739790', md5: '42b8889e2b623999d688866b74debf07', crc32: '8da6685c', sha1: 'eb17d20e008ff49adf91f2b5f9110d29e2ee3157', format: 'Flac', length: '231.17', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Ray Price', track: '2', album: 'The Essential Willie Nelson', title: 'Faded Love', 'external-identifier': ['urn:acoustid:a918f9c9-e23c-436c-bd68-018e56fa2eef', 'urn:mb_recording_id:7e5f3a79-5315-4934-be5b-d27b67c3bf6f', 'urn:spotify:track:5AqdbGrt4nokb4nPLoI0Oq', 'urn:youtube:ESeyLLz82mE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.mp3', source: 'derivative', creator: 'Willie Nelson; Ray Price', title: 'Faded Love', track: '2', album: 'The Essential Willie Nelson', bitrate: '189', length: '03:51', format: 'VBR MP3', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662236', size: '5566976', md5: '5145411fb7aa2601370356ac83bd6b82', crc32: '237917fa', sha1: '61785fc24101842dd52178363fbf1158573f6ee7', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662906', size: '11429', md5: '2e303fc7b52337c4f6bf6b175319ab71', crc32: 'd889a2df', sha1: '098c54b427f55f9b8bcc26160ce3fa6d996df2e2'
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Ray Price', title: 'Faded Love', track: '2', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662707', size: '720896', md5: '4aa730360cc211baa775b7c12886e1cc', crc32: '90b357ca', sha1: 'b95a66ae54db5fa8966d3539cd8040cd3fad9f32', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510663510', size: '337703', md5: '1997d5910ade37708594c6634213685c', crc32: '25a1f53b', sha1: '0984ec112209b240c5ad1153096e94a2be097319'
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510663889', size: '29312', md5: 'f80e2820b17455b7176dd1eb0836dd7a', crc32: 'c1a22678', sha1: '5290fe4a6e6530089297d1b6650ae9fa1d7b16d7'
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', source: 'original', mtime: '1510660042', size: '16211519', md5: '85923ccf5c53c5fedf9a5e5912466c03', crc32: '6be92b5a', sha1: '334ad74df470252305646f5675f62da50d2b99d8', format: 'Flac', length: '153.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '3', album: 'The Essential Willie Nelson', title: 'On the Road Again', 'external-identifier': ['urn:acoustid:2eba5a50-1f18-4add-837f-67144bac3390', 'urn:mb_recording_id:54e0b867-2e65-4f9b-8d43-443406d81eb2', 'urn:spotify:track:1OmKo4t4Bh95xQI6WGiUR3', 'urn:youtube:dBN86y30Ufc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'On the Road Again', track: '3', album: 'The Essential Willie Nelson', bitrate: '197', length: '02:33', format: 'VBR MP3', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662627', size: '3893248', md5: '3b1d999857881b61d00540f3d7fcc335', crc32: '88510073', sha1: 'e68cec618aa240e5d0d87f7e0c39f13efbca3a1f', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662891', size: '12824', md5: 'e69e803f2a5c767a7a5ead5cecb5e521', crc32: 'b194ee50', sha1: '5724a74490928f7aff2a3f890a1f6313b6fd675f'
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'On the Road Again', track: '3', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662694', size: '718336', md5: 'de1957667b2519f59b807962c7e0af3e', crc32: '133285f6', sha1: 'be47db7c0b1460cd82bc0c41d2df347c5dbfeed9', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.03. Willie Nelson - On the Road Again_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510663505', size: '307815', md5: 'ed9140374b684ed2c710ce387d5f135e', crc32: '894944d4', sha1: 'c718e102b6df1301c1843f505bdd52b9f1778323'
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663902', size: '41680', md5: 'a012c56a71b1dec3015ba20ff5085b2d', crc32: '22143f42', sha1: '3b9fb1bfa7a7fac610fc477b9990ba20b23d300b'
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', source: 'original', mtime: '1510659227', size: '26677039', md5: '990be46ba4fda38b16bc0ff824989850', crc32: '8a5a6aef', sha1: 'ab56b60f50efb6422eb2dbd82da575452abf0c3e', format: 'Flac', length: '271.89', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '4', album: 'The Essential Willie Nelson', title: 'Angel Flying Too Close to the Ground', 'external-identifier': ['urn:acoustid:77abcc32-55af-4caf-a2ac-6d1bdf9850ba', 'urn:mb_recording_id:213e6995-fe80-43ff-835a-47960f8f7f9c', 'urn:spotify:track:6oYqwLEYsuw71VPCuwBRFS', 'urn:youtube:C3PB1jWO3_E'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Angel Flying Too Close to the Ground', track: '4', album: 'The Essential Willie Nelson', bitrate: '173', length: '04:31', format: 'VBR MP3', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510662846', size: '5980160', md5: 'a051960b857378adcb68eb6e99ff349b', crc32: '85e9cf8f', sha1: '76ab2ae3b6ac9674f00d15a0deee8302b3dbfbc4', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663333', size: '12683', md5: 'b6ee1c376ab44976fb5b9b7e98a91efd', crc32: 'b3ce0374', sha1: 'fa8d75a5a3107050044ede4aeafae936097ef664'
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Angel Flying Too Close to the Ground', track: '4', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510662288', size: '650240', md5: '462f0d376c02e0e2980d80c2bd69f9d4', crc32: 'd5fbf749', sha1: '12f52a13a12c2e536b53d10af16c02de03f0aea3', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663581', size: '319431', md5: '088c71c5dbee8b3857cf4a851b95afd0', crc32: '66a473ee', sha1: '701af24ca5603bec91e68c12573d98ce40fd5a99'
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663917', size: '31792', md5: '8e2db58d7fe73a067c59982db177d535', crc32: 'e1a410c2', sha1: '669eaec1dd227e57944b89a9d360ef44a08ab211'
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', source: 'original', mtime: '1510658588', size: '21154449', md5: 'a9885c85018350776085e5a82ff572e8', crc32: 'e8a7f6b0', sha1: 'f74019e05c7f309bf78fbe978f6fb946403477c3', format: 'Flac', length: '212.33', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '5', album: 'The Essential Willie Nelson', title: 'Always on My Mind', 'external-identifier': ['urn:acoustid:382bd49f-26e2-4a4c-b493-6d74c93778f2', 'urn:mb_recording_id:19d0be93-fdbc-4510-8a5e-c849967a927f', 'urn:spotify:track:2xYQTU2bbg6WVAmpY1eae4', 'urn:youtube:yoPYQ-FmQB4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Always on My Mind', track: '5', album: 'The Essential Willie Nelson', bitrate: '184', length: '03:32', format: 'VBR MP3', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510662784', size: '5001216', md5: '6c383c40d62ced4680c88c034481fbb3', crc32: 'b6e2fcbb', sha1: '302e63687328237727847f61162ccdea49b8a98d', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663377', size: '12781', md5: '29e9aa5d8ee4a84be01e504efcfccccc', crc32: 'e71930a0', sha1: 'ba893c0d63c2d17c872088074a5cf5ae8767b794'
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Always on My Mind', track: '5', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510662766', size: '678912', md5: '110078e343d2e3061075db1b5c128ba4', crc32: '8851ab11', sha1: 'ac7f4df61c1d964c07eb35636ae9c98776cc867e', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.05. Willie Nelson - Always on My Mind_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663591', size: '334965', md5: '06e41040217e098974fa7e84e5bf327d', crc32: '6aed6586', sha1: 'a2436d9f2ff26a9605f2d7124d3d3d76b2e1ca33'
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663940', size: '36536', md5: 'cb526a3381d8dd187b06d41595f1065f', crc32: '6a100f06', sha1: '6bf18d7d9ff8d19d4fc72870da3db126251c7b1d'
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', source: 'original', mtime: '1510658564', size: '25753244', md5: '96dd395a39eefae3648b557c98eff824', crc32: '1cf48ce6', sha1: 'eff80cefcce899ab32e2bb0198d62b5d48b624e5', format: 'Flac', length: '261.77', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '6', album: 'The Essential Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', 'external-identifier': ['urn:acoustid:a146d21f-df37-4a3a-bbc5-6fefaa1c29c1', 'urn:mb_recording_id:18cab4bd-e40a-4b9d-b01d-dc1788000138', 'urn:spotify:track:7viJvsSKvbL4aBGmTzg4vi', 'urn:youtube:vYpGEAwH1k0'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', track: '6', album: 'The Essential Willie Nelson', bitrate: '195', length: '04:21', format: 'VBR MP3', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510662805', size: '6497280', md5: 'd47f9ceed378fedd9d1bf99922b5e808', crc32: '72062da1', sha1: '0b371c02f4bf5d6e25a987820f50c7178eb288d6', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663315', size: '12679', md5: '59464d19a5fefa0b626132d89cef8fac', crc32: 'a353376f', sha1: '5cb91be6bfdabb42511c7f7f802b40f471acdd1a'
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', track: '6', album: 'The Essential Willie Nelson', bitrate: '159', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510662176', size: '706048', md5: '4bf6eb5ede17e058034d02169e11c413', crc32: 'd6f84b5a', sha1: 'f1fd02f8579c94248e650c8c0b1c855c7fb007b1', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663576', size: '334144', md5: '77209b74676bc4f6ee83bef79cf54f91', crc32: 'b17ebbb5', sha1: 'dfbfbb4bbd3c3452088c200e767e590296cc9382'
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663867', size: '44640', md5: '56a68a409a6420bfbe10a02bb6256558', crc32: 'b411d90c', sha1: '2eb27b5ce9e0f23b8002cf13b9d593b2c74baf6f'
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', source: 'original', mtime: '1510659169', size: '29907550', md5: 'ab6d56ec70f99c2cf15737f7a543864b', crc32: 'eda87cd6', sha1: '3bdcaad8841d1553dc70cca6eb1df8ec661ce4c7', format: 'Flac', length: '288.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Merle Haggard', track: '7', album: 'The Essential Willie Nelson', title: 'Pancho and Lefty', 'external-identifier': ['urn:acoustid:de01aaa5-e363-443e-ab03-fb64237bf0bd', 'urn:mb_recording_id:b6abc46a-b783-4eee-9236-0c7375551e03', 'urn:spotify:track:1A6P8IxzNyBRsQualaNXNY', 'urn:youtube:sT9NSmZFE_Q'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.mp3', source: 'derivative', creator: 'Willie Nelson; Merle Haggard', title: 'Pancho and Lefty', track: '7', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:48', format: 'VBR MP3', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510662098', size: '7293952', md5: '5c69760c9daf3c0e1e431c8e4c04acba', crc32: '27bd0bee', sha1: 'c2bd2ace145356f7bca3b74b6b38a3c91baeb430', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663392', size: '12782', md5: '40644aeeb5a38664373753ae1be1ba48', crc32: '362e4dca', sha1: '064a2693f97fab797fa590f113a1a2b311bfd85a'
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Merle Haggard', title: 'Pancho and Lefty', track: '7', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510662370', size: '722944', md5: '647e172b1f6b8b9116a98522c23d809d', crc32: '9abd301f', sha1: 'fb5b562ce0949a7905c6320dd4f7fcc0a1fa5f6a', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663525', size: '325976', md5: '5d065d47f07e1d598d53f0aeaa10e439', crc32: '24cc66bc', sha1: '49e510a4ae9ad063a8298056aef7042b42e7a752'
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.afpk", source: 'derivative', format: 'Columbia Peaks', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663788', size: '32368', md5: '77e80b367d10ca6966df3d3a09a7a3c7', crc32: '8cbe5c57', sha1: '610b4743d6d5b4d43881f43b0028777eea8a0307'
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", source: 'original', mtime: '1510658572', size: '24709923', md5: '43e24a569b1f1aa4099c20a70ccca23b', crc32: 'b127c537', sha1: 'cf1e1f318aaf628f95e42c191585d2bab5addbc0', format: 'Flac', length: '214.56', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Julio Iglesias', track: '8', album: 'The Essential Willie Nelson', title: "To All the Girls I've Loved Before", 'external-identifier': ['urn:acoustid:9b980594-7ffc-417e-8fc0-b3a5ca168d5f', 'urn:mb_recording_id:e80ff2a6-c33a-41a5-983e-11bf80eb876b', 'urn:spotify:track:2BhMmYodsANRcZohekmum8', 'urn:youtube:51tvZnkn5V8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.mp3", source: 'derivative', creator: 'Willie Nelson; Julio Iglesias', title: "To All the Girls I've Loved Before", track: '8', album: 'The Essential Willie Nelson', bitrate: '192', length: '03:34', format: 'VBR MP3', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510662077', size: '5254144', md5: 'ac27425b1a289d1283c40281a000cbe8', crc32: '669e299b', sha1: '3f9e5a544706140dd8fe3bf0c8c266b03902f844', height: '0', width: '0', private: 'true'
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.png", source: 'derivative', format: 'PNG', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663421', size: '12737', md5: 'dadfcb943d56c478fbb967b99691a1f3', crc32: 'f63c004c', sha1: '73c4cbbc01c27e385e2e680f775ea7bbc62a1738'
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before_sample.mp3", source: 'derivative', creator: 'Willie Nelson; Julio Iglesias', title: "To All the Girls I've Loved Before", track: '8', album: 'The Essential Willie Nelson', bitrate: '151', length: '00:30', format: 'MP3 Sample', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510662201', size: '675840', md5: '92f5bfd5a1a932d679b8e38b1fe10509', crc32: '29fa10ed', sha1: 'b5beb6e65a4c5a8f84774de9dbfa6f60cf9d0c11', height: '0', width: '0'
+  }, {
+    name: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before_spectrogram.png", source: 'derivative', format: 'Spectrogram', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663546', size: '330974', md5: 'c018771e02b46138547d634a714ce6fc', crc32: 'ba8714ab', sha1: 'acdd260d5f63bf087b9b370ed1a8d4b60cf972e7'
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510664142', size: '48440', md5: '13b0e230b4f1e6d1a8a3a93233cc430a', crc32: '3c12e20a', sha1: '1eea429f27411abd15ce0da7f2afa9849d36700f'
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', source: 'original', mtime: '1510660054', size: '34706236', md5: '2daa286a6117df9398a39950e34323ba', crc32: '793bb122', sha1: '1afe58f693c69799aaf6d91441dab2788edd5e4f', format: 'Flac', length: '292.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '9', album: 'The Essential Willie Nelson', title: 'City of New Orleans', 'external-identifier': ['urn:acoustid:06bb63f4-e364-402e-a2f6-05d8468f062f', 'urn:mb_recording_id:37870bd7-52b6-442e-a706-cf9752ee1ba5', 'urn:spotify:track:15qBdyeOsal1QJvB3ysW9g', 'urn:youtube:6XyRdJr4LSc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'City of New Orleans', track: '9', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:52', format: 'VBR MP3', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510662460', size: '7415296', md5: 'ef8a92b52c089477f89eea5ef2d35b76', crc32: '80e384bb', sha1: '1a8480fae994e692e9dec366efe1c32c39978855', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510663262', size: '11976', md5: 'fee490bc2dbf05f1d0c69fcc21266fd6', crc32: '74e35f60', sha1: '6e19a70765354a720514a997c916f8119d8fa0c3'
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'City of New Orleans', track: '9', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510662468', size: '681984', md5: '14651920b6e093083b75a756596cec3c', crc32: 'd3e04b0b', sha1: '7ffea3f5bb4868b0402bab3bdbe70dba94d0064e', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.09. Willie Nelson - City of New Orleans_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510663498', size: '312518', md5: 'b65a2f2e2a1926e5ceed7d0f03c4a822', crc32: '517b600b', sha1: '5c16a66b28b37053bc52f31afa0e1721f7544a35'
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510664157', size: '36936', md5: 'f256d9b134ac5de39fc452cef94fbec8', crc32: '5e0a7dc8', sha1: '89e890ccba67ebca535856ea88474423acd3fa8e'
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', source: 'original', mtime: '1510659188', size: '23485819', md5: 'd5cfc9a37c79bd60da109b855cca3964', crc32: '07150d8a', sha1: 'b0d4b0f3e703114a2403ff1ddce88a1d6555dd6d', format: 'Flac', length: '232.51', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Ray Charles', track: '10', album: 'The Essential Willie Nelson', title: 'Seven Spanish Angels', 'external-identifier': ['urn:acoustid:486a4e9f-579b-44c5-9cb9-cdc7081b9fde', 'urn:mb_recording_id:7fe0144a-077a-4a98-b545-229e7c188eba', 'urn:spotify:track:7i59jjqTqjNvEbDW2H8Z7R', 'urn:youtube:T4g7lYRGAx8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.mp3', source: 'derivative', creator: 'Willie Nelson; Ray Charles', title: 'Seven Spanish Angels', track: '10', album: 'The Essential Willie Nelson', bitrate: '182', length: '03:52', format: 'VBR MP3', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510662488', size: '5408256', md5: 'bd1a50cf6e2ae630f01d5f77673175dc', crc32: 'e71c2767', sha1: 'b0aea0a8605310ae9d3fdc46330a9c068c8f1ac9', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510663133', size: '12692', md5: '5ab0783fff97b9fa2c679dff05205675', crc32: 'd0afd998', sha1: '819fa3f53170e383dc7517dc21785ef425d0ce34'
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Ray Charles', title: 'Seven Spanish Angels', track: '10', album: 'The Essential Willie Nelson', bitrate: '154', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510662760', size: '687616', md5: 'be99b500e0666be73ce7973f3492f877', crc32: 'e8ef8a4e', sha1: '13aecd41fec9adb7a662118aa76bf344a1c650f0', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510663463', size: '339185', md5: 'ebd1dc8a7bdf17dfb082de5963bf1a8d', crc32: 'd1602ea6', sha1: 'f225f6edcebd073f28fde78980301a72e569bd06'
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510664170', size: '26144', md5: '8e34ca206608c853816f13d25b6ca812', crc32: 'ba604844', sha1: 'da1d9eb04518b2ee834e0141aaae9f6e1623ccd7'
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', source: 'original', mtime: '1510660063', size: '17991051', md5: '778661119a5cfe3a8e57e21eb6bf6912', crc32: 'de3a9944', sha1: 'fb4b81bc19b4863be29c3b27c4f16dc3525e8509', format: 'Flac', length: '169.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '11', album: 'The Essential Willie Nelson', title: 'Forgiving You Was Easy', 'external-identifier': ['urn:acoustid:e6b5fc08-26f6-4623-bf8c-ad5122cad960', 'urn:mb_recording_id:6671c4f3-69b4-4eb9-8df9-9f5c62018f7b', 'urn:spotify:track:7iV3RG0FKOAdQ93QVfPwR7', 'urn:youtube:sgPbslG-DTc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Forgiving You Was Easy', track: '11', album: 'The Essential Willie Nelson', bitrate: '193', length: '02:49', format: 'VBR MP3', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662517', size: '4190720', md5: '987c5e4670f43cc2049502adf371115a', crc32: 'db21338d', sha1: '63e697070d39f904a07edd79fe6451988c1e6113', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662918', size: '12162', md5: '6ca5d2bdc529d7a4e10f2976193b4e74', crc32: 'f8ef08d8', sha1: '7ae34e7e67c144a91125ec3f2c05d0de2ad73032'
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Forgiving You Was Easy', track: '11', album: 'The Essential Willie Nelson', bitrate: '157', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662754', size: '700416', md5: '7dbd84dc6ee15aaf822b51524e6b9c78', crc32: 'a10a444b', sha1: '9e237ae5b3440df2409a9ce7fe381a879ca13eae', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510663595', size: '324601', md5: '1fc35fae8c2eaa4092441b93e24573a3', crc32: '6d4ec9fa', sha1: '9380df61a442b6cfe60b4b2b25e5588f984cd8bc'
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510664193', size: '30528', md5: '29b0ab7c7d400c95883fee21e2f599f1', crc32: 'd2594514', sha1: '30c99d3f4e4851ad5837c986345dd8f3ec553e87'
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman.flac', source: 'original', mtime: '1510659176', size: '20894807', md5: '2fa00933acd008802a8628c5e1812ac8', crc32: 'bb38a207', sha1: '75abcae0c294f652547acff4738ecaec158686e7', format: 'Flac', length: '184.63', height: '640', width: '632', private: 'true', artist: 'The Highwaymen', track: '12', album: 'The Essential Willie Nelson', title: 'Highwayman', 'external-identifier': ['urn:acoustid:05112dbf-030f-433c-8f52-787128e20e09', 'urn:mb_recording_id:277494e7-bf84-4eda-8381-33b204c0a9de', 'urn:spotify:track:7jWbXvrgdbkajU8L28ahn5', 'urn:youtube:qFSA8-pxrqc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman.mp3', source: 'derivative', creator: 'The Highwaymen', title: 'Highwayman', track: '12', album: 'The Essential Willie Nelson', bitrate: '199', length: '03:04', format: 'VBR MP3', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662557', size: '4695552', md5: 'a7a5927fd07df78846016e6a52418163', crc32: 'e3eee71c', sha1: '1540718765e4ea8ffd37a809d0c7733ade5f38c3', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662939', size: '11536', md5: 'b54d7bafcbe5e854e7d4e6813a68bfd0', crc32: '72ecd006', sha1: '529a5e23e1bc56a206d24f39798b9802f95c1000'
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman_sample.mp3', source: 'derivative', creator: 'The Highwaymen', title: 'Highwayman', track: '12', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662605', size: '722432', md5: '312f94941090a9786e483e63652f5cdf', crc32: '9f352785', sha1: 'f4b9a5e3d089f34ec1c33ef44d1ffca0c8c6bcb6', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.12. The Highwaymen - Highwayman_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510663531', size: '327048', md5: '1c594cb956ad31d1c632a084866e2d66', crc32: '0eed4071', sha1: 'b2f580d47bb04f7e188c7909ea2781cff261ed12'
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510664208', size: '27712', md5: '4c3d7b390ae272bc54d7b8c1aa64ee3c', crc32: 'fec4aa16', sha1: 'a7db0a74567e4d3853d454ee364d2d54505c9379'
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', source: 'original', mtime: '1510659182', size: '19951678', md5: '906175fd53b02988af2efb66ef342c57', crc32: '94fac46a', sha1: '5a50faef1aa745b2a583a9fc0307fc66fb3d86bf', format: 'Flac', length: '202.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '13', album: 'The Essential Willie Nelson', title: 'Living in the Promiseland', 'external-identifier': ['urn:acoustid:27a24127-0ad5-4b8b-a5b5-ea03913c9df3', 'urn:mb_recording_id:27d94671-a95f-470d-886d-51ed498e4c7d', 'urn:youtube:wqIyIvL-gBs'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Living in the Promiseland', track: '13', album: 'The Essential Willie Nelson', bitrate: '188', length: '03:22', format: 'VBR MP3', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510662217', size: '4868096', md5: 'aab74ded5f0aa03af069f766b8d7958c', crc32: '16bf99b2', sha1: '9edf61fc7f83b4bdd882d3b4ff9380ac5cb369fb', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510663160', size: '12015', md5: 'cbf9d41348b355490ccc2050844453cf', crc32: '21080313', sha1: 'fa2afe0c1fab0152a4a2165ca296802b4b77645b'
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Living in the Promiseland', track: '13', album: 'The Essential Willie Nelson', bitrate: '158', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510662104', size: '704512', md5: 'e4cec454af563b197b0a86a74e1ed802', crc32: 'c312ae6e', sha1: '608d07a1c7dfe0bea1bca99618db2a4e3357d14e', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.13. Willie Nelson - Living in the Promiseland_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510663567', size: '322440', md5: '0ff74dfc5b8006c79ec4817063162759', crc32: '0c22a4b0', sha1: '4b2a02ae4a646eb445e4a87ded67ddf32dc1e2ea'
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510663774', size: '35672', md5: '0586116fa954eb06d7495e855018000f', crc32: '37e670f7', sha1: '10682acb54b04a05ae0124162634d3bcf2f70621'
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', source: 'original', mtime: '1510658614', size: '22986577', md5: '1ca35b679901e179e33cd454a0a2d022', crc32: 'a4582e42', sha1: 'aa59b26d91ea3f5b3f18fc606ac0e28a1e7791ec', format: 'Flac', length: '199.8', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '14', album: 'The Essential Willie Nelson', title: 'Nothing I Can Do About It Now', 'external-identifier': ['urn:acoustid:58bcbdac-7df2-4a1a-b932-a63d7c004ce7', 'urn:mb_recording_id:c55926b5-fa55-4209-a060-8949a14109bd', 'urn:spotify:track:0xbY7q5aImO8winKbVTIwo', 'urn:youtube:vAS5sbt-8yE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Nothing I Can Do About It Now', track: '14', album: 'The Essential Willie Nelson', bitrate: '185', length: '03:19', format: 'VBR MP3', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510661916', size: '4725760', md5: '5c15b136ba75aa7be286a2875b3ce16f', crc32: '314a982e', sha1: '338395efa70f5d0541d0617595c494b9408562b7', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510662878', size: '10155', md5: '9d6d44224e21d7bf4e3350a09b9dfe60', crc32: '0b3bae09', sha1: '5ada47792a07ddf65b0ba3e83220acc3d7e8e2d8'
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Nothing I Can Do About It Now', track: '14', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510662040', size: '651776', md5: '9c4cd5ea55cd091f07273dce13d59a76', crc32: 'ed6328e9', sha1: '27748e6b672a3e60a7f4f543867a230fc49b21e1', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510663553', size: '316129', md5: '43c7b31f66c40704685cddacb9c8b9a1', crc32: '8398e466', sha1: '0b7b7aa8f44b84980c245a875fcc5f738521d987'
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663967', size: '56056', md5: '3068e8b084049891808551f493007695', crc32: 'fcf031ce', sha1: '44ac14c96052c38c4f20f58f6015f93d48731e03'
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland.flac', source: 'original', mtime: '1510658598', size: '34383660', md5: 'c9c53078f8f912bb420a834ed49acf45', crc32: '46e324be', sha1: '901129d1a9634e22a9e9beb8757979efb69eada4', format: 'Flac', length: '286.13', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '15', album: 'The Essential Willie Nelson', title: 'Graceland', 'external-identifier': ['urn:acoustid:5031f621-e5f5-4288-9d49-24659fd6f3ed', 'urn:mb_recording_id:8f44f8e3-c87c-4cae-aeb9-b21b3f4db413', 'urn:spotify:track:6KRuBpMlAvHJuMKyHO32G4', 'urn:youtube:KId0MCDuD1I'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Graceland', track: '15', album: 'The Essential Willie Nelson', bitrate: '201', length: '04:46', format: 'VBR MP3', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510661943', size: '7317504', md5: 'dace8f28c0fa1fa3d45bbcca85365b89', crc32: '947289bd', sha1: '8191b9907df93f6a670483cb9e0bbc8a6944aad9', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663056', size: '9887', md5: '7b3f6e28a4e22e8e909c5ac9c1d2d97a', crc32: 'f5239d39', sha1: '5e7c994ff61c3c1c616046ffca34033afb0e2204'
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland_sample.mp3', source: 'derivative', creator: 'Willie Nelson', title: 'Graceland', track: '15', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510662681', size: '718336', md5: 'a1e5089ea8f3613a2749badc0ff4b098', crc32: '6e899e38', sha1: '2bdf0207c8e8dc8008f77bc31a66ab319087c8d0', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.15. Willie Nelson - Graceland_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663486', size: '303775', md5: '88bf32cb7748d118134da9b13225534c', crc32: '375d1aeb', sha1: 'b06da3276d847ff56b4fb432a9703b77b5d43311'
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663839', size: '36120', md5: 'af515ba4689c91be88e63277e1b0d2d3', crc32: 'b6adaa7c', sha1: 'e89b6a262c928fb952384309a4caaad73c2b11d9'
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', source: 'original', mtime: '1510658630', size: '23106845', md5: 'f6b5d9418e4016eda02b137948d348b3', crc32: '38ff4835', sha1: 'b05c21836e8d640d63f3dca61dfdd892cf17d4d8', format: 'Flac', length: '232.57', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Emmylou Harris', track: '16', album: 'The Essential Willie Nelson', title: 'Everywhere I Go', 'external-identifier': ['urn:acoustid:d9a9fd40-d0b8-4603-9430-167c00bd04a4', 'urn:mb_recording_id:2eb70150-c489-4b03-a766-52cd4527809c', 'urn:youtube:n50qI2AxEH8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.mp3', source: 'derivative', creator: 'Willie Nelson; Emmylou Harris', title: 'Everywhere I Go', track: '16', album: 'The Essential Willie Nelson', bitrate: '193', length: '03:52', format: 'VBR MP3', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510661969', size: '5717504', md5: '5a3fa3aa13dd7312e58ca2fa74691131', crc32: '9ea9ad66', sha1: '2b13608c06180fe4d0f02787f65b245904d87a5c', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663106', size: '11411', md5: '67867d6e977999d3963d31af328e286c', crc32: 'e58f3b9e', sha1: 'acfaeed09f69a7c87ae84c362292a88158cf3df9'
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Emmylou Harris', title: 'Everywhere I Go', track: '16', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510662612', size: '718848', md5: '12870e2d8e934fba1f1f624e1fc872d7', crc32: '99ea7892', sha1: '8d3656885df591199009dd5a7abd5548f63cc246', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663478', size: '336617', md5: '631186c1c5c5700342f78775ecf819b6', crc32: 'c111c67b', sha1: 'fbf5e188f10d519b69f70afdd1dd6a446fbc63aa'
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663952', size: '38480', md5: 'b3f484766da11671f4e6e2aa96b0f5cd', crc32: '217da072', sha1: '095a9cefa8da4e97d2b304c928f63ad0cc6bba17'
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', source: 'original', mtime: '1510659752', size: '25201170', md5: '2c13af1d36cf2b386b428c9e0ef5fa59', crc32: '3f4800d4', sha1: '93df01b0d647c97c3d7c615be2cca05beb4ac1c7', format: 'Flac', length: '242.47', height: '640', width: '632', private: 'true', artist: 'U2; Willie Nelson; Mickey Raphael on Harmonica', track: '17', album: 'The Essential Willie Nelson', title: 'Slow Dancing', 'external-identifier': ['urn:acoustid:bb1f67a5-0bfa-4d90-a87d-c4edc02398c7', 'urn:mb_recording_id:5fa38bd5-f3bf-4ff0-aa4f-c839627fa1fb', 'urn:youtube:nlPfmXu61CU'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.mp3', source: 'derivative', creator: 'U2; Willie Nelson; Mickey Raphael on Harmonica', title: 'Slow Dancing', track: '17', album: 'The Essential Willie Nelson', bitrate: '172', length: '04:02', format: 'VBR MP3', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510662004', size: '5320192', md5: '163e4675b6dca447b5ecb29830b2aa7d', crc32: 'b7a6ef94', sha1: '8e3917154e7d72dcb69ae3caf307e89abb9b351a', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663233', size: '11932', md5: 'c78ce40d6d806baff93d90ca09e24b91', crc32: 'd9a0c2d3', sha1: 'ebd8f2f67d9e0edd2a6acb8bbd52f897e3bc89cd'
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing_sample.mp3', source: 'derivative', creator: 'U2; Willie Nelson; Mickey Raphael on Harmonica', title: 'Slow Dancing', track: '17', album: 'The Essential Willie Nelson', bitrate: '141', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510662667', size: '639488', md5: '2340fbe6540427f84ce5144a26214ab2', crc32: '0e9402b6', sha1: 'a7bdae46ede1bfa7c1fa82908c554e76ecba3812', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663467', size: '323969', md5: '742965874040262dab3a806e8f1a6101', crc32: '6052eda9', sha1: 'e8e0e751b34fa16a0cc864c3a446eee322bb9fa2'
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663743', size: '50360', md5: '1424e7491f8324121f80a538d8b78f27', crc32: 'c6fa8e68', sha1: '026d8d0fdd57d126c137d0280dc5c8d819b368b7'
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', source: 'original', mtime: '1510659235', size: '32999010', md5: '1be57c89a67e85dabd38875e95b88e20', crc32: '9e6093cd', sha1: 'da35711125a3ec0a0bf8a4e3cd6b78956569d261', format: 'Flac', length: '273.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Lee Ann Womack', track: '18', album: 'The Essential Willie Nelson', title: 'Mendocino County Line', 'external-identifier': ['urn:acoustid:7cc23a37-8bff-4494-885c-fbed1762e0dc', 'urn:mb_recording_id:61235c66-6f84-48e5-80b8-f431d120a2cd', 'urn:spotify:track:4mgdl5v71oF18Tp4bM8bKX', 'urn:youtube:RZD6BNj67c8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.mp3', source: 'derivative', creator: 'Willie Nelson; Lee Ann Womack', title: 'Mendocino County Line', track: '18', album: 'The Essential Willie Nelson', bitrate: '195', length: '04:33', format: 'VBR MP3', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510662033', size: '6769664', md5: 'e8695e362d2c609ccfa5701ed625823a', crc32: 'd9a56ee6', sha1: 'f865a40bda9bd17f9cfb8d1a36a66cf5cc952fe6', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663183', size: '10117', md5: '3d0d817188cfd6325234ba7fb97ff3fd', crc32: 'a10ffbc8', sha1: 'aceb463a26904d706f03aded99789a0607d52942'
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Lee Ann Womack', title: 'Mendocino County Line', track: '18', album: 'The Essential Willie Nelson', bitrate: '153', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510662634', size: '686080', md5: '09977908178f4195c9401ec11bc6f490', crc32: 'c64054db', sha1: '0856e5070011f635ccc993f8c0b361f6e5dea934', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663460', size: '322099', md5: 'ed9046597beadafed66852a1e145ae73', crc32: '39fc3d4e', sha1: 'cc22f8c971716545d940268ae6a3f633a7c5839d'
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663763', size: '61400', md5: '6e94f52a090e07cf08805b466f1ea8f0', crc32: 'b39e7dbd', sha1: '59f89737291bdaa3fd46864f6bb8ade29909f302'
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', source: 'original', mtime: '1510659199', size: '36848126', md5: '649880a4b68de354c803e0dbfb5f2c82', crc32: 'baeb4fb2', sha1: 'd4a032871a49c26704913bc9bbaa2e385574acf4', format: 'Flac', length: '323.63', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Steven Tyler; Aerosmith', track: '19', album: 'The Essential Willie Nelson', title: 'One Time Too Many', 'external-identifier': ['urn:acoustid:02ba9afd-5042-42f9-b5c0-2a8b8da9f04a', 'urn:mb_recording_id:c295efa6-d108-4d32-9c14-45fa496302cb', 'urn:youtube:vgRIUArsP7o'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.mp3', source: 'derivative', creator: 'Willie Nelson; Steven Tyler; Aerosmith', title: 'One Time Too Many', track: '19', album: 'The Essential Willie Nelson', bitrate: '187', length: '05:23', format: 'VBR MP3', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510661896', size: '7660544', md5: '55ee957a1e6a038cdcb823082aec8e80', crc32: '5cb1f341', sha1: 'cf6758e09aaaf7a861a40123b58af660f8403678', height: '0', width: '0', private: 'true'
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.png', source: 'derivative', format: 'PNG', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663219', size: '8025', md5: '9a7dadfb2a3098528daba816aeb9fc6d', crc32: 'fb4bcecc', sha1: 'b00137a32e51ca290894a3987af142b8626c379e'
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many_sample.mp3', source: 'derivative', creator: 'Willie Nelson; Steven Tyler; Aerosmith', title: 'One Time Too Many', track: '19', album: 'The Essential Willie Nelson', bitrate: '156', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510662732', size: '694784', md5: '09e1f43b7e76be6d8c9f4ed82cbad95d', crc32: 'd280c27f', sha1: '5f7cf07a75b3e04993b43d503d275e999676a2b5', height: '0', width: '0'
+  }, {
+    name: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663455', size: '330912', md5: '783d42e2cdcd6cd76189a09e94197f09', crc32: '79aeaa8e', sha1: 'f5682c3cec7d83fcdb18bbf34a728ce38cf18d36'
+  }, {
+    name: 'disc2\/Willie Nelson - The Essential Willie Nelson.cue', source: 'original', mtime: '1510660067', size: '4751', md5: '4019c6f1f55a9615edd2c7bf0fec9e9c', crc32: '1dc0a024', sha1: 'c44f5e14a7f284c4c5e3a29ab9eae4183fb31902', format: 'Cue Sheet', private: 'true'
+  }, {
+    name: 'disc2\/Willie Nelson - The Essential Willie Nelson.log', source: 'original', mtime: '1510658550', size: '8011', md5: '4c5dc82b7b5147964c4300327a2b2d3f', crc32: '09aa4bbb', sha1: 'f639e3afa1fbca427d5cfdb3542bb4503625d993', format: 'Log', private: 'true'
+  }, {
+    name: 'disc2\/Willie Nelson - The Essential Willie Nelson.m3u', source: 'original', mtime: '1510658576', size: '3964', md5: 'd1ad92a265f130aac3d79cd736263a1b', crc32: '3e77120d', sha1: 'c689c6f857e92f39e248737a92cfe0a0f948deb6', format: 'M3U', private: 'true'
+  }],
+  files_count: 266,
+  item_size: 1459126554,
   metadata: {
-    identifier: ['cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul'], adaptive_ocr: ['true'], betterpdf: ['true'], boxid: ['IA1561409'], collection: ['acdc', 'archiveofcontemporarymusic', 'samples_only', 'audio_music'], 'collection-catalog-number': ['03-362'], contributor: ['Internet Archive'], country: ['US'], creator: ['Willie Nelson', 'Aerosmith', 'Emmylou Harris', 'Julio Iglesias', 'Lee Ann Womack', 'Leon Russell', 'Merle Haggard', 'Mickey Raphael on Harmonica', 'Ray Charles', 'Ray Price', 'Steven Tyler', 'The Highwaymen', 'U2', 'Waylon Jennings'], date: ['2003-04-01'], description: ["Tracklist:\n\nDisc 1:\n 1. Night Life\n 2. Hello Walls\n 3. Crazy\n 4. Funny How Time Slips Away\n 5. I Never Cared for You\n 6. The Party's Over\n 7. Good Times\n 8. Me and Paul\n 9. Shotgun Willie\n10. Bloody Mary Morning\n11. Blue Eyes Crying in the Rain\n12. Good Hearted Woman - Willie Nelson; Waylon Jennings\n13. If You've Got the Money I've Got the Time\n14. Uncloudy Day\n15. Mammas Don't Let Your Babies Grow Up to Be Cowboys - Willie Nelson; Waylon Jennings\n16. Georgia on My Mind\n17. Blue Skies\n18. All of Me\n19. Heartbreak Hotel - Willie Nelson; Leon Russell\n20. Help Me Make It Through the Night\n21. Whiskey River (live)\n22. Stay a Little Longer (live)\n\nDisc 2:\n 1. My Heroes Have Always Been Cowboys\n 2. Faded Love - Willie Nelson; Ray Price\n 3. On the Road Again\n 4. Angel Flying Too Close to the Ground\n 5. Always on My Mind\n 6. Last Thing I Needed First Thing This Morning\n 7. Pancho and Lefty - Willie Nelson; Merle Haggard\n 8. To All the Girls I've Loved Before - Willie Nelson; Julio Iglesias\n 9. City of New Orleans\n10. Seven Spanish Angels - Willie Nelson; Ray Charles\n11. Forgiving You Was Easy\n12. Highwayman - The Highwaymen\n13. Living in the Promiseland\n14. Nothing I Can Do About It Now\n15. Graceland\n16. Everywhere I Go - Willie Nelson; Emmylou Harris\n17. Slow Dancing - U2; Willie Nelson; Mickey Raphael on Harmonica\n18. Mendocino County Line - Willie Nelson; Lee Ann Womack\n19. One Time Too Many - Willie Nelson; Steven Tyler; Aerosmith"], 'external-identifier': ['urn:freedb_id:misc+2e0fff16', 'urn:freedb_id:country+07116c13', 'urn:freedb_id:blues+2e0fff16', 'urn:freedb_id:country+2e0fff16', 'urn:freedb_id:data+07116c13', 'urn:gracenote_id:40450702-6994172709B488B8D7673A286A755B45', 'urn:gracenote_id:40450118-D86849963D5B6420BD6772FBB64570DB', 'urn:mb_release_id:c78ad57e-1949-465e-a738-8ffd16d6b5dd', 'urn:mb_releasegroup_id:1d98f3e2-86ef-39f0-9c63-961027032ab7', 'urn:upc:696998674028'], language: ['eng'], mediatype: ['audio'], ppi: ['600'], publisher: ['Legacy'], 'publisher-catalog-number': ['TV2K 86740'], scandate: ['20171114084720'], scanner: ['archivecd-hk03 (ArchiveCD Version 2.1.40)'], scanningcenter: ['hongkong'], software_version: ['ArchiveCD Version 2.1.40'], source: ['CD'], 'source-id': ['musicbrainz.org'], sponsor: ['Kahle_Austin Foundation'], title: ['The Essential Willie Nelson'], 'total-time': ['898'], publicdate: ['2017-11-14 08:47:27'], addeddate: ['2017-11-14 08:47:27'], curation: ['[curator]validator@archive.org[\/curator][date]20171114084749[\/date][comment]checked for malware[\/comment]'], 'identifier-access': ['http:\/\/archive.org\/details\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul'], 'identifier-ark': ['ark:\/13960\/t6160xm1j'], imagecount: ['16'], ocr: ['ABBYY FineReader 11.0 (Extended OCR)'], external_metadata_update: ['2018-12-17T17:17:49Z']
+    identifier: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul', adaptive_ocr: 'true', betterpdf: 'true', boxid: 'IA1561409', collection: ['acdc', 'archiveofcontemporarymusic', 'samples_only', 'audio_music'], 'collection-catalog-number': '03-362', contributor: 'Internet Archive', country: 'US', creator: ['Willie Nelson', 'Aerosmith', 'Emmylou Harris', 'Julio Iglesias', 'Lee Ann Womack', 'Leon Russell', 'Merle Haggard', 'Mickey Raphael on Harmonica', 'Ray Charles', 'Ray Price', 'Steven Tyler', 'The Highwaymen', 'U2', 'Waylon Jennings'], date: '2003-04-01', description: "Tracklist:\n\nDisc 1:\n 1. Night Life\n 2. Hello Walls\n 3. Crazy\n 4. Funny How Time Slips Away\n 5. I Never Cared for You\n 6. The Party's Over\n 7. Good Times\n 8. Me and Paul\n 9. Shotgun Willie\n10. Bloody Mary Morning\n11. Blue Eyes Crying in the Rain\n12. Good Hearted Woman - Willie Nelson; Waylon Jennings\n13. If You've Got the Money I've Got the Time\n14. Uncloudy Day\n15. Mammas Don't Let Your Babies Grow Up to Be Cowboys - Willie Nelson; Waylon Jennings\n16. Georgia on My Mind\n17. Blue Skies\n18. All of Me\n19. Heartbreak Hotel - Willie Nelson; Leon Russell\n20. Help Me Make It Through the Night\n21. Whiskey River (live)\n22. Stay a Little Longer (live)\n\nDisc 2:\n 1. My Heroes Have Always Been Cowboys\n 2. Faded Love - Willie Nelson; Ray Price\n 3. On the Road Again\n 4. Angel Flying Too Close to the Ground\n 5. Always on My Mind\n 6. Last Thing I Needed First Thing This Morning\n 7. Pancho and Lefty - Willie Nelson; Merle Haggard\n 8. To All the Girls I've Loved Before - Willie Nelson; Julio Iglesias\n 9. City of New Orleans\n10. Seven Spanish Angels - Willie Nelson; Ray Charles\n11. Forgiving You Was Easy\n12. Highwayman - The Highwaymen\n13. Living in the Promiseland\n14. Nothing I Can Do About It Now\n15. Graceland\n16. Everywhere I Go - Willie Nelson; Emmylou Harris\n17. Slow Dancing - U2; Willie Nelson; Mickey Raphael on Harmonica\n18. Mendocino County Line - Willie Nelson; Lee Ann Womack\n19. One Time Too Many - Willie Nelson; Steven Tyler; Aerosmith\n\n", 'external-identifier': ['urn:discogs:master:330621', 'urn:discogs:release:1738288', 'urn:freedb_id:misc+2e0fff16', 'urn:freedb_id:country+07116c13', 'urn:freedb_id:blues+2e0fff16', 'urn:freedb_id:country+2e0fff16', 'urn:freedb_id:data+07116c13', 'urn:gracenote_id:40450702-6994172709B488B8D7673A286A755B45', 'urn:gracenote_id:40450118-D86849963D5B6420BD6772FBB64570DB', 'urn:mb_release_id:c78ad57e-1949-465e-a738-8ffd16d6b5dd', 'urn:mb_releasegroup_id:1d98f3e2-86ef-39f0-9c63-961027032ab7', 'urn:upc:696998674028'], language: 'eng', mediatype: 'audio', ppi: '600', publisher: 'Legacy', 'publisher-catalog-number': 'TV2K 86740', scandate: '20171114084720', scanner: 'archivecd-hk03 (ArchiveCD Version 2.1.40)', scanningcenter: 'hongkong', software_version: 'ArchiveCD Version 2.1.40', source: 'CD', 'source-id': 'musicbrainz.org', sponsor: 'Kahle_Austin Foundation', title: 'The Essential Willie Nelson', 'total-time': '898', publicdate: '2017-11-14 08:47:27', uploader: 'associate-yin-chau@archive.org', addeddate: '2017-11-14 08:47:27', curation: '[curator]validator@archive.org[/curator][date]20171114084749[/date][comment]checked for malware[/comment]', 'identifier-access': 'http://archive.org/details/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul', 'identifier-ark': 'ark:/13960/t6160xm1j', imagecount: '16', ocr: 'ABBYY FineReader 11.0 (Extended OCR)', external_metadata_update: '2019-04-16T06:12:54Z', backup_location: 'ia906600_16', 'bookreader-defaults': 'mode/1up'
   },
-  reviews: {
-    info: { num_reviews: 1, avg_rating: '2.00' },
-    reviews: [{
-      reviewbody: 'Why only 30 seconds each of these great songs?', reviewtitle: 'Only 30 seconds', reviewer: 'DrAMarx', reviewer_itemname: '@dramarx', reviewdate: '2018-08-09 20:00:05', stars: '2'
-    }]
-  },
-  files:
-  {
-    '\/__ia_thumb.jpg': {
-      source: 'original', mtime: '1530533494', size: '13007', format: 'JPEG Thumb', rotation: '0', md5: 'a21459bc4e2e7bec054ba62d6a74e978', crc32: '7d1f7811', sha1: '49c1897299aedf533badf137205ea2c5fa8782d9'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul.pdf': {
-      source: 'derivative', format: 'Text PDF', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz', mtime: '1510664666', size: '10486635', md5: '909bb837a391d97b093123c8e65fa03e', crc32: '216c390a', sha1: 'c41b56b1a8bffee9bf384263c4f89eaf1aca7a95'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz': {
-      source: 'derivative', format: 'Abbyy GZ', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_jp2.zip', mtime: '1510664395', size: '521284', md5: '6983645d2d8b5fb2dc77585f96e10bc4', crc32: 'd125ab27', sha1: '26228c0add83487c4170bfe7e1a0e6202f959abe'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.txt': {
-      source: 'derivative', format: 'DjVuTXT', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml', mtime: '1510664468', size: '36233', md5: '4fe53972df4bff6bdaf09cdbd3907a13', crc32: '0e941be9', sha1: '031dd3d779858cd8d2cf207d417e23080af9e616'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml': {
-      source: 'derivative', format: 'Djvu XML', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_abbyy.gz', mtime: '1510664442', size: '399233', md5: '8a8476d631b1d2cad8f5fd93b44c5a50', crc32: '4fd48917', sha1: 'dfd31a1059e126535b4d4e938d4c5915819d2e96'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_files.xml': { source: 'original', format: 'Metadata', md5: '69e448e11525868b2bce9a47490f42e9' },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_images.zip': {
-      source: 'original', mtime: '1510658535', size: '281226853', md5: '1a746677e0c6eb853fe6010a3a1389aa', crc32: 'de838840', sha1: '9768be2ececa893a54f0f14f5352d3df8980bd7e', format: 'Generic Raw Book Zip', private: 'true'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_itemimage.png': {
-      source: 'original', mtime: '1510658540', size: '731313', md5: '2cd8341c95ca937ce7f5865f4162b344', crc32: 'e3236fab', sha1: '1cc5a875eca715de5417aa5301f4318bb157e7bb', format: 'Item Image'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_jp2.zip': {
-      source: 'derivative', format: 'Single Page Processed JP2 ZIP', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_images.zip', mtime: '1510663687', size: '16442232', md5: '4f2dd9141f8e0041c8c3e4d73eade0ff', crc32: '48800a71', sha1: 'c2646121af00316d05e8ca6422d5a604bf3d8ce1'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_meta.sqlite': {
-      source: 'original', mtime: '1510661684', size: '73728', format: 'Metadata', md5: '065d59d79deb8b5662f3011244524778', crc32: 'ad3510a3', sha1: 'a866c4d12727d4d68053d3a8a700f1202f3bad16'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_meta.xml': {
-      source: 'original', mtime: '1545067231', size: '4596', format: 'Metadata', md5: 'f2beaa4f5b2a2e72719e70948f14301f', crc32: 'b5f93f63', sha1: '4006068edcbd357dd49a86de1e4940d5bce2c80b'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_reviews.xml': {
-      source: 'original', mtime: '1533844806', size: '587', md5: '1e947a7784a580ef323af7796ccf062d', crc32: '1f3dbd40', sha1: '54954cc9b73335c018ae0244f56b03558eba1ee5', format: 'Metadata'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_scandata.json': {
-      source: 'original', mtime: '1510658545', size: '224040', md5: 'f2e02f2b3a2e8b2e37118ccb8821c559', crc32: '94f2886d', sha1: 'ee23b248e7ea88977421e2e8b54acd1d7fabddc5', format: 'Scandata JSON', private: 'true'
-    },
-    '\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_scandata.xml': {
-      source: 'derivative', format: 'Scandata', original: 'cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_djvu.xml', mtime: '1510664467', size: '4760', md5: '1ce519a034f2e11135608e46cedf1a76', crc32: '86c22866', sha1: 'cc46f9bcd3626732c60055cf85fbd2f91f1e635a', private: 'true'
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663724', size: '23672', md5: '2d62085edd86e4f90516d75934645aff', crc32: '46532c1b', sha1: 'ba6b66cd23be07cecbf36db5f9aaa8fab5ce0670'
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life.flac': {
-      source: 'original', mtime: '1510661196', size: '11076392', md5: 'f9bb53b79851b621e986c4c2db2f7c24', crc32: '46e1e9b0', sha1: 'f2cdd7039262199b494476e70798711b28e50e50', format: 'Flac', length: '152.43', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '1', album: 'The Essential Willie Nelson', title: 'Night Life', 'external-identifier': ['urn:acoustid:13ed3700-7bda-4877-a2a1-d7e4630dd882', 'urn:mb_recording_id:1865ddbb-b8ba-4b3a-b12d-52b0a5297ab7', 'urn:spotify:track:5UeDQvUkdJuK3QVcri2jZ9', 'urn:youtube:69w7A8qb-SU'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Night Life', track: '1', album: 'The Essential Willie Nelson', bitrate: '133', length: '02:32', format: 'VBR MP3', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510662051', size: '2650624', md5: 'd38fdf12c65b4d4f3a40876e00225040', crc32: '659b6041', sha1: '4efb5861f0eae5a35e842497d05f9d9668e3933c', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663065', size: '12551', md5: '6356323b3f8cae8623cd27775afc7d63', crc32: '55070dec', sha1: '1cb4efffb02ff37d47050327480b8e378d7d7bd8'
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Night Life', track: '1', album: 'The Essential Willie Nelson', bitrate: '108', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510662255', size: '514560', md5: '6beff838f9805e0e53d661cdc7f58325', crc32: '447db8a5', sha1: 'ac10d01321a3aba6d359657b7a849b01735769e8', height: '0', width: '0'
-    },
-    '\/disc1\/01.01. Willie Nelson - Night Life_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.01. Willie Nelson - Night Life.flac', mtime: '1510663474', size: '284561', md5: '0ce5ab9d2afe51938666d93d33e030e1', crc32: '1ebf9a8c', sha1: '4237468f3bcb86cffe182ecdda28167803c3ab08'
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510664181', size: '21680', md5: 'dcb09d734ff55d52a80e77e73618beee', crc32: '7c2d6a5b', sha1: '18dcc02f04ac0914b8cdd5a1b0747e119883c40d'
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls.flac': {
-      source: 'original', mtime: '1510660072', size: '15743992', md5: 'cb684f2a12c96b6590f5119b888e4505', crc32: '96a5e7b5', sha1: 'fc90ead09468d75887547ddcc4ad202b33b7d735', format: 'Flac', length: '144.71', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '2', album: 'The Essential Willie Nelson', title: 'Hello Walls', 'external-identifier': ['urn:acoustid:f0a1a191-115f-41e0-bf39-430fb7811165', 'urn:mb_recording_id:38e3036a-68de-4ca9-b577-5b86137f3e39', 'urn:spotify:track:275SxfFiepqWJeKXvNlGKq'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Hello Walls', track: '2', album: 'The Essential Willie Nelson', bitrate: '184', length: '02:24', format: 'VBR MP3', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662401', size: '3445760', md5: '8d6a01bdb384a125b7d5b3742f53a812', crc32: 'd160e68a', sha1: 'fd1e98cd17007fc9a4b25ef2240b780fc8c942dc', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662927', size: '12530', md5: '35048d8617296b65aaec96a6aac07bd2', crc32: 'ce9c1c99', sha1: 'd9a3416c446f7b3476fd5675c27cce708f339f49'
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Hello Walls', track: '2', album: 'The Essential Willie Nelson', bitrate: '158', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510662057', size: '702976', md5: 'dc065c9ef43d764c1f3129471c5b3e2b', crc32: '274b5f0f', sha1: 'f3b0827450963842f554719248349b97e1047f57', height: '0', width: '0'
-    },
-    '\/disc1\/01.02. Willie Nelson - Hello Walls_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.02. Willie Nelson - Hello Walls.flac', mtime: '1510663520', size: '298042', md5: 'd7b53e1c4fa848bb5d63edfb0d8d29ed', crc32: '5fbe1905', sha1: 'e0952809f7cb1617a7d3a190f9117f97cc6a98dd'
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663927', size: '21952', md5: '668c2af15921d87a2a247c7e0c7c4537', crc32: '5edfb104', sha1: 'ba476dad7f745d6d7ceab9ad23db8c82f8f8bace'
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy.flac': {
-      source: 'original', mtime: '1510660079', size: '17858502', md5: 'fe36fe14ef07581a914428c838310bcc', crc32: '8d2eb6e6', sha1: '031a61f92711aa891dd44f5857c6c9623607de70', format: 'Flac', length: '172.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '3', album: 'The Essential Willie Nelson', title: 'Crazy', 'external-identifier': ['urn:acoustid:b00ec726-148c-4389-b4a2-717ee49d45b7', 'urn:mb_recording_id:a68b9249-86f1-42e9-9b60-df04a49fe230', 'urn:spotify:track:0xqtcLB45iKNfHroi5y1em'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Crazy', track: '3', album: 'The Essential Willie Nelson', bitrate: '176', length: '02:52', format: 'VBR MP3', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510662859', size: '3899904', md5: 'ffee2a19f1d090ef91f69cbc22d97e1a', crc32: 'b97ced01', sha1: '09b8133e7f67cf674535eee2df4b8c976075294d', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663022', size: '12825', md5: '13abab1737d348080412875dc8beb056', crc32: '43ec12fc', sha1: '9e3c45712cb1707be224534d245bf52c7809a3d2'
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Crazy', track: '3', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510661950', size: '668160', md5: '9b1d1d98c338d8ef3a3decfb050e8ab5', crc32: 'be090614', sha1: '161e74fcc103f449e9fbf32442642fa89d42701f', height: '0', width: '0'
-    },
-    '\/disc1\/01.03. Willie Nelson - Crazy_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.03. Willie Nelson - Crazy.flac', mtime: '1510663528', size: '283473', md5: 'a2f351a7e575e19f1e00ee2b3f585104', crc32: '26df5da2', sha1: '0e4c17d69b0f0f290e4509a293c5340a9d5829bb'
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663825', size: '24624', md5: '798f7d7b4ba0bc3c6d097655a9f19a6b', crc32: 'c8d8f880', sha1: '1848b47a536b9fceb8f881ab8affa7a12640c4e8'
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac': {
-      source: 'original', mtime: '1510660095', size: '18536530', md5: 'a26636bfa6885338845d2dc4c394de1a', crc32: 'c88d2e03', sha1: '58e353eb94cbd45d1b100f29690fbbb173f70b7c', format: 'Flac', length: '183', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '4', album: 'The Essential Willie Nelson', title: 'Funny How Time Slips Away', 'external-identifier': ['urn:acoustid:6936c03a-96bd-49af-8e80-6dd6cf884161', 'urn:mb_recording_id:a8580492-9df6-4690-9ffe-1abe6ecb6e46', 'urn:spotify:track:6Sr2e5J7WnRJ7sLpUpyie9'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z']
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Funny How Time Slips Away', track: '4', album: 'The Essential Willie Nelson', bitrate: '175', length: '03:03', format: 'VBR MP3', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510662580', size: '4119552', md5: '3a81db9205d03f484f9981bb39f36001', crc32: 'db059fac', sha1: 'a3a403d00e3ed54f977d3633168ad05f6131080f', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663363', size: '12312', md5: '516bf955df2e0ecd46a7be1845194c4d', crc32: '837268dd', sha1: 'c73dfc1cd98947c4e1a69d6983e69fe82f79d36b'
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Funny How Time Slips Away', track: '4', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510662712', size: '668672', md5: '083ceaf86ecdf1a49ec3cd9f373fd98e', crc32: 'ba6b0dfd', sha1: '0fd3b7ec133c71e7d5b7cd2acf120dd117739316', height: '0', width: '0'
-    },
-    '\/disc1\/01.04. Willie Nelson - Funny How Time Slips Away_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.04. Willie Nelson - Funny How Time Slips Away.flac', mtime: '1510663493', size: '274751', md5: '9ff5a8394ba1dd5707fa26a8d64a537c', crc32: 'baaf167a', sha1: '074261453367bd67efeada6c55b03a9fc6e3129b'
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510664218', size: '25744', md5: 'c4e72f029408b245fe3d236248eb51fa', crc32: 'ffc11a62', sha1: 'f614c94715048f950ceacef9d0dfee7fa3c38500'
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You.flac': {
-      source: 'original', mtime: '1510660114', size: '15098908', md5: '247a3bd87cb96c2134ac7d5c119c2743', crc32: '12c70717', sha1: '731937b1396a09951cc86e8a24bbf1d761168923', format: 'Flac', length: '152.53', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '5', album: 'The Essential Willie Nelson', title: 'I Never Cared for You', 'external-identifier': ['urn:acoustid:e11149ee-7819-4b8e-b017-d6df957e3345', 'urn:mb_recording_id:cc050cd0-b814-4aa0-93ce-e34d3ce14771', 'urn:spotify:track:4c8uCy3cc92cbGTmVD9oS7', 'urn:youtube:hEr23gTL0JA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'I Never Cared for You', track: '5', album: 'The Essential Willie Nelson', bitrate: '207', length: '02:32', format: 'VBR MP3', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510661983', size: '4049408', md5: 'dfcc8e587bff32068ba2aff11ef62f22', crc32: '87958603', sha1: 'c37c96611944323548d97a8e41a10d8fcf866e3c', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510662984', size: '11872', md5: 'c5679c64bc04e72c36cf1e9c319b60c4', crc32: 'b4dbb6a8', sha1: 'f61e83cd870817fd56367db3868770ddf7854579'
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'I Never Cared for You', track: '5', album: 'The Essential Willie Nelson', bitrate: '180', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510662655', size: '786432', md5: '9c687c87221f417e57ce2a3ac13e7e35', crc32: 'e584c231', sha1: '854eb35c461df7689620793a2c214be24dc36b20', height: '0', width: '0'
-    },
-    '\/disc1\/01.05. Willie Nelson - I Never Cared for You_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.05. Willie Nelson - I Never Cared for You.flac', mtime: '1510663517', size: '324128', md5: 'db6700f9dd4aa124b45a2a0a49a5e66f', crc32: '76d63834', sha1: '9d51b47e8a8695371461ac5f55b8b2fcbb7dcfce'
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over.afpk": {
-      source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510664037', size: '23200', md5: '2242cc9260c65d4ddd0381e53a6ddbb6', crc32: 'f23d296d', sha1: '56d0830d994c6331b042d21b29de3665cb972380'
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over.flac": {
-      source: 'original', mtime: '1510661233', size: '16281998', md5: '00af9c03b91d94054ea4e04d3f96564a', crc32: 'a14acb5e', sha1: 'd3206ecd4a0fc053a41c1a02b38a5e199e1c5ba2', format: 'Flac', length: '149.8', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '6', album: 'The Essential Willie Nelson', title: "The Party's Over", 'external-identifier': ['urn:acoustid:e031ebab-e7c8-4a1a-b481-d2e34abc32e7', 'urn:mb_recording_id:8dae4e64-2413-4c28-8e40-43986a2fee82', 'urn:spotify:track:3A9jxTBQFZ2p5AjaMhJu6y', 'urn:youtube:QoQZ0qmf-mk'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over.mp3": {
-      source: 'derivative', creator: 'Willie Nelson', title: "The Party's Over", track: '6', album: 'The Essential Willie Nelson', bitrate: '195', length: '02:29', format: 'VBR MP3', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510662249', size: '3755008', md5: 'e13019a367d1c4e302c40bd649679e8e', crc32: '7a8b85cd', sha1: 'aedd8635b00090a80e49d7d58d93d27cc5d20b69', height: '0', width: '0', private: 'true'
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over.png": {
-      source: 'derivative', format: 'PNG', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510663147', size: '12894', md5: '2f1b0e0089614c46792ff753f01c1e66', crc32: 'a113f9d1', sha1: '3322338c52637d666070a0f298a8c45e5edc5dd7'
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over_sample.mp3": {
-      source: 'derivative', creator: 'Willie Nelson', title: "The Party's Over", track: '6', album: 'The Essential Willie Nelson', bitrate: '166', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510662564', size: '733696', md5: 'f22e4de4135ef4d0a029c519d6164190', crc32: '7a7d1984', sha1: '8724d12dc53a0724ee38f6ac9beee5b2999d3b53', height: '0', width: '0'
-    },
-    "\/disc1\/01.06. Willie Nelson - The Party's Over_spectrogram.png": {
-      source: 'derivative', format: 'Spectrogram', original: "disc1\/01.06. Willie Nelson - The Party's Over.flac", mtime: '1510663490', size: '308439', md5: 'd5dc4306fe44166607426ac5ec62d7e3', crc32: '96f20655', sha1: 'a32ab03374a57db933bd37257bfbbcfbd3442a7a'
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510664001', size: '20392', md5: '8e10a9669a1be0621c418d0c5aca3632', crc32: '4d7d5c03', sha1: '3d735b340c57a23dc95fc1779de36755aa0a1523'
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times.flac': {
-      source: 'original', mtime: '1510660992', size: '14111627', md5: 'ce14f7e70527b151c8fa4bbd2b25658f', crc32: '15c1ae49', sha1: '589fd2a621830b271c1215408a5a49b22f764d68', format: 'Flac', length: '148.07', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '7', album: 'The Essential Willie Nelson', title: 'Good Times', 'external-identifier': ['urn:acoustid:b2303076-0168-4006-ad84-193e1c7d68a7', 'urn:mb_recording_id:33d1efe7-c026-426a-9077-4224239fefd9', 'urn:spotify:track:1kvft1Zif8xbTX14zxdYef', 'urn:youtube:ETZ7J7MSKGM'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-10-22T23:45:34Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Good Times', track: '7', album: 'The Essential Willie Nelson', bitrate: '200', length: '02:28', format: 'VBR MP3', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510662414', size: '3814400', md5: '610873a8fafad01285d45638a52230f9', crc32: 'b29b060a', sha1: '2363ea936dabe7a2c1810994242859b3b60d642f', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510663270', size: '13482', md5: '76df0a61493e6bac0837f04c42189e0a', crc32: '17b1d157', sha1: '25bc9cb9fa15b614888deee244b59308f277f93e'
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Good Times', track: '7', album: 'The Essential Willie Nelson', bitrate: '178', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510662700', size: '779264', md5: 'f82b584dcf82c3eaa4559f896f1a772f', crc32: 'ed8251cf', sha1: '111db290f5a8baf2491303d31a04e177bc67cd6e', height: '0', width: '0'
-    },
-    '\/disc1\/01.07. Willie Nelson - Good Times_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.07. Willie Nelson - Good Times.flac', mtime: '1510663447', size: '296523', md5: '4cc879b6a6362823c492317eb3be6a62', crc32: 'b385fe11', sha1: 'e898c06fb191264e5de4241dca979d11e33abe43'
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510664016', size: '37592', md5: 'faf00338a9ca9d9570c253570f86c52e', crc32: '61b6d594', sha1: '640dbd94a1b647d536948b62b8fef01434acba22'
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul.flac': {
-      source: 'original', mtime: '1510660975', size: '23284478', md5: 'b0d241b0421489e8aeef50ce32adfe43', crc32: 'ac8da23f', sha1: '19fde60424a9e1532d33a9ab9140fb777687a172', format: 'Flac', length: '229.09', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '8', album: 'The Essential Willie Nelson', title: 'Me and Paul', 'external-identifier': ['urn:acoustid:5077d27a-99fe-42a5-8399-4acbf538aa16', 'urn:mb_recording_id:8d42f6c3-4204-4ca3-9ca1-1b53978c777e', 'urn:spotify:track:4vcDnnuHUmombz20IRkzRO', 'urn:youtube:4uSFw165Qk0'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Me and Paul', track: '8', album: 'The Essential Willie Nelson', bitrate: '205', length: '03:49', format: 'VBR MP3', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510662323', size: '5992448', md5: '27cb6a1614f9736b862dd481b3113798', crc32: '266b2894', sha1: '706c773a3cea8c6b09474358ccb55e8dde2f7fb4', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510663037', size: '12008', md5: '805895f6d3574f8bcde27bff1a49fc82', crc32: '75eee56f', sha1: 'd415a307420353b7a5884b38e85fd43f360ecf0b'
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Me and Paul', track: '8', album: 'The Essential Willie Nelson', bitrate: '174', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510662641', size: '763392', md5: '7ba3dfbec2ae5479368c7c9a3ab0e7a3', crc32: '76473a8a', sha1: '4f1c3222f972cbec2d9ac6eca6bc2d9e2e24f159', height: '0', width: '0'
-    },
-    '\/disc1\/01.08. Willie Nelson - Me and Paul_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.08. Willie Nelson - Me and Paul.flac', mtime: '1510663482', size: '309073', md5: 'a95fa8ac4725331b07cef247d8c80103', crc32: '9603a9dc', sha1: 'ac850983e9ba32fb134ddea80d3be0ea71479075'
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510664028', size: '30624', md5: '9bd7c71376c2d9714650e03cfc610082', crc32: 'cb965c4f', sha1: '4ff01b0cae430e804d1098dc3e7a590414a435b3'
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie.flac': {
-      source: 'original', mtime: '1510661664', size: '17577936', md5: '54caa5bf7538e43bf18038568e491ea8', crc32: 'a988b49e', sha1: 'a5c1aad618c2aec6abc34df9e871dd5ee77f69f6', format: 'Flac', length: '159.71', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '9', album: 'The Essential Willie Nelson', title: 'Shotgun Willie', 'external-identifier': ['urn:acoustid:cb115b18-519a-4229-8119-0b419e82c008', 'urn:mb_recording_id:e3a1580c-2bee-4c9b-843b-46a9d6263f2f', 'urn:spotify:track:7fMOzTcT7U5A9hVCwCfWgD', 'urn:youtube:eK-7k8MHvnE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Shotgun Willie', track: '9', album: 'The Essential Willie Nelson', bitrate: '199', length: '02:39', format: 'VBR MP3', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510662269', size: '4082688', md5: '2091d3a2636ed27c49cc7e2eb7e2628f', crc32: '6e88d14b', sha1: 'aa7950b6f428851cbe90d9f4b93b843eb71c294d', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510663118', size: '12689', md5: 'cdd144071cc39fbd1fbee6eac070be9d', crc32: 'aca1e12a', sha1: '306f0dea007649c681bd9f9da3205741a7b32c51'
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Shotgun Willie', track: '9', album: 'The Essential Willie Nelson', bitrate: '164', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510662649', size: '726016', md5: '1fc170a37ed4abc55e3987a2fa20f6bc', crc32: '3000b2eb', sha1: 'b034e85f4403581542a5eda2246155ea7fae7d89', height: '0', width: '0'
-    },
-    '\/disc1\/01.09. Willie Nelson - Shotgun Willie_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.09. Willie Nelson - Shotgun Willie.flac', mtime: '1510663560', size: '314258', md5: '9dd9fa2a0ee724878a9577eacb0040c1', crc32: '5eccc3e9', sha1: '805199cbad0e95464fa356bddbfa48384cf5d25b'
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510664060', size: '33296', md5: '3af27d3452a1e5674c1d80b6003633cb', crc32: '851eb75e', sha1: '5b6a1ac32663715fed1fdd58e219f34de5daf2ed'
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac': {
-      source: 'original', mtime: '1510660590', size: '19482374', md5: 'e51844070b1df97c3f93525cc60123b8', crc32: '48644720', sha1: '2b3da29aeff675a23ecbf8317910e9cd804ab233', format: 'Flac', length: '169.73', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '10', album: 'The Essential Willie Nelson', title: 'Bloody Mary Morning', 'external-identifier': ['urn:acoustid:2197beee-d06e-491f-ab46-fcf8d8bc6d4e', 'urn:mb_recording_id:0c505681-80e9-483e-8954-a532f260dc9f', 'urn:spotify:track:5paRS95sOPkOVQlmUIUF4B', 'urn:youtube:NbrB4B5FoBQ'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Bloody Mary Morning', track: '10', album: 'The Essential Willie Nelson', bitrate: '212', length: '02:49', format: 'VBR MP3', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510662747', size: '4600832', md5: '926bed5523d91b902cc4ad9ce50d9c8f', crc32: '58e385c9', sha1: '17e6765463e454524837ac5c3be607e0dd74c5f4', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510663079', size: '11827', md5: '33e9eee821826ad84ef5c37fa1b57181', crc32: '26e32a69', sha1: 'c46518154ee814790a650091fe901d4d78a2df0a'
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Bloody Mary Morning', track: '10', album: 'The Essential Willie Nelson', bitrate: '172', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510662126', size: '755712', md5: '61282b7468ec9b82f61c1182b4b33127', crc32: '0a78e32c', sha1: '76cf573e74c083bd2822eb1cbe399dc7d9ee4153', height: '0', width: '0'
-    },
-    '\/disc1\/01.10. Willie Nelson - Bloody Mary Morning_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.10. Willie Nelson - Bloody Mary Morning.flac', mtime: '1510663598', size: '320633', md5: 'b54489133bf420c9f5fd501d41cfd248', crc32: '4740b8c4', sha1: '11fa23b984cf439bd189fab9b92cae6f4864b0f3'
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510664070', size: '19168', md5: '8e98c3cc103e801e83295911b073db69', crc32: 'fb476877', sha1: '0ca6daecf4045cd7ce1d7ca8a6553c7ae783ca0d'
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac': {
-      source: 'original', mtime: '1510660119', size: '11083146', md5: 'b4095a5c24cad7e2487c9cbf87b6e7d6', crc32: '6847d14f', sha1: '4ead2b4df28306514790d7da5a3e0872f03cd10f', format: 'Flac', length: '141.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '11', album: 'The Essential Willie Nelson', title: 'Blue Eyes Crying in the Rain', 'external-identifier': ['urn:acoustid:dda238da-08a4-4ed7-b0b5-2230c772523b', 'urn:mb_recording_id:1e0ff41e-80bc-4812-a57c-1735bf814d57', 'urn:spotify:track:2uRVPeQbsEpRQD0DKr1WTo', 'urn:youtube:crgtWomWg90'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Blue Eyes Crying in the Rain', track: '11', album: 'The Essential Willie Nelson', bitrate: '177', length: '02:21', format: 'VBR MP3', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510662281', size: '3236352', md5: '15b5c672983a34c462979cb04ddbebc8', crc32: '43c09e59', sha1: '0ed797d19d03a7b3a844f7b2f6762e2917f76106', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510663431', size: '12697', md5: '73aaff795bec66525aa59583d73afa2e', crc32: '29452325', sha1: '6290abd0a653f13573ad2fc75ff76626f3f6bdc8'
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Blue Eyes Crying in the Rain', track: '11', album: 'The Essential Willie Nelson', bitrate: '136', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510662811', size: '622080', md5: '85508c85913681587c68224b1746eae8', crc32: 'f6df935a', sha1: '960a5550bd72ab9d6be1c96129090338a5a34a93', height: '0', width: '0'
-    },
-    '\/disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.11. Willie Nelson - Blue Eyes Crying in the Rain.flac', mtime: '1510663542', size: '312649', md5: '297039c4081828ba86d1dd70c3bfd2e6', crc32: 'dd2e832a', sha1: 'eb26f178f141a064ab546a7fcf7fe3e07382de5e'
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663992', size: '32568', md5: '3deb31c0d75781d8164551959db9341c', crc32: '727daf42', sha1: '4cc5a48b96a6c9df51497b6b2593e34581b978b0'
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac': {
-      source: 'original', mtime: '1510660089', size: '19312085', md5: '477c4cb1aff3a2c0f9b4d767c87e2e8e', crc32: 'bbee9cd8', sha1: '4c50a18c72bbcfb6ba0d6e05e1538defe44fbcd8', format: 'Flac', length: '179.07', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Waylon Jennings', track: '12', album: 'The Essential Willie Nelson', title: 'Good Hearted Woman', 'external-identifier': ['urn:acoustid:3433cd9a-c797-4388-a2ca-aa1ee22337f5', 'urn:mb_recording_id:13a2f394-e61b-4b84-8bd5-42c1551b3115', 'urn:spotify:track:3CqLvQ9fPOLtLIKb7r5ti6', 'urn:youtube:swRJeMsk21g'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: 'Good Hearted Woman', track: '12', album: 'The Essential Willie Nelson', bitrate: '187', length: '02:59', format: 'VBR MP3', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510662303', size: '4304896', md5: 'b436bbb6a068ddf555ba56e9c16e38a5', crc32: '73311228', sha1: '48e9be3c9f72c880a5b0eb235261219dd69f41e3', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663352', size: '12255', md5: '2c01646835822aa47151087fe5ff4fa2', crc32: '408c1daa', sha1: 'f73c983cde501f4a7a73a472d62e756e91d1581e'
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: 'Good Hearted Woman', track: '12', album: 'The Essential Willie Nelson', bitrate: '151', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510662062', size: '676864', md5: '107b9f2cc977c4d472d466da98016ae3', crc32: '5230701f', sha1: '33cb606dc97945ff2c6ed02c752eef1d8def82ea', height: '0', width: '0'
-    },
-    '\/disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.12. Willie Nelson; Waylon Jennings - Good Hearted Woman.flac', mtime: '1510663563', size: '319121', md5: '0abf080bedf6ef109d877c434d59ec77', crc32: 'eee8af97', sha1: '1cca3aa23ff471967c6af1b7e8fcf9f08a391776'
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.afpk": {
-      source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510664081', size: '25680', md5: 'f9388cb5046482f64f7c426eb4d5a3b5', crc32: '53236901', sha1: '43ca264e9b5f6604380ff86705a988b7bb276dc1'
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac": {
-      source: 'original', mtime: '1510660108', size: '13714638', md5: '5cd5600105a44c8bc25e5e1606e27b7f', crc32: '42b88a71', sha1: '0fbba2190d38e9828538dbc430e1cefb1fd204f9', format: 'Flac', length: '126.69', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '13', album: 'The Essential Willie Nelson', title: "If You've Got the Money I've Got the Time", 'external-identifier': ['urn:acoustid:25dd90cb-1fa4-4e98-88d8-49d9d6119645', 'urn:mb_recording_id:acd8fda3-4097-4666-a32b-de814b4dfd14', 'urn:spotify:track:7aVapcvsbFYYmcQvhkc8Rc', 'urn:youtube:KeoYaaojdCE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.mp3": {
-      source: 'derivative', creator: 'Willie Nelson', title: "If You've Got the Money I've Got the Time", track: '13', album: 'The Essential Willie Nelson', bitrate: '200', length: '02:06', format: 'VBR MP3', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510662335', size: '3270656', md5: '1b0c54078f6b435e7fd80320e5c477d8', crc32: 'b7745bed', sha1: 'cf6dafca07889b1dee65ec6d0d2e225469e0f36d', height: '0', width: '0', private: 'true'
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.png": {
-      source: 'derivative', format: 'PNG', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510663443', size: '10814', md5: '66409704f9c71db8f4d47a6d24c865d4', crc32: '89b3c4ff', sha1: '15120367ee102283ef6295bc5e4a859705e0a350'
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time_sample.mp3": {
-      source: 'derivative', creator: 'Willie Nelson', title: "If You've Got the Money I've Got the Time", track: '13', album: 'The Essential Willie Nelson', bitrate: '145', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510662151', size: '655872', md5: '3f5cc30c0dcf2e1fe2dc80e4d5339a53', crc32: '0263a7b6', sha1: '62ceeb65e23a7112201323902bee2b70001f8d7e', height: '0', width: '0'
-    },
-    "\/disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time_spectrogram.png": {
-      source: 'derivative', format: 'Spectrogram', original: "disc1\/01.13. Willie Nelson - If You've Got the Money I've Got the Time.flac", mtime: '1510663587', size: '324451', md5: 'b1043e2da665409cb01f9d41773e4880', crc32: 'c64aaab7', sha1: '927e4a609f9ab68c61575d08a1374729f37ab411'
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510664111', size: '53776', md5: 'e0e1e193516f4e6f007ad08a7c91b9fa', crc32: '73fb327b', sha1: '62a9a74b853968f6e443ad61243319ef7fb422b3'
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day.flac': {
-      source: 'original', mtime: '1510661203', size: '28313862', md5: 'f2717ab887f16bc7abe684ba9fa4a156', crc32: 'd17232db', sha1: 'dfd440ef021436bfa8bf25c4b2e32f79bfd87cbf', format: 'Flac', length: '280.91', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '14', album: 'The Essential Willie Nelson', title: 'Uncloudy Day', 'external-identifier': ['urn:acoustid:f67a8d30-d780-47df-9207-318c13cb3549', 'urn:mb_recording_id:990c34ea-e7a9-4a5b-9633-23c71d1c8e17', 'urn:spotify:track:7GZRUcgcXtUWkUwnx7SLkz', 'urn:youtube:w1-DHepnVLs'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Uncloudy Day', track: '14', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:40', format: 'VBR MP3', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662363', size: '7104512', md5: 'fc7b64e31be85f661c4d62f9ed5019b1', crc32: '215f8a32', sha1: 'e240c636aba5374617ca5bee28de451ea584e290', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662974', size: '11787', md5: '507142e801428fbd6865b00dae84f165', crc32: '4671d1d7', sha1: 'b0da5301711f347625383435076ed5e8bf5ed1ff'
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Uncloudy Day', track: '14', album: 'The Essential Willie Nelson', bitrate: '169', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510662674', size: '742912', md5: '713e38c2cc554b82faf32623857b28c5', crc32: '281c4a23', sha1: '0fd0a1c6541a556c521dd03b0b91b574bb7c7a08', height: '0', width: '0'
-    },
-    '\/disc1\/01.14. Willie Nelson - Uncloudy Day_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.14. Willie Nelson - Uncloudy Day.flac', mtime: '1510663514', size: '289360', md5: 'da47ab0080f446e0fd8e723dda9f3fac', crc32: '00a0666a', sha1: 'f97f9d1cee6bc34f64eff0607c90da84c24a4504'
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.afpk": {
-      source: 'derivative', format: 'Columbia Peaks', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510664048', size: '25216', md5: '58856b390cdd0df71c60fc78bf8dda5b', crc32: 'cdfcf169', sha1: '7ae1be2399adad93afbd23e7f3a0a7d49491adf6'
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac": {
-      source: 'original', mtime: '1510660147', size: '16360575', md5: '5b1161b2ed5c7a56e1eadf92928fd2f3', crc32: '719db41f', sha1: '09a42e73084b863d55a8779f4aaf8d8730aa72f6', format: 'Flac', length: '152.96', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Waylon Jennings', track: '15', album: 'The Essential Willie Nelson', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", 'external-identifier': ['urn:acoustid:3f76466e-c967-4f46-9ecb-7555d3a71d61', 'urn:mb_recording_id:b5512c53-cd1e-4273-ac7a-96f28785b403', 'urn:spotify:track:1gKSpFpX3poa17WIAyFVsp', 'urn:youtube:RePtDvh4Yq4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.mp3": {
-      source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", track: '15', album: 'The Essential Willie Nelson', bitrate: '181', length: '02:32', format: 'VBR MP3', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510662502', size: '3575808', md5: '8daa23631f83867e0e73612395d7c56e', crc32: 'c002e25e', sha1: '008b6a61f0554ce4b9d0e4508ef3e522202822ce', height: '0', width: '0', private: 'true'
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.png": {
-      source: 'derivative', format: 'PNG', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510663405', size: '11135', md5: 'b4fb2b898d7b6253ede2ac23d1fd7f31', crc32: 'cf455854', sha1: '6bff8cea184c76af82ade5fc7b06e209cfa36c45'
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys_sample.mp3": {
-      source: 'derivative', creator: 'Willie Nelson; Waylon Jennings', title: "Mammas Don't Let Your Babies Grow Up to Be Cowboys", track: '15', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510662725', size: '682496', md5: '72f2d718003e602508de2e54203684c1', crc32: '559df7e2', sha1: 'a6fcc7922e90ec5e69ebf086b1a9902a1b555a16', height: '0', width: '0'
-    },
-    "\/disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys_spectrogram.png": {
-      source: 'derivative', format: 'Spectrogram', original: "disc1\/01.15. Willie Nelson; Waylon Jennings - Mammas Don't Let Your Babies Grow Up to Be Cowboys.flac", mtime: '1510663534', size: '320341', md5: '55ba1678423c0d610fb2f588cedc6e50', crc32: 'd7ae860e', sha1: 'd6b632a950f1c7932a4beb5615ed122e43e0b52c'
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663704', size: '34816', md5: '8536b9b442844f0ad5e6adf65336032a', crc32: '84a9b965', sha1: '9daac02e6c1d825fe6fb7ffdeef6fc4e925b091d'
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind.flac': {
-      source: 'original', mtime: '1510661226', size: '23816391', md5: '63b1fb42fe2bf6e5157182c413695714', crc32: 'c02d6d1f', sha1: '4b8f38280d0cb3e7517273ec8da3be25c7e8abfd', format: 'Flac', length: '261.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '16', album: 'The Essential Willie Nelson', title: 'Georgia on My Mind', 'external-identifier': ['urn:acoustid:5f92e364-4eff-47c4-acdd-b9727a6e662f', 'urn:mb_recording_id:57866fe0-3d43-48f3-8704-c15c6c3114e5', 'urn:spotify:track:1HhXBDM4vhNiOiSU9BBBug', 'urn:youtube:FNlw0IDFKDA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Georgia on My Mind', track: '16', album: 'The Essential Willie Nelson', bitrate: '183', length: '04:21', format: 'VBR MP3', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510662539', size: '6099968', md5: 'c70a0edb54ed4ca885acca0a75d4df6d', crc32: '04e87270', sha1: 'fa1f50973ed272e9bf2360d1e5246a36bade05d6', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663246', size: '12332', md5: 'a6b1cc45013b28ff478c1fd4c31ad8ef', crc32: '1c2db7ca', sha1: '2b73322d0b88be8158160681a266fd1a8a6627d8'
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Georgia on My Mind', track: '16', album: 'The Essential Willie Nelson', bitrate: '149', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510662688', size: '668160', md5: '609d221d8705225147eb19fbddae36d1', crc32: '59d48864', sha1: '8eda3c0021ae33972812394bb848b43d242ec397', height: '0', width: '0'
-    },
-    '\/disc1\/01.16. Willie Nelson - Georgia on My Mind_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.16. Willie Nelson - Georgia on My Mind.flac', mtime: '1510663584', size: '325048', md5: '06c41fd96e4296b13c86ae837c934fea', crc32: '09ab0d1c', sha1: 'b9c1c96d2c1999dc74ebe7efc4a3605b3db2a5f9'
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510664096', size: '27528', md5: 'd7a7eb66240ae1bc910bfc6aff59b481', crc32: '87cad81e', sha1: 'c4ffbb1f8784ee0f75e68ed0657d718dcd3bd94e'
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies.flac': {
-      source: 'original', mtime: '1510660968', size: '21122389', md5: '589acb5f967afdca0043428d374cb5e9', crc32: '03c61d2b', sha1: '4d42f6bca98fb25f4f0b559c90e8367d253f722d', format: 'Flac', length: '215.17', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '17', album: 'The Essential Willie Nelson', title: 'Blue Skies', 'external-identifier': ['urn:acoustid:03ac4ca8-b529-4852-99de-4ba6f9992e7e', 'urn:mb_recording_id:5950b1b1-6f01-4d5a-9953-a6dee35b808d', 'urn:spotify:track:4dEPl3NXfpv1p9Z9MaHneO', 'urn:youtube:sGZDwxnjG1g'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Blue Skies', track: '17', album: 'The Essential Willie Nelson', bitrate: '190', length: '03:35', format: 'VBR MP3', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510662387', size: '5209600', md5: 'f1e0e312ca0b1646338a46ec0c5e1df5', crc32: '77e156b7', sha1: 'edec5a8cb7dafbb1cb401c63954e3613558c2ce9', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510663198', size: '13135', md5: 'd738da0fe353b7cfbc57b5d90822e6f8', crc32: '56c6dfb6', sha1: '4744a1cfbbb2a935a132009140426be078aa7407'
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Blue Skies', track: '17', album: 'The Essential Willie Nelson', bitrate: '153', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510662011', size: '684032', md5: '25fd153807ea8d5b4d1980ac4faa0bc7', crc32: 'bccc0343', sha1: 'b6f2575077c046be90203e88f4889ef244908867', height: '0', width: '0'
-    },
-    '\/disc1\/01.17. Willie Nelson - Blue Skies_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.17. Willie Nelson - Blue Skies.flac', mtime: '1510663450', size: '310948', md5: '35a04ccd277cca01f9e906596056c8da', crc32: '5d7116a1', sha1: 'b8bc5a2b0e5c3c1182830d107cacb915a33a3d52'
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663803', size: '34952', md5: '59e4d8aa952fe151104d43478d8de23a', crc32: 'd6ba968e', sha1: '7b674526252263f1bc6565f0a96300f551d13cec'
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me.flac': {
-      source: 'original', mtime: '1510660140', size: '23594146', md5: '493a0f0a0d1d6e1411cff3bd02ba272f', crc32: '4493586c', sha1: 'f60f10ee839f6a854789a971c640808219ce7f81', format: 'Flac', length: '234.87', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '18', album: 'The Essential Willie Nelson', title: 'All of Me', 'external-identifier': ['urn:acoustid:b3720789-2e26-486b-a906-e773bc0f7f16', 'urn:mb_recording_id:92990a9f-5e08-4a20-afcd-d287e68023cc', 'urn:spotify:track:4BuCqXf9foFZBn8ZCIv8gh', 'urn:youtube:X1ZSZUSrXc8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'All of Me', track: '18', album: 'The Essential Willie Nelson', bitrate: '187', length: '03:54', format: 'VBR MP3', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510662433', size: '5609472', md5: 'af98653ca34ecf36e48ae4fb6e861168', crc32: '05dd02cd', sha1: '92f0b5f9a65143898adddf55fff8f9db1fff4908', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663013', size: '11957', md5: 'fc13ad7b6e65b102bb4853ae224fcfb7', crc32: 'db965955', sha1: 'b7810967d2b00675ab7cd36c086e9a68128e6df0'
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'All of Me', track: '18', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510662661', size: '681472', md5: '139e1a8360507e06bb836ac11bdbf146', crc32: '3aab6440', sha1: 'f014e505f6dac8a2b2cdcd489b8eafa5c69a5b53', height: '0', width: '0'
-    },
-    '\/disc1\/01.18. Willie Nelson - All of Me_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.18. Willie Nelson - All of Me.flac', mtime: '1510663571', size: '307403', md5: '81c281d88ddf9a76919c7bf4b1a69a6e', crc32: 'fb00ad4d', sha1: 'e4c29d6fce65d2697ebbb938bcf8d631a2d92bda'
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663814', size: '37544', md5: '72547f03faf518d5837e112608321be0', crc32: '6fd32c66', sha1: '04a2b4696c42c0200dfbf236080b62f91209b534'
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac': {
-      source: 'original', mtime: '1510660133', size: '22190389', md5: 'f775d9b7b01349099dcf0d8c84b8d7b2', crc32: '74815452', sha1: 'c9eebad69de4a7a2fd71dbace5a7028126f3c3b5', format: 'Flac', length: '183.09', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Leon Russell', track: '19', album: 'The Essential Willie Nelson', title: 'Heartbreak Hotel', 'external-identifier': ['urn:acoustid:bd5d5e1f-d40a-43c3-b657-f60ae5ffcb91', 'urn:mb_recording_id:827b3c8e-20ad-4cd1-ae46-b63d2ec33d16', 'urn:spotify:track:6nhoh9rZfdtXKtK6tssNKU', 'urn:youtube:jcSEaVyaUaA'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Leon Russell', title: 'Heartbreak Hotel', track: '19', album: 'The Essential Willie Nelson', bitrate: '187', length: '03:03', format: 'VBR MP3', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510662119', size: '4384768', md5: '256490470d421788f8eeee613656b56f', crc32: 'cdc43565', sha1: 'a1233583036b5f1825357e4dbc1f4be1100e73c9', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663299', size: '7710', md5: 'b17b70a3f76b911095af5e32c34ce631', crc32: 'ca3adb32', sha1: '1d61fd9e0ce7daaf5e1284662cc1438d0039f5bf'
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Leon Russell', title: 'Heartbreak Hotel', track: '19', album: 'The Essential Willie Nelson', bitrate: '147', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510662824', size: '661504', md5: 'bdecc8f30e3f967b17e15c2a42f4eda4', crc32: 'b5fbf0f8', sha1: 'cb9cee4b060e434b6fc260efe41aaee4983289be', height: '0', width: '0'
-    },
-    '\/disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.19. Willie Nelson; Leon Russell - Heartbreak Hotel.flac', mtime: '1510663556', size: '305715', md5: '768848de9fedc3ba203782f8fcd1ea9f', crc32: 'a87edf53', sha1: '70c1985dc888d07d6b24e9564c8810315913dddb'
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663717', size: '34376', md5: '3f1a5c64e9219573e83ee44add2a7cbd', crc32: 'ea2ff30b', sha1: '09453a4f2b2b59f7f95f7292ab38de0d089f15ea'
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac': {
-      source: 'original', mtime: '1510660156', size: '23153392', md5: '5825e367b2df7c0bfbdcf9b6e608c652', crc32: '12022ad7', sha1: 'f636c09ef5f3199d8dc3e61c7064dde13924c8ab', format: 'Flac', length: '241.53', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '20', album: 'The Essential Willie Nelson', title: 'Help Me Make It Through the Night', 'external-identifier': ['urn:acoustid:ccb90091-a7ac-4801-8ad3-408b87a578ca', 'urn:mb_recording_id:8dd83700-727d-4507-a686-1ddb0d62185b', 'urn:spotify:track:69iVsk096xmrKtcrU2mVnj', 'urn:youtube:1bCDWLSrlI4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Help Me Make It Through the Night', track: '20', album: 'The Essential Willie Nelson', bitrate: '191', length: '04:01', format: 'VBR MP3', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510662146', size: '5892608', md5: '6a9de37d62e641243d6249c46a5ef1d7', crc32: 'b318ad01', sha1: '634faea42464fa29b640239a51fb8c0c63467c39', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663093', size: '13270', md5: '6deac301814893037b327402e787d321', crc32: 'd0de9e3e', sha1: '84a9808da0681437935c92525468ba02b3aa1b1e'
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Help Me Make It Through the Night', track: '20', album: 'The Essential Willie Nelson', bitrate: '142', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510662818', size: '643584', md5: 'f3fb44e4979e8a2652690568a458bba9', crc32: '75395c22', sha1: 'ef955cc6a360c61f0cfccd4f0d8e716ea4e9d4f8', height: '0', width: '0'
-    },
-    '\/disc1\/01.20. Willie Nelson - Help Me Make It Through the Night_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.20. Willie Nelson - Help Me Make It Through the Night.flac', mtime: '1510663549', size: '331562', md5: '20cde540c4d671db8c4fc355f06a740d', crc32: '10aec794', sha1: '22a4da35b35ec8ffd1718ae5cdeef57aec5f21f0'
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live).afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663980', size: '45424', md5: '93448d31d3e99819b8fcdfba14f76cee', crc32: 'a823c52a', sha1: '8be489646399624bcf3288b67cc970d425108b43'
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live).flac': {
-      source: 'original', mtime: '1510660584', size: '24671629', md5: '46e16d72d571d32aa8d5c0fc6b04ea80', crc32: 'de0830bf', sha1: '43dd4144dd4e2ff50930ad8150a55a7847aa9c54', format: 'Flac', length: '211.44', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '21', album: 'The Essential Willie Nelson', title: 'Whiskey River (live)', 'external-identifier': ['urn:acoustid:aa846e11-bd40-4eae-8b47-dd5ae0d42de7', 'urn:mb_recording_id:5a43f1a9-18b4-4e7b-acbb-fdd8783ba598', 'urn:spotify:track:0EHDEzu14gcx4Z3hOYVpTn', 'urn:youtube:w53dvztwQY4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live).mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Whiskey River (live)', track: '21', album: 'The Essential Willie Nelson', bitrate: '179', length: '03:31', format: 'VBR MP3', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510662169', size: '4835840', md5: '6afce16f787857ee1e95fa925fcfbf95', crc32: '30587f62', sha1: 'fa4b371e82814645c8b3ccd9ef6897c69d7af1af', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live).png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663001', size: '11612', md5: 'd7996f325a42e6b34bd6b50aaf23b4f4', crc32: '3aca5e0f', sha1: 'ee52e92889d29ff30588f24dd1726f35e9c0f57c'
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live)_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Whiskey River (live)', track: '21', album: 'The Essential Willie Nelson', bitrate: '136', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510661869', size: '622080', md5: 'd2ea89b7963e2442dbc279ac366b7d5c', crc32: 'f6df4448', sha1: 'e68c98d365cb79f4f823dca40921c0b58818836c', height: '0', width: '0'
-    },
-    '\/disc1\/01.21. Willie Nelson - Whiskey River (live)_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.21. Willie Nelson - Whiskey River (live).flac', mtime: '1510663472', size: '302840', md5: '9047bd3dfc0066128ae8dcd1e408d9d6', crc32: '69449590', sha1: '9039d1139f40a9aa6fc6956a62a85434d5f1ec2e'
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live).afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663851', size: '45408', md5: '682533fa956fb12220eae01935fd399b', crc32: 'e6d61ca8', sha1: 'fbabf117ba31735851cb33214c4c1b51b62f727d'
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac': {
-      source: 'original', mtime: '1510661646', size: '23733419', md5: 'dd4b4233b176dd7a344fc9a02a77c2de', crc32: '7b58317a', sha1: 'a97e3dd7b1c870435b1e3575a496aa057a824bdb', format: 'Flac', length: '205.33', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '22', album: 'The Essential Willie Nelson', title: 'Stay a Little Longer (live)', 'external-identifier': ['urn:acoustid:73e95b96-87e7-4905-a538-25bf123c7292', 'urn:mb_recording_id:7abc5bc6-3da2-4c01-8dde-87cbf055b948', 'urn:spotify:track:1Y2XmNnjyrH087OVy05knW', 'urn:youtube:FHZorrDDX4A'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live).mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Stay a Little Longer (live)', track: '22', album: 'The Essential Willie Nelson', bitrate: '180', length: '03:25', format: 'VBR MP3', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510662195', size: '4737536', md5: '9bad6a152e7c7bf80aab90f630605088', crc32: 'fec50a73', sha1: 'f51ba204010e7bdcec4a09e6e70b46161d712768', height: '0', width: '0', private: 'true'
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live).png': {
-      source: 'derivative', format: 'PNG', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663285', size: '10306', md5: '1de1dde0ab2ccf30b9dd2474cfbeba62', crc32: '7dc24235', sha1: 'eca4b015661338ed5d37184be1faa32f4ebf9288'
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live)_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Stay a Little Longer (live)', track: '22', album: 'The Essential Willie Nelson', bitrate: '140', length: '00:30', format: 'MP3 Sample', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510662341', size: '636416', md5: '72ea57170a49c6a64c28d5c8f619e7aa', crc32: '9451ea50', sha1: '0ddf3990f43afa18d81e781d2f2376007e91ab9d', height: '0', width: '0'
-    },
-    '\/disc1\/01.22. Willie Nelson - Stay a Little Longer (live)_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc1\/01.22. Willie Nelson - Stay a Little Longer (live).flac', mtime: '1510663538', size: '302413', md5: '815fe6ec2094b3a55a769aa4d99c5eca', crc32: '25ba1ac2', sha1: 'c0d805cb664848bc10daa830fdcd202de8fb31b2'
-    },
-    '\/disc1\/Willie Nelson - The Essential Willie Nelson.cue': {
-      source: 'original', mtime: '1510661651', size: '4743', md5: '0a55debd30330e98854e8f96db5f1b43', crc32: '79a66d34', sha1: 'e35585a6e1c3fd7c75feb13bb4318d8144575469', format: 'Cue Sheet', private: 'true'
-    },
-    '\/disc1\/Willie Nelson - The Essential Willie Nelson.log': {
-      source: 'original', mtime: '1510660083', size: '9039', md5: 'a1b3946eb2f84ef758b0631020ebc063', crc32: '24592e31', sha1: '82dde236fde123c35ef65d956f422d86eb5e9182', format: 'Log', private: 'true'
-    },
-    '\/disc1\/Willie Nelson - The Essential Willie Nelson.m3u': {
-      source: 'original', mtime: '1510660124', size: '4252', md5: 'e0596e6c0903dd9c390890beeb11158f', crc32: '99d38346', sha1: 'd9757891b060bc9f129b6a11d468fab167add8f6', format: 'M3U', private: 'true'
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510663878', size: '24232', md5: 'b67bf21f62e89d77fd6f4dfef7792bda', crc32: 'aea25d94', sha1: 'a490b48ed962d379b34e4ba7b107a6ec28c550d1'
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac': {
-      source: 'original', mtime: '1510659242', size: '18629435', md5: '51ef101da69c243395f5951b40ac7984', crc32: '549e2c21', sha1: '3b88ef85d6ba6e8f1f35a13abd4fb2cb572d082b', format: 'Flac', length: '186.49', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '1', album: 'The Essential Willie Nelson', title: 'My Heroes Have Always Been Cowboys', 'external-identifier': ['urn:acoustid:4272300d-ccde-4f06-b9f7-9c7327fe9b24', 'urn:mb_recording_id:b9374fc0-604c-400f-8e9c-568ab18ede5d', 'urn:spotify:track:0dlNwpfDzFIKdtuJSnHbzK', 'urn:youtube:vFDq0VMV-Vc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'My Heroes Have Always Been Cowboys', track: '1', album: 'The Essential Willie Nelson', bitrate: '175', length: '03:06', format: 'VBR MP3', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662598', size: '4191744', md5: '6b7a3e0df90e5fcd8a8a74984a1a9528', crc32: '1360bebb', sha1: '7be1a217df17af6f1fbc4e847bcd0d1c33415197', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662950', size: '12902', md5: 'bdd5072dcd614d4b60e02b0ced4b8326', crc32: '88978d8f', sha1: 'b75815ebc7764b2320e933402cb779e3c812ae6d'
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'My Heroes Have Always Been Cowboys', track: '1', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510662718', size: '650240', md5: 'f4e74bb3e38f7bf24dda2440b76e4940', crc32: 'a836cd9e', sha1: 'bff298bf1b4506c342eda36479c264d362fe47bc', height: '0', width: '0'
-    },
-    '\/disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.01. Willie Nelson - My Heroes Have Always Been Cowboys.flac', mtime: '1510663501', size: '311306', md5: 'b54e63254d80a5c70f4a1b9f4a234d40', crc32: 'baa365a8', sha1: '513d5e0185342ffafba15603308a7e2183d7c0a4'
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510664125', size: '42088', md5: '7e9336f06b0e31741d3b75f66895182b', crc32: '214c5358', sha1: '73445d834023cdd1ba1671f270f25b16456ff140'
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac': {
-      source: 'original', mtime: '1510659156', size: '23739790', md5: '42b8889e2b623999d688866b74debf07', crc32: '8da6685c', sha1: 'eb17d20e008ff49adf91f2b5f9110d29e2ee3157', format: 'Flac', length: '231.17', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Ray Price', track: '2', album: 'The Essential Willie Nelson', title: 'Faded Love', 'external-identifier': ['urn:acoustid:a918f9c9-e23c-436c-bd68-018e56fa2eef', 'urn:mb_recording_id:7e5f3a79-5315-4934-be5b-d27b67c3bf6f', 'urn:spotify:track:5AqdbGrt4nokb4nPLoI0Oq', 'urn:youtube:ESeyLLz82mE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Ray Price', title: 'Faded Love', track: '2', album: 'The Essential Willie Nelson', bitrate: '189', length: '03:51', format: 'VBR MP3', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662236', size: '5566976', md5: '5145411fb7aa2601370356ac83bd6b82', crc32: '237917fa', sha1: '61785fc24101842dd52178363fbf1158573f6ee7', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662906', size: '11429', md5: '2e303fc7b52337c4f6bf6b175319ab71', crc32: 'd889a2df', sha1: '098c54b427f55f9b8bcc26160ce3fa6d996df2e2'
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Ray Price', title: 'Faded Love', track: '2', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510662707', size: '720896', md5: '4aa730360cc211baa775b7c12886e1cc', crc32: '90b357ca', sha1: 'b95a66ae54db5fa8966d3539cd8040cd3fad9f32', height: '0', width: '0'
-    },
-    '\/disc2\/02.02. Willie Nelson; Ray Price - Faded Love_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.02. Willie Nelson; Ray Price - Faded Love.flac', mtime: '1510663510', size: '337703', md5: '1997d5910ade37708594c6634213685c', crc32: '25a1f53b', sha1: '0984ec112209b240c5ad1153096e94a2be097319'
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510663889', size: '29312', md5: 'f80e2820b17455b7176dd1eb0836dd7a', crc32: 'c1a22678', sha1: '5290fe4a6e6530089297d1b6650ae9fa1d7b16d7'
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again.flac': {
-      source: 'original', mtime: '1510660042', size: '16211519', md5: '85923ccf5c53c5fedf9a5e5912466c03', crc32: '6be92b5a', sha1: '334ad74df470252305646f5675f62da50d2b99d8', format: 'Flac', length: '153.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '3', album: 'The Essential Willie Nelson', title: 'On the Road Again', 'external-identifier': ['urn:acoustid:2eba5a50-1f18-4add-837f-67144bac3390', 'urn:mb_recording_id:54e0b867-2e65-4f9b-8d43-443406d81eb2', 'urn:spotify:track:1OmKo4t4Bh95xQI6WGiUR3', 'urn:youtube:dBN86y30Ufc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'On the Road Again', track: '3', album: 'The Essential Willie Nelson', bitrate: '197', length: '02:33', format: 'VBR MP3', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662627', size: '3893248', md5: '3b1d999857881b61d00540f3d7fcc335', crc32: '88510073', sha1: 'e68cec618aa240e5d0d87f7e0c39f13efbca3a1f', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662891', size: '12824', md5: 'e69e803f2a5c767a7a5ead5cecb5e521', crc32: 'b194ee50', sha1: '5724a74490928f7aff2a3f890a1f6313b6fd675f'
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'On the Road Again', track: '3', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510662694', size: '718336', md5: 'de1957667b2519f59b807962c7e0af3e', crc32: '133285f6', sha1: 'be47db7c0b1460cd82bc0c41d2df347c5dbfeed9', height: '0', width: '0'
-    },
-    '\/disc2\/02.03. Willie Nelson - On the Road Again_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.03. Willie Nelson - On the Road Again.flac', mtime: '1510663505', size: '307815', md5: 'ed9140374b684ed2c710ce387d5f135e', crc32: '894944d4', sha1: 'c718e102b6df1301c1843f505bdd52b9f1778323'
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663902', size: '41680', md5: 'a012c56a71b1dec3015ba20ff5085b2d', crc32: '22143f42', sha1: '3b9fb1bfa7a7fac610fc477b9990ba20b23d300b'
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac': {
-      source: 'original', mtime: '1510659227', size: '26677039', md5: '990be46ba4fda38b16bc0ff824989850', crc32: '8a5a6aef', sha1: 'ab56b60f50efb6422eb2dbd82da575452abf0c3e', format: 'Flac', length: '271.89', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '4', album: 'The Essential Willie Nelson', title: 'Angel Flying Too Close to the Ground', 'external-identifier': ['urn:acoustid:77abcc32-55af-4caf-a2ac-6d1bdf9850ba', 'urn:mb_recording_id:213e6995-fe80-43ff-835a-47960f8f7f9c', 'urn:spotify:track:6oYqwLEYsuw71VPCuwBRFS', 'urn:youtube:C3PB1jWO3_E'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Angel Flying Too Close to the Ground', track: '4', album: 'The Essential Willie Nelson', bitrate: '173', length: '04:31', format: 'VBR MP3', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510662846', size: '5980160', md5: 'a051960b857378adcb68eb6e99ff349b', crc32: '85e9cf8f', sha1: '76ab2ae3b6ac9674f00d15a0deee8302b3dbfbc4', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663333', size: '12683', md5: 'b6ee1c376ab44976fb5b9b7e98a91efd', crc32: 'b3ce0374', sha1: 'fa8d75a5a3107050044ede4aeafae936097ef664'
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Angel Flying Too Close to the Ground', track: '4', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510662288', size: '650240', md5: '462f0d376c02e0e2980d80c2bd69f9d4', crc32: 'd5fbf749', sha1: '12f52a13a12c2e536b53d10af16c02de03f0aea3', height: '0', width: '0'
-    },
-    '\/disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.04. Willie Nelson - Angel Flying Too Close to the Ground.flac', mtime: '1510663581', size: '319431', md5: '088c71c5dbee8b3857cf4a851b95afd0', crc32: '66a473ee', sha1: '701af24ca5603bec91e68c12573d98ce40fd5a99'
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663917', size: '31792', md5: '8e2db58d7fe73a067c59982db177d535', crc32: 'e1a410c2', sha1: '669eaec1dd227e57944b89a9d360ef44a08ab211'
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind.flac': {
-      source: 'original', mtime: '1510658588', size: '21154449', md5: 'a9885c85018350776085e5a82ff572e8', crc32: 'e8a7f6b0', sha1: 'f74019e05c7f309bf78fbe978f6fb946403477c3', format: 'Flac', length: '212.33', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '5', album: 'The Essential Willie Nelson', title: 'Always on My Mind', 'external-identifier': ['urn:acoustid:382bd49f-26e2-4a4c-b493-6d74c93778f2', 'urn:mb_recording_id:19d0be93-fdbc-4510-8a5e-c849967a927f', 'urn:spotify:track:2xYQTU2bbg6WVAmpY1eae4', 'urn:youtube:yoPYQ-FmQB4'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Always on My Mind', track: '5', album: 'The Essential Willie Nelson', bitrate: '184', length: '03:32', format: 'VBR MP3', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510662784', size: '5001216', md5: '6c383c40d62ced4680c88c034481fbb3', crc32: 'b6e2fcbb', sha1: '302e63687328237727847f61162ccdea49b8a98d', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663377', size: '12781', md5: '29e9aa5d8ee4a84be01e504efcfccccc', crc32: 'e71930a0', sha1: 'ba893c0d63c2d17c872088074a5cf5ae8767b794'
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Always on My Mind', track: '5', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510662766', size: '678912', md5: '110078e343d2e3061075db1b5c128ba4', crc32: '8851ab11', sha1: 'ac7f4df61c1d964c07eb35636ae9c98776cc867e', height: '0', width: '0'
-    },
-    '\/disc2\/02.05. Willie Nelson - Always on My Mind_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.05. Willie Nelson - Always on My Mind.flac', mtime: '1510663591', size: '334965', md5: '06e41040217e098974fa7e84e5bf327d', crc32: '6aed6586', sha1: 'a2436d9f2ff26a9605f2d7124d3d3d76b2e1ca33'
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663940', size: '36536', md5: 'cb526a3381d8dd187b06d41595f1065f', crc32: '6a100f06', sha1: '6bf18d7d9ff8d19d4fc72870da3db126251c7b1d'
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac': {
-      source: 'original', mtime: '1510658564', size: '25753244', md5: '96dd395a39eefae3648b557c98eff824', crc32: '1cf48ce6', sha1: 'eff80cefcce899ab32e2bb0198d62b5d48b624e5', format: 'Flac', length: '261.77', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '6', album: 'The Essential Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', 'external-identifier': ['urn:acoustid:a146d21f-df37-4a3a-bbc5-6fefaa1c29c1', 'urn:mb_recording_id:18cab4bd-e40a-4b9d-b01d-dc1788000138', 'urn:spotify:track:7viJvsSKvbL4aBGmTzg4vi', 'urn:youtube:vYpGEAwH1k0'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', track: '6', album: 'The Essential Willie Nelson', bitrate: '195', length: '04:21', format: 'VBR MP3', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510662805', size: '6497280', md5: 'd47f9ceed378fedd9d1bf99922b5e808', crc32: '72062da1', sha1: '0b371c02f4bf5d6e25a987820f50c7178eb288d6', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663315', size: '12679', md5: '59464d19a5fefa0b626132d89cef8fac', crc32: 'a353376f', sha1: '5cb91be6bfdabb42511c7f7f802b40f471acdd1a'
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Last Thing I Needed First Thing This Morning', track: '6', album: 'The Essential Willie Nelson', bitrate: '159', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510662176', size: '706048', md5: '4bf6eb5ede17e058034d02169e11c413', crc32: 'd6f84b5a', sha1: 'f1fd02f8579c94248e650c8c0b1c855c7fb007b1', height: '0', width: '0'
-    },
-    '\/disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.06. Willie Nelson - Last Thing I Needed First Thing This Morning.flac', mtime: '1510663576', size: '334144', md5: '77209b74676bc4f6ee83bef79cf54f91', crc32: 'b17ebbb5', sha1: 'dfbfbb4bbd3c3452088c200e767e590296cc9382'
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663867', size: '44640', md5: '56a68a409a6420bfbe10a02bb6256558', crc32: 'b411d90c', sha1: '2eb27b5ce9e0f23b8002cf13b9d593b2c74baf6f'
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac': {
-      source: 'original', mtime: '1510659169', size: '29907550', md5: 'ab6d56ec70f99c2cf15737f7a543864b', crc32: 'eda87cd6', sha1: '3bdcaad8841d1553dc70cca6eb1df8ec661ce4c7', format: 'Flac', length: '288.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Merle Haggard', track: '7', album: 'The Essential Willie Nelson', title: 'Pancho and Lefty', 'external-identifier': ['urn:acoustid:de01aaa5-e363-443e-ab03-fb64237bf0bd', 'urn:mb_recording_id:b6abc46a-b783-4eee-9236-0c7375551e03', 'urn:spotify:track:1A6P8IxzNyBRsQualaNXNY', 'urn:youtube:sT9NSmZFE_Q'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Merle Haggard', title: 'Pancho and Lefty', track: '7', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:48', format: 'VBR MP3', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510662098', size: '7293952', md5: '5c69760c9daf3c0e1e431c8e4c04acba', crc32: '27bd0bee', sha1: 'c2bd2ace145356f7bca3b74b6b38a3c91baeb430', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663392', size: '12782', md5: '40644aeeb5a38664373753ae1be1ba48', crc32: '362e4dca', sha1: '064a2693f97fab797fa590f113a1a2b311bfd85a'
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Merle Haggard', title: 'Pancho and Lefty', track: '7', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510662370', size: '722944', md5: '647e172b1f6b8b9116a98522c23d809d', crc32: '9abd301f', sha1: 'fb5b562ce0949a7905c6320dd4f7fcc0a1fa5f6a', height: '0', width: '0'
-    },
-    '\/disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.07. Willie Nelson; Merle Haggard - Pancho and Lefty.flac', mtime: '1510663525', size: '325976', md5: '5d065d47f07e1d598d53f0aeaa10e439', crc32: '24cc66bc', sha1: '49e510a4ae9ad063a8298056aef7042b42e7a752'
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.afpk": {
-      source: 'derivative', format: 'Columbia Peaks', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663788', size: '32368', md5: '77e80b367d10ca6966df3d3a09a7a3c7', crc32: '8cbe5c57', sha1: '610b4743d6d5b4d43881f43b0028777eea8a0307'
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac": {
-      source: 'original', mtime: '1510658572', size: '24709923', md5: '43e24a569b1f1aa4099c20a70ccca23b', crc32: 'b127c537', sha1: 'cf1e1f318aaf628f95e42c191585d2bab5addbc0', format: 'Flac', length: '214.56', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Julio Iglesias', track: '8', album: 'The Essential Willie Nelson', title: "To All the Girls I've Loved Before", 'external-identifier': ['urn:acoustid:9b980594-7ffc-417e-8fc0-b3a5ca168d5f', 'urn:mb_recording_id:e80ff2a6-c33a-41a5-983e-11bf80eb876b', 'urn:spotify:track:2BhMmYodsANRcZohekmum8', 'urn:youtube:51tvZnkn5V8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.mp3": {
-      source: 'derivative', creator: 'Willie Nelson; Julio Iglesias', title: "To All the Girls I've Loved Before", track: '8', album: 'The Essential Willie Nelson', bitrate: '192', length: '03:34', format: 'VBR MP3', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510662077', size: '5254144', md5: 'ac27425b1a289d1283c40281a000cbe8', crc32: '669e299b', sha1: '3f9e5a544706140dd8fe3bf0c8c266b03902f844', height: '0', width: '0', private: 'true'
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.png": {
-      source: 'derivative', format: 'PNG', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663421', size: '12737', md5: 'dadfcb943d56c478fbb967b99691a1f3', crc32: 'f63c004c', sha1: '73c4cbbc01c27e385e2e680f775ea7bbc62a1738'
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before_sample.mp3": {
-      source: 'derivative', creator: 'Willie Nelson; Julio Iglesias', title: "To All the Girls I've Loved Before", track: '8', album: 'The Essential Willie Nelson', bitrate: '151', length: '00:30', format: 'MP3 Sample', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510662201', size: '675840', md5: '92f5bfd5a1a932d679b8e38b1fe10509', crc32: '29fa10ed', sha1: 'b5beb6e65a4c5a8f84774de9dbfa6f60cf9d0c11', height: '0', width: '0'
-    },
-    "\/disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before_spectrogram.png": {
-      source: 'derivative', format: 'Spectrogram', original: "disc2\/02.08. Willie Nelson; Julio Iglesias - To All the Girls I've Loved Before.flac", mtime: '1510663546', size: '330974', md5: 'c018771e02b46138547d634a714ce6fc', crc32: 'ba8714ab', sha1: 'acdd260d5f63bf087b9b370ed1a8d4b60cf972e7'
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510664142', size: '48440', md5: '13b0e230b4f1e6d1a8a3a93233cc430a', crc32: '3c12e20a', sha1: '1eea429f27411abd15ce0da7f2afa9849d36700f'
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans.flac': {
-      source: 'original', mtime: '1510660054', size: '34706236', md5: '2daa286a6117df9398a39950e34323ba', crc32: '793bb122', sha1: '1afe58f693c69799aaf6d91441dab2788edd5e4f', format: 'Flac', length: '292.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '9', album: 'The Essential Willie Nelson', title: 'City of New Orleans', 'external-identifier': ['urn:acoustid:06bb63f4-e364-402e-a2f6-05d8468f062f', 'urn:mb_recording_id:37870bd7-52b6-442e-a706-cf9752ee1ba5', 'urn:spotify:track:15qBdyeOsal1QJvB3ysW9g', 'urn:youtube:6XyRdJr4LSc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'City of New Orleans', track: '9', album: 'The Essential Willie Nelson', bitrate: '199', length: '04:52', format: 'VBR MP3', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510662460', size: '7415296', md5: 'ef8a92b52c089477f89eea5ef2d35b76', crc32: '80e384bb', sha1: '1a8480fae994e692e9dec366efe1c32c39978855', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510663262', size: '11976', md5: 'fee490bc2dbf05f1d0c69fcc21266fd6', crc32: '74e35f60', sha1: '6e19a70765354a720514a997c916f8119d8fa0c3'
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'City of New Orleans', track: '9', album: 'The Essential Willie Nelson', bitrate: '152', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510662468', size: '681984', md5: '14651920b6e093083b75a756596cec3c', crc32: 'd3e04b0b', sha1: '7ffea3f5bb4868b0402bab3bdbe70dba94d0064e', height: '0', width: '0'
-    },
-    '\/disc2\/02.09. Willie Nelson - City of New Orleans_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.09. Willie Nelson - City of New Orleans.flac', mtime: '1510663498', size: '312518', md5: 'b65a2f2e2a1926e5ceed7d0f03c4a822', crc32: '517b600b', sha1: '5c16a66b28b37053bc52f31afa0e1721f7544a35'
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510664157', size: '36936', md5: 'f256d9b134ac5de39fc452cef94fbec8', crc32: '5e0a7dc8', sha1: '89e890ccba67ebca535856ea88474423acd3fa8e'
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac': {
-      source: 'original', mtime: '1510659188', size: '23485819', md5: 'd5cfc9a37c79bd60da109b855cca3964', crc32: '07150d8a', sha1: 'b0d4b0f3e703114a2403ff1ddce88a1d6555dd6d', format: 'Flac', length: '232.51', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Ray Charles', track: '10', album: 'The Essential Willie Nelson', title: 'Seven Spanish Angels', 'external-identifier': ['urn:acoustid:486a4e9f-579b-44c5-9cb9-cdc7081b9fde', 'urn:mb_recording_id:7fe0144a-077a-4a98-b545-229e7c188eba', 'urn:spotify:track:7i59jjqTqjNvEbDW2H8Z7R', 'urn:youtube:T4g7lYRGAx8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Ray Charles', title: 'Seven Spanish Angels', track: '10', album: 'The Essential Willie Nelson', bitrate: '182', length: '03:52', format: 'VBR MP3', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510662488', size: '5408256', md5: 'bd1a50cf6e2ae630f01d5f77673175dc', crc32: 'e71c2767', sha1: 'b0aea0a8605310ae9d3fdc46330a9c068c8f1ac9', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510663133', size: '12692', md5: '5ab0783fff97b9fa2c679dff05205675', crc32: 'd0afd998', sha1: '819fa3f53170e383dc7517dc21785ef425d0ce34'
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Ray Charles', title: 'Seven Spanish Angels', track: '10', album: 'The Essential Willie Nelson', bitrate: '154', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510662760', size: '687616', md5: 'be99b500e0666be73ce7973f3492f877', crc32: 'e8ef8a4e', sha1: '13aecd41fec9adb7a662118aa76bf344a1c650f0', height: '0', width: '0'
-    },
-    '\/disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.10. Willie Nelson; Ray Charles - Seven Spanish Angels.flac', mtime: '1510663463', size: '339185', md5: 'ebd1dc8a7bdf17dfb082de5963bf1a8d', crc32: 'd1602ea6', sha1: 'f225f6edcebd073f28fde78980301a72e569bd06'
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510664170', size: '26144', md5: '8e34ca206608c853816f13d25b6ca812', crc32: 'ba604844', sha1: 'da1d9eb04518b2ee834e0141aaae9f6e1623ccd7'
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac': {
-      source: 'original', mtime: '1510660063', size: '17991051', md5: '778661119a5cfe3a8e57e21eb6bf6912', crc32: 'de3a9944', sha1: 'fb4b81bc19b4863be29c3b27c4f16dc3525e8509', format: 'Flac', length: '169.27', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '11', album: 'The Essential Willie Nelson', title: 'Forgiving You Was Easy', 'external-identifier': ['urn:acoustid:e6b5fc08-26f6-4623-bf8c-ad5122cad960', 'urn:mb_recording_id:6671c4f3-69b4-4eb9-8df9-9f5c62018f7b', 'urn:spotify:track:7iV3RG0FKOAdQ93QVfPwR7', 'urn:youtube:sgPbslG-DTc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Forgiving You Was Easy', track: '11', album: 'The Essential Willie Nelson', bitrate: '193', length: '02:49', format: 'VBR MP3', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662517', size: '4190720', md5: '987c5e4670f43cc2049502adf371115a', crc32: 'db21338d', sha1: '63e697070d39f904a07edd79fe6451988c1e6113', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662918', size: '12162', md5: '6ca5d2bdc529d7a4e10f2976193b4e74', crc32: 'f8ef08d8', sha1: '7ae34e7e67c144a91125ec3f2c05d0de2ad73032'
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Forgiving You Was Easy', track: '11', album: 'The Essential Willie Nelson', bitrate: '157', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510662754', size: '700416', md5: '7dbd84dc6ee15aaf822b51524e6b9c78', crc32: 'a10a444b', sha1: '9e237ae5b3440df2409a9ce7fe381a879ca13eae', height: '0', width: '0'
-    },
-    '\/disc2\/02.11. Willie Nelson - Forgiving You Was Easy_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.11. Willie Nelson - Forgiving You Was Easy.flac', mtime: '1510663595', size: '324601', md5: '1fc35fae8c2eaa4092441b93e24573a3', crc32: '6d4ec9fa', sha1: '9380df61a442b6cfe60b4b2b25e5588f984cd8bc'
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510664193', size: '30528', md5: '29b0ab7c7d400c95883fee21e2f599f1', crc32: 'd2594514', sha1: '30c99d3f4e4851ad5837c986345dd8f3ec553e87'
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman.flac': {
-      source: 'original', mtime: '1510659176', size: '20894807', md5: '2fa00933acd008802a8628c5e1812ac8', crc32: 'bb38a207', sha1: '75abcae0c294f652547acff4738ecaec158686e7', format: 'Flac', length: '184.63', height: '640', width: '632', private: 'true', artist: 'The Highwaymen', track: '12', album: 'The Essential Willie Nelson', title: 'Highwayman', 'external-identifier': ['urn:acoustid:05112dbf-030f-433c-8f52-787128e20e09', 'urn:mb_recording_id:277494e7-bf84-4eda-8381-33b204c0a9de', 'urn:spotify:track:7jWbXvrgdbkajU8L28ahn5', 'urn:youtube:qFSA8-pxrqc'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman.mp3': {
-      source: 'derivative', creator: 'The Highwaymen', title: 'Highwayman', track: '12', album: 'The Essential Willie Nelson', bitrate: '199', length: '03:04', format: 'VBR MP3', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662557', size: '4695552', md5: 'a7a5927fd07df78846016e6a52418163', crc32: 'e3eee71c', sha1: '1540718765e4ea8ffd37a809d0c7733ade5f38c3', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662939', size: '11536', md5: 'b54d7bafcbe5e854e7d4e6813a68bfd0', crc32: '72ecd006', sha1: '529a5e23e1bc56a206d24f39798b9802f95c1000'
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman_sample.mp3': {
-      source: 'derivative', creator: 'The Highwaymen', title: 'Highwayman', track: '12', album: 'The Essential Willie Nelson', bitrate: '163', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510662605', size: '722432', md5: '312f94941090a9786e483e63652f5cdf', crc32: '9f352785', sha1: 'f4b9a5e3d089f34ec1c33ef44d1ffca0c8c6bcb6', height: '0', width: '0'
-    },
-    '\/disc2\/02.12. The Highwaymen - Highwayman_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.12. The Highwaymen - Highwayman.flac', mtime: '1510663531', size: '327048', md5: '1c594cb956ad31d1c632a084866e2d66', crc32: '0eed4071', sha1: 'b2f580d47bb04f7e188c7909ea2781cff261ed12'
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510664208', size: '27712', md5: '4c3d7b390ae272bc54d7b8c1aa64ee3c', crc32: 'fec4aa16', sha1: 'a7db0a74567e4d3853d454ee364d2d54505c9379'
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland.flac': {
-      source: 'original', mtime: '1510659182', size: '19951678', md5: '906175fd53b02988af2efb66ef342c57', crc32: '94fac46a', sha1: '5a50faef1aa745b2a583a9fc0307fc66fb3d86bf', format: 'Flac', length: '202.93', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '13', album: 'The Essential Willie Nelson', title: 'Living in the Promiseland', 'external-identifier': ['urn:acoustid:27a24127-0ad5-4b8b-a5b5-ea03913c9df3', 'urn:mb_recording_id:27d94671-a95f-470d-886d-51ed498e4c7d', 'urn:youtube:wqIyIvL-gBs'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Living in the Promiseland', track: '13', album: 'The Essential Willie Nelson', bitrate: '188', length: '03:22', format: 'VBR MP3', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510662217', size: '4868096', md5: 'aab74ded5f0aa03af069f766b8d7958c', crc32: '16bf99b2', sha1: '9edf61fc7f83b4bdd882d3b4ff9380ac5cb369fb', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510663160', size: '12015', md5: 'cbf9d41348b355490ccc2050844453cf', crc32: '21080313', sha1: 'fa2afe0c1fab0152a4a2165ca296802b4b77645b'
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Living in the Promiseland', track: '13', album: 'The Essential Willie Nelson', bitrate: '158', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510662104', size: '704512', md5: 'e4cec454af563b197b0a86a74e1ed802', crc32: 'c312ae6e', sha1: '608d07a1c7dfe0bea1bca99618db2a4e3357d14e', height: '0', width: '0'
-    },
-    '\/disc2\/02.13. Willie Nelson - Living in the Promiseland_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.13. Willie Nelson - Living in the Promiseland.flac', mtime: '1510663567', size: '322440', md5: '0ff74dfc5b8006c79ec4817063162759', crc32: '0c22a4b0', sha1: '4b2a02ae4a646eb445e4a87ded67ddf32dc1e2ea'
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510663774', size: '35672', md5: '0586116fa954eb06d7495e855018000f', crc32: '37e670f7', sha1: '10682acb54b04a05ae0124162634d3bcf2f70621'
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac': {
-      source: 'original', mtime: '1510658614', size: '22986577', md5: '1ca35b679901e179e33cd454a0a2d022', crc32: 'a4582e42', sha1: 'aa59b26d91ea3f5b3f18fc606ac0e28a1e7791ec', format: 'Flac', length: '199.8', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '14', album: 'The Essential Willie Nelson', title: 'Nothing I Can Do About It Now', 'external-identifier': ['urn:acoustid:58bcbdac-7df2-4a1a-b932-a63d7c004ce7', 'urn:mb_recording_id:c55926b5-fa55-4209-a060-8949a14109bd', 'urn:spotify:track:0xbY7q5aImO8winKbVTIwo', 'urn:youtube:vAS5sbt-8yE'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Nothing I Can Do About It Now', track: '14', album: 'The Essential Willie Nelson', bitrate: '185', length: '03:19', format: 'VBR MP3', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510661916', size: '4725760', md5: '5c15b136ba75aa7be286a2875b3ce16f', crc32: '314a982e', sha1: '338395efa70f5d0541d0617595c494b9408562b7', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510662878', size: '10155', md5: '9d6d44224e21d7bf4e3350a09b9dfe60', crc32: '0b3bae09', sha1: '5ada47792a07ddf65b0ba3e83220acc3d7e8e2d8'
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Nothing I Can Do About It Now', track: '14', album: 'The Essential Willie Nelson', bitrate: '144', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510662040', size: '651776', md5: '9c4cd5ea55cd091f07273dce13d59a76', crc32: 'ed6328e9', sha1: '27748e6b672a3e60a7f4f543867a230fc49b21e1', height: '0', width: '0'
-    },
-    '\/disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.14. Willie Nelson - Nothing I Can Do About It Now.flac', mtime: '1510663553', size: '316129', md5: '43c7b31f66c40704685cddacb9c8b9a1', crc32: '8398e466', sha1: '0b7b7aa8f44b84980c245a875fcc5f738521d987'
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663967', size: '56056', md5: '3068e8b084049891808551f493007695', crc32: 'fcf031ce', sha1: '44ac14c96052c38c4f20f58f6015f93d48731e03'
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland.flac': {
-      source: 'original', mtime: '1510658598', size: '34383660', md5: 'c9c53078f8f912bb420a834ed49acf45', crc32: '46e324be', sha1: '901129d1a9634e22a9e9beb8757979efb69eada4', format: 'Flac', length: '286.13', height: '640', width: '632', private: 'true', artist: 'Willie Nelson', track: '15', album: 'The Essential Willie Nelson', title: 'Graceland', 'external-identifier': ['urn:acoustid:5031f621-e5f5-4288-9d49-24659fd6f3ed', 'urn:mb_recording_id:8f44f8e3-c87c-4cae-aeb9-b21b3f4db413', 'urn:spotify:track:6KRuBpMlAvHJuMKyHO32G4', 'urn:youtube:KId0MCDuD1I'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Graceland', track: '15', album: 'The Essential Willie Nelson', bitrate: '201', length: '04:46', format: 'VBR MP3', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510661943', size: '7317504', md5: 'dace8f28c0fa1fa3d45bbcca85365b89', crc32: '947289bd', sha1: '8191b9907df93f6a670483cb9e0bbc8a6944aad9', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663056', size: '9887', md5: '7b3f6e28a4e22e8e909c5ac9c1d2d97a', crc32: 'f5239d39', sha1: '5e7c994ff61c3c1c616046ffca34033afb0e2204'
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson', title: 'Graceland', track: '15', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510662681', size: '718336', md5: 'a1e5089ea8f3613a2749badc0ff4b098', crc32: '6e899e38', sha1: '2bdf0207c8e8dc8008f77bc31a66ab319087c8d0', height: '0', width: '0'
-    },
-    '\/disc2\/02.15. Willie Nelson - Graceland_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.15. Willie Nelson - Graceland.flac', mtime: '1510663486', size: '303775', md5: '88bf32cb7748d118134da9b13225534c', crc32: '375d1aeb', sha1: 'b06da3276d847ff56b4fb432a9703b77b5d43311'
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663839', size: '36120', md5: 'af515ba4689c91be88e63277e1b0d2d3', crc32: 'b6adaa7c', sha1: 'e89b6a262c928fb952384309a4caaad73c2b11d9'
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac': {
-      source: 'original', mtime: '1510658630', size: '23106845', md5: 'f6b5d9418e4016eda02b137948d348b3', crc32: '38ff4835', sha1: 'b05c21836e8d640d63f3dca61dfdd892cf17d4d8', format: 'Flac', length: '232.57', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Emmylou Harris', track: '16', album: 'The Essential Willie Nelson', title: 'Everywhere I Go', 'external-identifier': ['urn:acoustid:d9a9fd40-d0b8-4603-9430-167c00bd04a4', 'urn:mb_recording_id:2eb70150-c489-4b03-a766-52cd4527809c', 'urn:youtube:n50qI2AxEH8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Emmylou Harris', title: 'Everywhere I Go', track: '16', album: 'The Essential Willie Nelson', bitrate: '193', length: '03:52', format: 'VBR MP3', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510661969', size: '5717504', md5: '5a3fa3aa13dd7312e58ca2fa74691131', crc32: '9ea9ad66', sha1: '2b13608c06180fe4d0f02787f65b245904d87a5c', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663106', size: '11411', md5: '67867d6e977999d3963d31af328e286c', crc32: 'e58f3b9e', sha1: 'acfaeed09f69a7c87ae84c362292a88158cf3df9'
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Emmylou Harris', title: 'Everywhere I Go', track: '16', album: 'The Essential Willie Nelson', bitrate: '162', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510662612', size: '718848', md5: '12870e2d8e934fba1f1f624e1fc872d7', crc32: '99ea7892', sha1: '8d3656885df591199009dd5a7abd5548f63cc246', height: '0', width: '0'
-    },
-    '\/disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.16. Willie Nelson; Emmylou Harris - Everywhere I Go.flac', mtime: '1510663478', size: '336617', md5: '631186c1c5c5700342f78775ecf819b6', crc32: 'c111c67b', sha1: 'fbf5e188f10d519b69f70afdd1dd6a446fbc63aa'
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663952', size: '38480', md5: 'b3f484766da11671f4e6e2aa96b0f5cd', crc32: '217da072', sha1: '095a9cefa8da4e97d2b304c928f63ad0cc6bba17'
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac': {
-      source: 'original', mtime: '1510659752', size: '25201170', md5: '2c13af1d36cf2b386b428c9e0ef5fa59', crc32: '3f4800d4', sha1: '93df01b0d647c97c3d7c615be2cca05beb4ac1c7', format: 'Flac', length: '242.47', height: '640', width: '632', private: 'true', artist: 'U2; Willie Nelson; Mickey Raphael on Harmonica', track: '17', album: 'The Essential Willie Nelson', title: 'Slow Dancing', 'external-identifier': ['urn:acoustid:bb1f67a5-0bfa-4d90-a87d-c4edc02398c7', 'urn:mb_recording_id:5fa38bd5-f3bf-4ff0-aa4f-c839627fa1fb', 'urn:youtube:nlPfmXu61CU'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.mp3': {
-      source: 'derivative', creator: 'U2; Willie Nelson; Mickey Raphael on Harmonica', title: 'Slow Dancing', track: '17', album: 'The Essential Willie Nelson', bitrate: '172', length: '04:02', format: 'VBR MP3', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510662004', size: '5320192', md5: '163e4675b6dca447b5ecb29830b2aa7d', crc32: 'b7a6ef94', sha1: '8e3917154e7d72dcb69ae3caf307e89abb9b351a', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663233', size: '11932', md5: 'c78ce40d6d806baff93d90ca09e24b91', crc32: 'd9a0c2d3', sha1: 'ebd8f2f67d9e0edd2a6acb8bbd52f897e3bc89cd'
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing_sample.mp3': {
-      source: 'derivative', creator: 'U2; Willie Nelson; Mickey Raphael on Harmonica', title: 'Slow Dancing', track: '17', album: 'The Essential Willie Nelson', bitrate: '141', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510662667', size: '639488', md5: '2340fbe6540427f84ce5144a26214ab2', crc32: '0e9402b6', sha1: 'a7bdae46ede1bfa7c1fa82908c554e76ecba3812', height: '0', width: '0'
-    },
-    '\/disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.17. U2; Willie Nelson; Mickey Raphael on Harmonica - Slow Dancing.flac', mtime: '1510663467', size: '323969', md5: '742965874040262dab3a806e8f1a6101', crc32: '6052eda9', sha1: 'e8e0e751b34fa16a0cc864c3a446eee322bb9fa2'
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663743', size: '50360', md5: '1424e7491f8324121f80a538d8b78f27', crc32: 'c6fa8e68', sha1: '026d8d0fdd57d126c137d0280dc5c8d819b368b7'
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac': {
-      source: 'original', mtime: '1510659235', size: '32999010', md5: '1be57c89a67e85dabd38875e95b88e20', crc32: '9e6093cd', sha1: 'da35711125a3ec0a0bf8a4e3cd6b78956569d261', format: 'Flac', length: '273.47', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Lee Ann Womack', track: '18', album: 'The Essential Willie Nelson', title: 'Mendocino County Line', 'external-identifier': ['urn:acoustid:7cc23a37-8bff-4494-885c-fbed1762e0dc', 'urn:mb_recording_id:61235c66-6f84-48e5-80b8-f431d120a2cd', 'urn:spotify:track:4mgdl5v71oF18Tp4bM8bKX', 'urn:youtube:RZD6BNj67c8'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'spotify:2018-08-23T13:12:14Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Lee Ann Womack', title: 'Mendocino County Line', track: '18', album: 'The Essential Willie Nelson', bitrate: '195', length: '04:33', format: 'VBR MP3', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510662033', size: '6769664', md5: 'e8695e362d2c609ccfa5701ed625823a', crc32: 'd9a56ee6', sha1: 'f865a40bda9bd17f9cfb8d1a36a66cf5cc952fe6', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663183', size: '10117', md5: '3d0d817188cfd6325234ba7fb97ff3fd', crc32: 'a10ffbc8', sha1: 'aceb463a26904d706f03aded99789a0607d52942'
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Lee Ann Womack', title: 'Mendocino County Line', track: '18', album: 'The Essential Willie Nelson', bitrate: '153', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510662634', size: '686080', md5: '09977908178f4195c9401ec11bc6f490', crc32: 'c64054db', sha1: '0856e5070011f635ccc993f8c0b361f6e5dea934', height: '0', width: '0'
-    },
-    '\/disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.18. Willie Nelson; Lee Ann Womack - Mendocino County Line.flac', mtime: '1510663460', size: '322099', md5: 'ed9046597beadafed66852a1e145ae73', crc32: '39fc3d4e', sha1: 'cc22f8c971716545d940268ae6a3f633a7c5839d'
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.afpk': {
-      source: 'derivative', format: 'Columbia Peaks', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663763', size: '61400', md5: '6e94f52a090e07cf08805b466f1ea8f0', crc32: 'b39e7dbd', sha1: '59f89737291bdaa3fd46864f6bb8ade29909f302'
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac': {
-      source: 'original', mtime: '1510659199', size: '36848126', md5: '649880a4b68de354c803e0dbfb5f2c82', crc32: 'baeb4fb2', sha1: 'd4a032871a49c26704913bc9bbaa2e385574acf4', format: 'Flac', length: '323.63', height: '640', width: '632', private: 'true', artist: 'Willie Nelson; Steven Tyler; Aerosmith', track: '19', album: 'The Essential Willie Nelson', title: 'One Time Too Many', 'external-identifier': ['urn:acoustid:02ba9afd-5042-42f9-b5c0-2a8b8da9f04a', 'urn:mb_recording_id:c295efa6-d108-4d32-9c14-45fa496302cb', 'urn:youtube:vgRIUArsP7o'], 'external-identifier-match-date': ['acoustid:2018-12-17T17:17:49Z', 'mb_recording_id:2018-09-13T16:19:23Z', 'youtube:2018-07-02T12:11:31Z']
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Steven Tyler; Aerosmith', title: 'One Time Too Many', track: '19', album: 'The Essential Willie Nelson', bitrate: '187', length: '05:23', format: 'VBR MP3', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510661896', size: '7660544', md5: '55ee957a1e6a038cdcb823082aec8e80', crc32: '5cb1f341', sha1: 'cf6758e09aaaf7a861a40123b58af660f8403678', height: '0', width: '0', private: 'true'
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.png': {
-      source: 'derivative', format: 'PNG', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663219', size: '8025', md5: '9a7dadfb2a3098528daba816aeb9fc6d', crc32: 'fb4bcecc', sha1: 'b00137a32e51ca290894a3987af142b8626c379e'
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many_sample.mp3': {
-      source: 'derivative', creator: 'Willie Nelson; Steven Tyler; Aerosmith', title: 'One Time Too Many', track: '19', album: 'The Essential Willie Nelson', bitrate: '156', length: '00:30', format: 'MP3 Sample', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510662732', size: '694784', md5: '09e1f43b7e76be6d8c9f4ed82cbad95d', crc32: 'd280c27f', sha1: '5f7cf07a75b3e04993b43d503d275e999676a2b5', height: '0', width: '0'
-    },
-    '\/disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many_spectrogram.png': {
-      source: 'derivative', format: 'Spectrogram', original: 'disc2\/02.19. Willie Nelson; Steven Tyler; Aerosmith - One Time Too Many.flac', mtime: '1510663455', size: '330912', md5: '783d42e2cdcd6cd76189a09e94197f09', crc32: '79aeaa8e', sha1: 'f5682c3cec7d83fcdb18bbf34a728ce38cf18d36'
-    },
-    '\/disc2\/Willie Nelson - The Essential Willie Nelson.cue': {
-      source: 'original', mtime: '1510660067', size: '4751', md5: '4019c6f1f55a9615edd2c7bf0fec9e9c', crc32: '1dc0a024', sha1: 'c44f5e14a7f284c4c5e3a29ab9eae4183fb31902', format: 'Cue Sheet', private: 'true'
-    },
-    '\/disc2\/Willie Nelson - The Essential Willie Nelson.log': {
-      source: 'original', mtime: '1510658550', size: '8011', md5: '4c5dc82b7b5147964c4300327a2b2d3f', crc32: '09aa4bbb', sha1: 'f639e3afa1fbca427d5cfdb3542bb4503625d993', format: 'Log', private: 'true'
-    },
-    '\/disc2\/Willie Nelson - The Essential Willie Nelson.m3u': {
-      source: 'original', mtime: '1510658576', size: '3964', md5: 'd1ad92a265f130aac3d79cd736263a1b', crc32: '3e77120d', sha1: 'c689c6f857e92f39e248737a92cfe0a0f948deb6', format: 'M3U', private: 'true'
-    }
-  },
-  misc:
-  { image: 'https:\/\/ia800103.us.archive.org\/16\/items\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul\/cd_the-essential-willie-nelson_willie-nelson-aerosmith-emmylou-harris-jul_itemimage.png', 'collection-title': 'Audiophile CD Collection' },
-  item:
-  { downloads: 2299, month: 78 }
+  reviews: [{
+    reviewbody: 'Why only 30 seconds each of these great songs?', reviewtitle: 'Only 30 seconds', reviewer: 'DrAMarx', reviewer_itemname: '@dramarx', reviewdate: '2018-08-09 20:00:05', createdate: '2018-08-09 20:00:05', stars: '2'
+  }],
+  server: 'ia600103.us.archive.org',
+  uniq: 1294725796,
+  workable_servers: ['ia600103.us.archive.org', 'ia800103.us.archive.org']
 };
 
 

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -47,7 +47,7 @@ class DataHydrator extends Component {
   }
 
   fetchData(identifier) {
-    const detailsJSONPath = `/api/details/${identifier}?output=json`;
+    const detailsJSONPath = `/api/metadata/${identifier}`;
     const jwplayerPlaylistJSONPath = `/api/embed/${identifier}?output=json`;
     const base = axios.create({
       headers: {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
@@ -30,7 +30,6 @@ const archiveDerivedAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier 
   const itemPhotoCandidates = {};
   const trackFilesHaveYoutubeSpotify = [];
 
-  debugger;
   const tracks = files.reduce((neededItems = [], currentFile) => {
     const { source, original = '', name: currentFileName } = currentFile;
     const isPrivate = currentFile.private || null;

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
@@ -25,11 +25,12 @@ import { isValidAudioFile, isValidImageFile } from './utils';
  * @returns { object } : tracks, itemPhotoCandidates, trackFilesHaveYoutubeSpotify
  *
  */
-const archiveLPAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) => {
+const archiveDerivedAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) => {
   let itemPhoto = '';
   const itemPhotoCandidates = {};
   const trackFilesHaveYoutubeSpotify = [];
 
+  debugger;
   const tracks = files.reduce((neededItems = [], currentFile) => {
     const { source, original = '', name: currentFileName } = currentFile;
     const isPrivate = currentFile.private || null;
@@ -37,7 +38,7 @@ const archiveLPAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) =>
     let flattenedImportantRelatedFiles = null;
     const externalIdentifiers = currentFile['external-identifier'] || null;
     const isOriginal = source === 'original';
-    const isMainTrackItem = original.match(`${itemIdentifier}_segments.`);
+    const isDerivedFile = original.match(`${itemIdentifier}_segments.`);
     const fileToSkip = `${itemIdentifier}.mp3`; // phantom audio file to map to full album
     const isAudioFile = isValidAudioFile(currentFileName);
     const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
@@ -61,7 +62,7 @@ const archiveLPAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) =>
       }
     }
 
-    if (isMainTrackItem && isAudioFile) {
+    if (isDerivedFile && isAudioFile) {
       // get related files
       const relatedFiles = filter(files, thisFile => thisFile.original === currentFileName);
 
@@ -116,4 +117,4 @@ const archiveLPAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier }) =>
   return returnItems;
 };
 
-export default archiveLPAlbumParser;
+export default archiveDerivedAlbumParser;

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -58,21 +58,23 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
   } = metadata;
   const { collection, identifier } = albumMetadata;
   const fileDirectoryPrefix = `https://${server}${directoryPath}/`;
-  const fileNames = Object.keys(allFiles);
   const itemIdentifier = head(identifier);
 
   /**
    * Take original item's file list
    * & only return the files we are interested in
    */
-  const slimFiles = reduce(fileNames, (neededFiles = [], fileName) => {
-    const isNeededFile = isValidAudioFile(fileName) || isValidImageFile(fileName);
-    const file = allFiles[fileName];
-    file.name = fileName.slice(1, fileName.length);
-    if (isNeededFile) {
-      neededFiles.push(file);
+  const slimFiles = allFiles.reduce((acc = [], file) => {
+    const { name: fileName } = file;
+    const isValidAudio = isValidAudioFile(fileName);
+    const isValidImage = isValidImageFile(fileName);
+    const isNeededFile = isValidAudio || isValidImage;
+    if (!isNeededFile) {
+      return acc;
     }
-    return neededFiles;
+
+    acc.push(file);
+    return acc;
   }, []);
 
   const playSamples = playFullIAAudio ? false : includes(collection, 'samples_only');

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -2,11 +2,10 @@ import {
   includes,
   reduce,
   chain,
-  head,
 } from 'lodash';
 
 import archiveDefaultAlbumParser from './archive-default-album-parser';
-import archiveLPAlbumParser from './archive-lp-album-parser';
+import archiveDerivedAlbumParser from './archive-derived-album-parser';
 import gatherYoutubeAndSpotifyInfo from './youtube-spotify-parser';
 import { isValidAudioFile, isValidImageFile } from './utils';
 
@@ -89,7 +88,7 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
   const playSamples = playFullIAAudio ? false : includes(collection, 'samples_only');
   const albumSpotifyYoutubeInfo = gatherYoutubeAndSpotifyInfo(albumMetadata['external-identifier']) || {};
   const trackFilter = countOriginalAudioFiles < countSampleMP3
-    ? archiveLPAlbumParser
+    ? archiveDerivedAlbumParser
     : archiveDefaultAlbumParser;
 
   const {

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.test.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.test.js
@@ -70,7 +70,7 @@ describe('Music Player Util - Flatten Album Data', () => {
     });
     test('has identifier', () => {
       expect(albumMetadaToDisplay).toHaveProperty('identifier');
-      expect(stringifiedID).toEqual(dataFlattened.identifier[0]);
+      expect(stringifiedID).toEqual(dataFlattened.identifier);
       expect(stringifiedID).toBeDefined();
       expect(stringifiedID).toBeTruthy();
     });

--- a/packages/ia-components/sandbox/track-lists/track-list.jsx
+++ b/packages/ia-components/sandbox/track-lists/track-list.jsx
@@ -23,7 +23,7 @@ const parseTrackTitle = ({
   isAlbum = false
 }) => {
   if (isAlbum) { return 'Full album'; }
-  const albumCreatorString = albumCreator.join ? albumCreator.join('; ') : albumCreator;
+  const albumCreatorString = Array.isArray(albumCreator) ? albumCreator.join('; ') : albumCreator;
   const whichArtistVal = creator || artist;
   /* this considers "Best of" albums */
   const titleHasTrackArtist = albumName.includes(whichArtistVal);

--- a/packages/ia-components/sandbox/track-lists/track-list.jsx
+++ b/packages/ia-components/sandbox/track-lists/track-list.jsx
@@ -23,7 +23,7 @@ const parseTrackTitle = ({
   isAlbum = false
 }) => {
   if (isAlbum) { return 'Full album'; }
-  const albumCreatorString = albumCreator.join('; ');
+  const albumCreatorString = albumCreator.join ? albumCreator.join('; ') : albumCreator;
   const whichArtistVal = creator || artist;
   /* this considers "Best of" albums */
   const titleHasTrackArtist = albumName.includes(whichArtistVal);


### PR DESCRIPTION
**Description**
Music Player files parser updates:
- use /metadata schema to do transformations. This will get us closer to allow @mitra42 and DWEB client to user player
- remove collection-based switch to toggle between the 2 parsers we have.

https://webarchive.jira.com/browse/WEBDEV-2638

**Technical**

Parser tests run through `flatten-album-data.test.js` at this time.
We will continue to have 2 different parser files so we can separate logic into something we can understand.

**Testing**

run storybook > go to theatre stories > check this identifier: `national_lampoon_thats_not_funny_thats_sick` > player should show correctly with track listing