### PR TITLE
Playback Controls: Add Controls for Jumping Through Sections

### DIFF
--- a/packages/playback-controls/demo/index.html
+++ b/packages/playback-controls/demo/index.html
@@ -33,6 +33,8 @@
           @back-button-pressed=${backButtonPressed}
           @play-pause-button-pressed=${playPauseButtonPressed}
           @forward-button-pressed=${forwardButtonPressed}
+          @prev-section-button-pressed=${prevSectionButtonPressed}
+          @next-section-button-pressed=${nextSectionButtonPressed}
           >
         </playback-controls>
 
@@ -43,16 +45,28 @@
     );
 
     function backButtonPressed() {
-      document.getElementById('currentAction').innerText = "Back Button Pressed"
+      updateCurrentActionText("Back Button Pressed");
     }
 
     function playPauseButtonPressed() {
-      document.getElementById('currentAction').innerText = "Play/Pause Button Pressed";
+      updateCurrentActionText("Play/Pause Button Pressed");
     }
 
     function forwardButtonPressed() {
-      document.getElementById('currentAction').innerText = "Forward Button Pressed"
+      updateCurrentActionText("Forward Button Pressed");
     }
-  </script>
+
+    function prevSectionButtonPressed() {
+      updateCurrentActionText("Previous Section Button Pressed");
+    }
+
+    function nextSectionButtonPressed() {
+      updateCurrentActionText("Next Section Button Pressed");
+    }
+
+    function updateCurrentActionText(text) {
+      document.getElementById('currentAction').innerText = text
+    }
+</script>
 </body>
 </html>

--- a/packages/playback-controls/package.json
+++ b/packages/playback-controls/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc -p tsconfig.build.json",
-    "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
+    "watch": "tsc --watch",
+    "devserver": "es-dev-server --app-index demo/index.html --node-resolve --open --watch",
+    "start": "concurrently \"npm run watch\" \"npm run devserver\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",
     "lint:eslint": "eslint --ext .ts . --ignore-path .gitignore",
     "format:eslint": "eslint --ext .ts . --fix --ignore-path .gitignore",

--- a/packages/playback-controls/src/assets/img/next-section.ts
+++ b/packages/playback-controls/src/assets/img/next-section.ts
@@ -1,0 +1,12 @@
+import { html } from 'lit-html';
+
+const image = html`
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" viewBox="0 0 18 20">
+  <g fill="none" fill-rule="evenodd" transform="translate(1)">
+    <polygon fill="#FFF" points="7 3 16 17 -2 17" transform="rotate(90 7 10)"/>
+    <line x1="15" x2="15" y1="20" stroke="#FFF" stroke-width="2"/>
+  </g>
+</svg>
+`;
+
+export default image;

--- a/packages/playback-controls/src/assets/img/previous-section.ts
+++ b/packages/playback-controls/src/assets/img/previous-section.ts
@@ -1,0 +1,12 @@
+import { html } from 'lit-html';
+
+const image = html`
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" viewBox="0 0 18 20">
+  <g fill="none" fill-rule="evenodd" transform="translate(1 1)">
+    <polygon fill="#FFF" points="9 2 18 16 0 16" transform="rotate(-90 9 9)"/>
+    <line x1=".5" x2=".5" y1="18" stroke="#FFF" stroke-width="2"/>
+  </g>
+</svg>
+`;
+
+export default image;

--- a/packages/playback-controls/src/playback-controls.ts
+++ b/packages/playback-controls/src/playback-controls.ts
@@ -1,6 +1,9 @@
 import { LitElement, html, css, customElement, property, TemplateResult } from 'lit-element';
 import { PlaybackMode } from './playback-mode';
 
+import nextSectionImage from './assets/img/next-section';
+import prevSectionImage from './assets/img/previous-section';
+
 import replayImage from './assets/img/replay';
 import skipAheadImage from './assets/img/skip-ahead';
 import playImage from './assets/img/play';
