### PR TITLE
Replace assert to expect function test

### DIFF
--- a/packages/ia-components/live/example-react-component/example.test.js
+++ b/packages/ia-components/live/example-react-component/example.test.js
@@ -1,14 +1,13 @@
-import React from 'react'
-import TestRenderer from 'react-test-renderer'
-import assert from 'assert'
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
 
 // Moved this to a local import rather than via index because depends on experimental extension
-import { IAUXExampleComponent } from '../index'
+import IAUXExampleComponent from './index';
 
 /**
  * Test for IAUXExampleComponent
  *
- * Using both `expect` (from Jest) & `assert`
+ * Using `expect` (from Jest)
  */
 test('IAUXExampleComponent draws', () => {
   const component = TestRenderer.create(
@@ -22,6 +21,5 @@ test('IAUXExampleComponent draws', () => {
   expect(tree).toMatchSnapshot()
   expect(testInstance.children.length).toEqual(1)
 
-  assert(component instanceof Object)
-  assert.equal(testInstance.children.length, 1, 'number of children')
-})
+  expect(component instanceof Object)
+});

--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -22,7 +22,6 @@
         "@storybook/addon-jest": "^4.1.6",
         "@storybook/addon-knobs": "^4.1.4",
         "@storybook/react": "^4.1.4",
-        "assert": "^1.4.1",
         "axios": "^0.19.0",
         "babel-loader": "^8.0.5",
         "chromedriver": "^76.0.0",

--- a/packages/ia-components/yarn.lock
+++ b/packages/ia-components/yarn.lock
@@ -2263,7 +2263,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert@^1.1.1, assert@^1.4.1:
+assert@^1.1.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=


### PR DESCRIPTION

Swap out assert to expect and remove assert dependency.

**Description**

#242 Replaced 'assert' to 'expect' and removed assert depency.

**Technical**

The method assert was removed and replaced to expect from Jest. Also assert dependency was removed because is not used anymore.

**Testing**

Run 'yarn:test' and check 'example-react-component/example.test.js' is 100% coveraged.

**Evidence**

![image](https://user-images.githubusercontent.com/4400304/66009005-12e58a00-e48f-11e9-92ed-846ca5f36448.png)

