### PR TITLE
Audio Element: Stop Bubbling of Events

### DIFF
--- a/packages/audio-element/src/audio-element.ts
+++ b/packages/audio-element/src/audio-element.ts
@@ -112,8 +112,6 @@ export default class AudioElement extends LitElement {
     const target = e.target as HTMLAudioElement;
     const event = new CustomEvent('durationchange', {
       detail: { duration: target.duration },
-      bubbles: true,
-      composed: true,
     });
     this.dispatchEvent(event);
   }
@@ -122,8 +120,6 @@ export default class AudioElement extends LitElement {
     const target = e.target as HTMLAudioElement;
     const event = new CustomEvent('timeupdate', {
       detail: { currentTime: target.currentTime },
-      bubbles: true,
-      composed: true,
     });
     this.dispatchEvent(event);
   }


### PR DESCRIPTION
**Description**

> We don't want events to escape their shadowRoot. This prevents them from leaking up to parent listeners.

**Technical**

> n/a

**Testing**

> n/a

**Evidence**

> n/a