### PR TITLE
Creates ia-components release script

### DIFF
--- a/packages/ia-components/CHANGELOG.md
+++ b/packages/ia-components/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.0
+
+Initial version

--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -4,13 +4,15 @@
     "source": true,
     "license": "AGPL-3.0-only",
     "scripts": {
+        "postversion": "node scripts/postversion.js",
         "storybook": "yarn run test:generate-output && yarn run storybook:start",
         "storybook:start": "start-storybook -p 9001 -c .storybook",
         "test:generate-output": "mkdir jest-test-utils && jest --json --outputFile=jest-test-utils/jest-test-results.json || true",
         "test:update-snapshots": "jest --updateSnapshot",
         "test": "start-server-and-test storybook http-get://localhost:9001 'jest --updateSnapshot --coverage'",
         "test:watch": "yarn run test --watch",
-        "test:integration": "node_modules/.bin/jest --config integration/jest.config.js"
+        "test:integration": "node_modules/.bin/jest --config integration/jest.config.js",
+        "version": "node scripts/version.js"
     },
     "devDependencies": {
         "@babel/core": "^7.2.2",

--- a/packages/ia-components/scripts/postversion.js
+++ b/packages/ia-components/scripts/postversion.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const { version: NEW_VERSION } = require('../package.json');
+const { execSync } = require('child_process');
+
+const tag = `v${NEW_VERSION}`;
+const releaseBody = fs.readFileSync('CHANGELOG.md').toString()
+.split(/\n# /)[0] // split at headings and get first heading
+.split('\n').slice(1).join('\n'); // remove heading line
+
+const GITHUB_RELEASE_URL = `https://github.com/internetarchive/iaux/releases/new?tag=${tag}&title=${tag}&body=${encodeURIComponent(releaseBody)}`;
+execSync(`echo "${GITHUB_RELEASE_URL}" | pbcopy`);
+execSync(`open "${GITHUB_RELEASE_URL}"`);
+console.log(`After you push/merge, use this link to release: ${GITHUB_RELEASE_URL}\n\nThe URL has also been copied to the clipboard.`);

--- a/packages/ia-components/scripts/version.js
+++ b/packages/ia-components/scripts/version.js
@@ -1,15 +1,16 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
 const { version: NEW_VERSION } = require('../package.json');
+const writeFence = '<!-- Write here... -->';
 
 async function main() {
   // Update the changelog
-  const old_changelog = fs.readFileSync('CHANGELOG.md').toString();
-  const new_changelog = `# ${NEW_VERSION}\n<!-- Write here... -->\n\n` + old_changelog;
-  fs.writeFileSync('CHANGELOG.md', new_changelog);
-  while (fs.readFileSync('CHANGELOG.md').toString().includes('<!-- Write here... -->')) {
+  const oldChangelog = fs.readFileSync('CHANGELOG.md').toString();
+  const newChangelog = `# ${NEW_VERSION}\n${writeFence}\n\n` + oldChangelog;
+  fs.writeFileSync('CHANGELOG.md', newChangelog);
+  while (fs.readFileSync('CHANGELOG.md').toString().includes(writeFence)) {
     console.log('Changelog contains dummy text. Update the changelog, and press ENTER continue.');
-    await new Promise(res => process.stdin.once("data", res));
+    await new Promise(res => process.stdin.once('data', res));
   }
   execSync('git add CHANGELOG.md');
 }

--- a/packages/ia-components/scripts/version.js
+++ b/packages/ia-components/scripts/version.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { version: NEW_VERSION } = require('../package.json');
+
+async function main() {
+  // Update the changelog
+  const old_changelog = fs.readFileSync('CHANGELOG.md').toString();
+  const new_changelog = `# ${NEW_VERSION}\n<!-- Write here... -->\n\n` + old_changelog;
+  fs.writeFileSync('CHANGELOG.md', new_changelog);
+  while (fs.readFileSync('CHANGELOG.md').toString().includes('<!-- Write here... -->')) {
+    console.log('Changelog contains dummy text. Update the changelog, and press ENTER continue.');
+    await new Promise(res => process.stdin.once("data", res));
+  }
+  execSync('git add CHANGELOG.md');
+}
+
+main().then(() => process.exit());


### PR DESCRIPTION
**Description**

Adds version and postversion scripts to make tagging releases in GitHub easier.
Closes #332 . 

**Technical**

Version number should first be updated in package.json. Once updated, running `npm run version` will write a release message placeholder to CHANGELOG.md. Replace with your release message, save CHANGELOG.md, then press a key at the prompt. A browser window should open with the release info prefilled, the URL copied to the clipboard, and rendered to the terminal output.

**Testing**

Run `npm run version`