### PR TITLE
Use Postinstall Hook to Compile TypeScript

### DIFF
--- a/packages/audio-element/package.json
+++ b/packages/audio-element/package.json
@@ -7,7 +7,7 @@
   "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc -p tsconfig.build.json",
     "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",

--- a/packages/playback-controls/package.json
+++ b/packages/playback-controls/package.json
@@ -7,7 +7,7 @@
   "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc -p tsconfig.build.json",
     "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",

--- a/packages/scrubber-bar/package.json
+++ b/packages/scrubber-bar/package.json
@@ -7,7 +7,7 @@
   "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc -p tsconfig.build.json",
     "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",

--- a/packages/transcript-view/package.json
+++ b/packages/transcript-view/package.json
@@ -7,7 +7,7 @@
   "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc -p tsconfig.build.json",
     "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",

--- a/packages/waveform-progress/package.json
+++ b/packages/waveform-progress/package.json
@@ -7,7 +7,7 @@
   "module": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc -p tsconfig.build.json",
     "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",


### PR DESCRIPTION
**Description**

> I was using the `prepare` step, but that gets triggered before the publish happens. We need the TypeScript to be compiled after it is installed

**Technical**

> Just changes the lifecycle event for the install

**Testing**

> n/a

**Evidence**

> n/a
