### PR TITLE
Add Public Access Control for NPM

### DIFF
--- a/packages/audio-element/package.json
+++ b/packages/audio-element/package.json
@@ -66,6 +66,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "src/**/*.ts": [
       "eslint --fix",

--- a/packages/playback-controls/package.json
+++ b/packages/playback-controls/package.json
@@ -66,6 +66,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",

--- a/packages/scrubber-bar/package.json
+++ b/packages/scrubber-bar/package.json
@@ -66,6 +66,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",

--- a/packages/transcript-view/package.json
+++ b/packages/transcript-view/package.json
@@ -66,6 +66,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "*.ts": [
       "eslint --fix",

--- a/packages/waveform-progress/package.json
+++ b/packages/waveform-progress/package.json
@@ -66,6 +66,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "lint-staged": {
     "*.js": [
       "eslint --fix",


### PR DESCRIPTION
**Description**

> In order to make a package public on NPM, you have to add `publishConfig` to `package.json`

**Technical**

> n/a

**Testing**

> n/a

**Evidence**

> <img width="861" alt="Screen Shot 2019-10-09 at 2 30 42 PM" src="https://user-images.githubusercontent.com/51138/66522057-64020900-eaa1-11e9-9b6a-280dcb5cdc90.png">

