### PR TITLE
music player, data parser: handle items that aren't restricted with samples

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/utils/flatten-album-data.js
@@ -59,6 +59,7 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
   const fileDirectoryPrefix = `https://${server}${directoryPath}/`;
 
   let countSampleMP3 = 0;
+  let countFullMP3 = 0;
   let countOriginalAudioFiles = 0;
   /**
    * Take original item's file list
@@ -69,16 +70,26 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
     const isValidAudio = isValidAudioFile(fileName);
     const isValidImage = isValidImageFile(fileName);
     const isNeededFile = isValidAudio || isValidImage;
+    const fileIsDerived = source === 'derivative';
+    const isSampleMP3 = fileName.match('_sample.mp3');
+    const isMP3 = fileName.match('.mp3');
+
     if (!isNeededFile) {
       return acc;
     }
 
-    if (isValidAudio && fileName.match('_sample.mp3')) {
-      countSampleMP3 += 1;
-    }
+    if (isValidAudio) {
+      if (isSampleMP3) {
+        countSampleMP3 += 1;
+      }
 
-    if (isValidAudio && (source === 'original')) {
-      countOriginalAudioFiles += 1;
+      if (isMP3 && fileIsDerived && !isSampleMP3) {
+        countFullMP3 += 1;
+      }
+
+      if (source === 'original') {
+        countOriginalAudioFiles += 1;
+      }
     }
 
     acc.push(file);
@@ -87,7 +98,7 @@ const flattenAlbumData = (metadata, playFullIAAudio) => {
 
   const playSamples = playFullIAAudio ? false : includes(collection, 'samples_only');
   const albumSpotifyYoutubeInfo = gatherYoutubeAndSpotifyInfo(albumMetadata['external-identifier']) || {};
-  const trackFilter = countOriginalAudioFiles < countSampleMP3
+  const trackFilter = ((countOriginalAudioFiles < countSampleMP3) || (countOriginalAudioFiles < countFullMP3))
     ? archiveDerivedAlbumParser
     : archiveDefaultAlbumParser;
 


### PR DESCRIPTION
**Description**

We are starting to use the music player with collections that are mixed with restricted & non restricted items.

That means, we need to move music player out of handling only restricted items.

This shift is described here: https://webarchive.jira.com/browse/WEBDEV-2687

**Technical**

In the file parser, we will add another check to make sure we are correctly using the right one.

**Testing**
Check Before: `https://58-review-webdev-268-75hs41.archive.org/details/deathofsalesmans00mill`

Test After:
Load storybook > go to theatre > load music player > scroll past Willie Nelson and add this identifier to the ad-hoc input field: `deathofsalesmans00mill`

Track list should look like this:
![image](https://user-images.githubusercontent.com/7840857/65710202-5da67280-e047-11e9-8921-72a764f5b04d.png)