@@ -24,7 +27,7 @@ export default class PlaybackControls extends LitElement {
       <div class="container">
         <div class="vertical-button-stack playback-speed">
           <div class="vertical-button-container">
-            <button class="unstyled-button" @click="${this.handlePlaybackRateChange}">
+            <button id="playback-rate-btn" class="unstyled-button" @click="${this.handlePlaybackRateChange}">
               ${playbackSpeedImage}
             </button>
           </div>
@@ -32,6 +35,9 @@ export default class PlaybackControls extends LitElement {
             ${this.playbackRate}x
           </div>
         </div>
+        <button id="prev-section-btn" class="jump-btn unstyled-button" @click="${this.handlePrevSectionButton}">
+          ${prevSectionImage}
+        </button>
         <button id="back-btn" class="jump-btn unstyled-button" @click="${this.handleBackButton}">
           ${replayImage}
         </button>
@@ -41,9 +47,12 @@ export default class PlaybackControls extends LitElement {
         <button id="forward-btn" class="jump-btn unstyled-button" @click="${this.handleForwardButton}">
           ${skipAheadImage}
         </button>
+        <button id="next-section-btn" class="jump-btn unstyled-button" @click="${this.handleNextSectionButton}">
+          ${nextSectionImage}
+        </button>
         <div class="vertical-button-stack volume">
           <div class="vertical-button-container">
-            <button class="unstyled-button" @click="${this.handleVolumeChange}">
+            <button id="volume-control-btn" class="unstyled-button" @click="${this.handleVolumeChange}">
               ${this.volumeButtonImage}
             </button>
           </div>
@@ -88,8 +97,6 @@ export default class PlaybackControls extends LitElement {
 
     const event = new CustomEvent('playbackRateChange', {
       detail: { playbackRate: this.playbackRate },
-      bubbles: true,
-      composed: true,
     });
     this.dispatchEvent(event);
   }
@@ -103,14 +110,22 @@ export default class PlaybackControls extends LitElement {
 
     const event = new CustomEvent('volumeChange', {
       detail: { volume: this.volume },
-      bubbles: true,
-      composed: true,
     });
     this.dispatchEvent(event);
   }
 
   handleBackButton() {
     const event = new Event('back-button-pressed');
+    this.dispatchEvent(event);
+  }
+
+  handlePrevSectionButton() {
+    const event = new Event('prev-section-button-pressed');
+    this.dispatchEvent(event);
+  }
+
+  handleNextSectionButton() {
+    const event = new Event('next-section-button-pressed');
     this.dispatchEvent(event);
   }
 
@@ -126,6 +141,8 @@ export default class PlaybackControls extends LitElement {
   }
 
   static get styles() {
+    const playPauseDiameterCss = css`var(--playPauseDiameter, 4rem)`;
+
     return css`
       :host {
         display: flex;
@@ -168,8 +185,8 @@ export default class PlaybackControls extends LitElement {
 
       #play-pause-btn {
         border-radius: 50%;
-        height: 3rem;
-        width: 3rem;
+        height: ${playPauseDiameterCss};
+        width: ${playPauseDiameterCss};
         border: none;
         background-color: white;
         vertical-align: middle;

--- a/packages/playback-controls/test/playback-controls.test.js
+++ b/packages/playback-controls/test/playback-controls.test.js
@@ -76,4 +76,87 @@ describe('PlaybackControls', () => {
     const response = await oneEvent(el, 'forward-button-pressed');
     expect(response).to.exist;
   });
+
+  it('emits an event when playback rate button is pressed', async () => {
+    const el = await fixture(html`
+      <playback-controls></playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('playback-rate-btn');
+    const clickEvent = new MouseEvent('click');
+
+    setTimeout(() => { forwardBtn.dispatchEvent(clickEvent); });
+
+    const response = await oneEvent(el, 'playbackRateChange');
+    expect(response).to.exist;
+  });
+
+  it('emits an event when volume control button is pressed', async () => {
+    const el = await fixture(html`
+      <playback-controls></playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('volume-control-btn');
+    const clickEvent = new MouseEvent('click');
+
+    setTimeout(() => { forwardBtn.dispatchEvent(clickEvent); });
+
+    const response = await oneEvent(el, 'volumeChange');
+    expect(response).to.exist;
+  });
+
+  it('emits an event when previous section button is pressed', async () => {
+    const el = await fixture(html`
+      <playback-controls></playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('prev-section-btn');
+    const clickEvent = new MouseEvent('click');
+
+    setTimeout(() => { forwardBtn.dispatchEvent(clickEvent); });
+
+    const response = await oneEvent(el, 'prev-section-button-pressed');
+    expect(response).to.exist;
+  });
+
+  it('emits an event when next section button is pressed', async () => {
+    const el = await fixture(html`
+      <playback-controls></playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('next-section-btn');
+    const clickEvent = new MouseEvent('click');
+
+    setTimeout(() => { forwardBtn.dispatchEvent(clickEvent); });
+
+    const response = await oneEvent(el, 'next-section-button-pressed');
+    expect(response).to.exist;
+  });
+
+  it('changes playback rate to 0.5 after it has reached 2.0', async () => {
+    const el = await fixture(html`
+      <playback-controls
+        playbackRate='2.0'>
+      </playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('playback-rate-btn');
+    const clickEvent = new MouseEvent('click');
+    forwardBtn.dispatchEvent(clickEvent);
+    expect(el.playbackRate).to.equal(0.5);
+  });
+
+  it('changes volume by 0.25 when less than 1.0', async () => {
+    const el = await fixture(html`
+      <playback-controls
+        volume='0.5'>
+      </playback-controls>
+    `);
+
+    const forwardBtn = el.shadowRoot.getElementById('volume-control-btn');
+    const clickEvent = new MouseEvent('click');
+    forwardBtn.dispatchEvent(clickEvent);
+    expect(el.volume).to.equal(0.75);
+  });
+
 });


### PR DESCRIPTION
**Description**

> This adds two buttons for going backwards and forwards by section.

**Technical**

> Adds new SVGs and emits events when the buttons are pressed.

**Testing**

> Run `yarn install`, `yarn test` to run the tests. Run `yarn start` to play with the controls in the browser.

**Evidence**

> ![Screen Shot 2019-10-29 at 3 31 07 PM](https://user-images.githubusercontent.com/51138/67814684-e6a73400-fa61-11e9-838b-553c16e84ee6.png)

