### PR TITLE
Moves radio element out of label to prevent double event firing

### DIFF
--- a/packages/ia-components/sandbox/selectors/horizontal-radio-group/horizontal-radio-group.jsx
+++ b/packages/ia-components/sandbox/selectors/horizontal-radio-group/horizontal-radio-group.jsx
@@ -44,14 +44,15 @@ const HorizontalRadioGroup = ({
 
     return (
       <div key={uniqueKey} className={optionClassName}>
-        <label {...clickTrackDataAttr}>
-          <input
-            type="radio"
-            name={name}
-            value={value}
-            onChange={onChange}
-            checked={isSelected ? 'checked' : ''}
-          />
+        <input
+          type="radio"
+          name={name}
+          id={`${name}-${value}`}
+          value={value}
+          onChange={onChange}
+          checked={isSelected ? 'checked' : ''}
+        />
+        <label htmlFor={`${name}-${value}`} {...clickTrackDataAttr}>
           <span>{label}</span>
         </label>
       </div>

--- a/packages/ia-components/sandbox/selectors/horizontal-radio-group/horizontal-radio-group.less
+++ b/packages/ia-components/sandbox/selectors/horizontal-radio-group/horizontal-radio-group.less
@@ -44,14 +44,6 @@
   label {
     cursor: pointer;
     margin-bottom: 0;
-
-    > input[type='radio']:checked + span {
-      opacity: 1;
-    }
-
-    > input[type='radio'] + span {
-      opacity: 0.5;
-    }
   }
 
   input[type='radio'] {
@@ -59,5 +51,17 @@
     // the radio set should look like a button group
     // with only one "on" at a given time
     display: none;
+    + label {
+      > span {
+        opacity: 0.5;
+      }
+    }
+    &:checked {
+      + label {
+        > span {
+          opacity: 1;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description**

Fixes https://webarchive.jira.com/browse/WEBDEV-2574

**Technical**

The click event on items in the horizontal radio group fired twice because the radio element was inside of the label element. The change event simulates a click event on parent elements. Moving it just before the label and changing the CSS selector chain for checked state prevent the second click event firing.

**Testing**

See Jira ticket above

**Evidence**

![single_analytics_tracker](https://user-images.githubusercontent.com/39553/65344109-ca7fbf80-dba4-11e9-81b3-f4fde04e57a2.gif)
