### PR TITLE
Scrubber Bar: Add Section Markers

### DIFF
--- a/packages/scrubber-bar/demo/index.html
+++ b/packages/scrubber-bar/demo/index.html
@@ -4,7 +4,15 @@
   <meta charset="utf-8">
   <style>
     body {
-      background: #fafafa;
+      background: black;
+      color: white;
+    }
+
+    scrubber-bar {
+      --trackFillColor: rgba(50, 114, 182, 1);
+      --trackColor: rgba(255, 255, 255, 0.2);
+      --markerHeightExpanded: 25px;
+      --markerHeightCollapsed: 10px;
     }
   </style>
 </head>
@@ -17,10 +25,19 @@
 
     render(
       html`
-        <scrubber-bar></scrubber-bar>
+        <scrubber-bar
+          sectionMarkerPercentages='[0, 10, 11, 25, 30, 50, 75, 100]'
+          value='37'
+          @valuechange=${valueChange}>
+        </scrubber-bar>
+        <span class="value">0</span>%
       `,
       document.querySelector('#demo')
     );
+
+    function valueChange(e) {
+      document.querySelector('.value').innerHTML = e.detail.value;
+    }
   </script>
 </body>
 </html>

--- a/packages/scrubber-bar/index.js
+++ b/packages/scrubber-bar/index.js
@@ -1,3 +1,4 @@
 import ScrubberBar from './lib/scrubber-bar.js';
+import { SectionMarker, SectionMarkerMode } from './lib/section-marker.js';
 
-export default ScrubberBar;
+export { ScrubberBar, SectionMarker, SectionMarkerMode };

--- a/packages/scrubber-bar/package.json
+++ b/packages/scrubber-bar/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc -p tsconfig.build.json",
-    "start": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch\"",
+    "watch": "tsc --watch",
+    "devserver": "es-dev-server --app-index demo/index.html --node-resolve --open --watch",
+    "start": "concurrently \"npm run watch\" \"npm run devserver\"",
     "start:compatibility": "concurrently \"tsc --watch\" \"es-dev-server --app-index demo/index.html --node-resolve --open --watch --compatibility all\"",
     "lint:eslint": "eslint --ext .ts . --ignore-path .gitignore",
     "format:eslint": "eslint --ext .ts . --fix --ignore-path .gitignore",

--- a/packages/scrubber-bar/src/assets/img/next-section-marker.ts
+++ b/packages/scrubber-bar/src/assets/img/next-section-marker.ts
@@ -1,0 +1,7 @@
+import { html } from 'lit-html';
+
+const image = html`
+<svg height="10" viewBox="0 0 8 10" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m4 1 5 8h-10z" fill="#fff" fill-rule="evenodd" transform="matrix(0 1 -1 0 9 1)"/></svg>
+`;
+
+export default image;

--- a/packages/scrubber-bar/src/assets/img/previous-section-marker.ts
+++ b/packages/scrubber-bar/src/assets/img/previous-section-marker.ts
@@ -1,0 +1,7 @@
+import { html } from 'lit-html';
+
+const image = html`
+<svg height="10" viewBox="0 0 8 10" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m4 1 5 8h-10z" fill="#fff" fill-rule="evenodd" transform="matrix(0 -1 1 0 -1 9)"/></svg>
+`;
+
+export default image;

--- a/packages/scrubber-bar/src/scrubber-bar.ts
+++ b/packages/scrubber-bar/src/scrubber-bar.ts
@@ -237,7 +237,7 @@ export default class ScrubberBar extends LitElement {
       section-marker {
         position: absolute;
         width: 2rem;
-        height: 40px;
+        height: ${trackHeight};
         bottom: 7px;
         /*
           we set the left side of the marker to the spot where we want it, but the marker line is in

--- a/packages/scrubber-bar/src/scrubber-bar.ts
+++ b/packages/scrubber-bar/src/scrubber-bar.ts
@@ -9,6 +9,9 @@ import {
   CSSResult,
 } from 'lit-element';
 
+import './section-marker';
+import { SectionMarker, SectionMarkerMode } from './section-marker';
+
 @customElement('scrubber-bar')
 export default class ScrubberBar extends LitElement {
   @property({ type: Number }) value = 0;
@@ -18,6 +21,10 @@ export default class ScrubberBar extends LitElement {
   @property({ type: Number }) max = 100;
 
   @property({ type: Number }) step = 0.1;
+
+  @property({ type: Array }) sectionMarkerPercentages: number[] = [];
+
+  @property({ type: Boolean }) expandSectionMarkers: boolean = false;
 
   get percentage(): number {
     const delta: number = this.max - this.min;
@@ -35,6 +42,20 @@ export default class ScrubberBar extends LitElement {
   render(): TemplateResult {
     return html`
       <div class="container">
+        <div class="color-fill">
+        </div>
+
+        <div class="marker-container">
+        ${this.sectionMarkerPercentages.map((markerPercent: number) => {
+          return html`
+            <section-marker
+              data-location=${markerPercent}
+              style="left: ${markerPercent}%">
+            </section-marker>
+          `;
+        })}
+        </div>
+
         <input
           id="slider"
           type="range"
@@ -49,6 +70,7 @@ export default class ScrubberBar extends LitElement {
           @input=${this.handleSlide}
           @change=${this.handleSlide}
         />
+
         <div id="webkit-range-input-style"></div>
       </div>
     `;
@@ -57,20 +79,24 @@ export default class ScrubberBar extends LitElement {
   updated(changedProperties: PropertyValues): void {
     if (this._userInteracting || !changedProperties.has('value')) { return; }
     this._value = this.value;
+    /* istanbul ignore else */
     if (this.rangeSlider) {
       this.rangeSlider.value = `${this.value}`;
     }
-    this.updateSliderProgress();
+    this.updateWebkitSliderStyle();
+    this.updateMarkerFlags();
   }
 
   firstUpdated(): void {
-    this.updateSliderProgress();
+    this.updateWebkitSliderStyle();
+    this.updateMarkerFlags();
   }
 
   private handleSlide(e: Event): void {
     const newValue = (e.target as HTMLInputElement).value;
     this._value = parseFloat(newValue);
-    this.updateSliderProgress();
+    this.updateWebkitSliderStyle();
+    this.updateMarkerFlags();
     this.emitChangeEvent();
   }
 
@@ -92,15 +118,16 @@ export default class ScrubberBar extends LitElement {
     return this.shadowRoot && this.shadowRoot.getElementById('webkit-range-input-style');
   }
 
-  private updateSliderProgress(): void {
+  private updateWebkitSliderStyle(): void {
+    /* istanbul ignore if */
     if (!this.webkitStyle) { return; }
 
     this.webkitStyle.innerHTML = `
       <style>
-        input[type=range]::-webkit-slider-runnable-track {
+        .color-fill {
           background: linear-gradient(to right,
             var(--trackFillColor, #3272b6) 0%, var(--trackFillColor, #3272b6) ${this.percentage}%,
-            var(--trackColor, purple) ${this.percentage}%, var(--trackColor, purple) 100%);
+            var(--trackColor, rgba(0, 0, 0, 0.1)) ${this.percentage}%, var(--trackColor, rgba(0, 0, 0, 0.1)) 100%);
         }
       </style>
     `;
@@ -109,13 +136,48 @@ export default class ScrubberBar extends LitElement {
   private emitChangeEvent(): void {
     const event = new CustomEvent('valuechange', {
       detail: { value: this._value },
-      bubbles: true,
-      composed: true,
     });
     this.dispatchEvent(event);
   }
 
+  private get sortedMarkers(): number[] {
+    return this.sectionMarkerPercentages.sort();
+  }
+
+  private updateMarkerFlags(): void {
+    if (!this.expandSectionMarkers) { return; }
+
+    const currentValue: number = this._value;
+
+    const percentsGreaterThanValue: number[] = this.sortedMarkers.filter(value => value > currentValue);
+    const closestUpper = Math.min(...percentsGreaterThanValue);
+
+    const percentsLessThanValue: number[] = this.sortedMarkers.filter(value => value <= currentValue);
+    const closestLower = Math.max(...percentsLessThanValue);
+
+    this.sectionMarkerPercentages.forEach(value => {
+      /* istanbul ignore if */
+      if (!this.shadowRoot) { return; }
+      const marker: SectionMarker | null = this.shadowRoot.querySelector(`section-marker[data-location="${value}"]`)
+      /* istanbul ignore if */
+      if (!marker) { return; }
+
+      switch (value) {
+        case closestUpper:
+          marker.markerMode = SectionMarkerMode.left;
+          break;
+        case closestLower:
+          marker.markerMode = SectionMarkerMode.right;
+          break;
+        default:
+          marker.markerMode = SectionMarkerMode.neither;
+      }
+    });
+  }
+
   static get styles(): CSSResult {
+    const markerInset = css`var(--markerInset, 10px)`;
+
     const scrubberBarHeight = css`var(--scrubberBarHeight, 20px)`;
 
     const thumbDiameter = css`var(--thumbDiameter, 20px)`;
@@ -127,7 +189,7 @@ export default class ScrubberBar extends LitElement {
     const trackBorderRadius = css`var(--trackBorderRadius, 5px)`;
     const trackBorder = css`var(--trackBorder, 1px solid white)`;
     const trackFillColor = css`var(--trackFillColor, #3272b6)`;
-    const trackColor = css`var(--trackColor, black)`;
+    const trackColor = css`var(--trackColor, rgba(0, 0, 0, 0.1))`;
 
     const webkitThumbTopMargin = css`var(--webkitThumbTopMargin, -6px)`;
 
@@ -146,12 +208,45 @@ export default class ScrubberBar extends LitElement {
     `;
 
     const commonTrackDefinitions = css`
-      background-color: ${trackColor};
       border: ${trackBorder};
       ${trackSizeDefinitions};
     `;
 
     return css`
+      .container {
+        position: relative;
+        height: 20px;
+      }
+
+      .color-fill {
+        height: 10px;
+        border-radius: 1em;
+        position: absolute;
+        bottom: 7px;
+        left: 2px;
+        right: -2px;
+      }
+
+      .marker-container {
+        position: absolute;
+        left: ${markerInset};
+        right: ${markerInset};
+        height: 100%;
+      }
+
+      section-marker {
+        position: absolute;
+        width: 2rem;
+        height: 40px;
+        bottom: 7px;
+        /*
+          we set the left side of the marker to the spot where we want it, but the marker line is in
+          the center of the marker so we need to shift it to the left by half its width so this transform
+          is doing that
+         */
+        transform: translateX(-50%);
+      }
+
       input[type='range'] {
         -webkit-appearance: none;
         height: ${scrubberBarHeight};
@@ -159,6 +254,8 @@ export default class ScrubberBar extends LitElement {
         width: 100%;
         background: none;
         outline: none;
+        position: absolute;
+        bottom: 0;
       }
 
       input[type='range']::-webkit-slider-thumb {
@@ -187,7 +284,6 @@ export default class ScrubberBar extends LitElement {
       }
 
       input[type='range']::-moz-range-progress {
-        background-color: ${trackFillColor};
         ${trackSizeDefinitions};
       }
 

--- a/packages/scrubber-bar/src/section-marker.ts
+++ b/packages/scrubber-bar/src/section-marker.ts
@@ -1,0 +1,92 @@
+import {
+  LitElement,
+  html,
+  css,
+  customElement,
+  property,
+  PropertyValues,
+  TemplateResult,
+  CSSResult,
+} from 'lit-element';
+
+enum SectionMarkerMode {
+  left = 'left',
+  right = 'right',
+  both = 'both',
+  neither = 'neither',
+}
+
+import prevSectionImage from './assets/img/previous-section-marker';
+import nextSectionImage from './assets/img/next-section-marker';
+
+@customElement('section-marker')
+class SectionMarker extends LitElement {
+
+  @property({ type: SectionMarkerMode }) markerMode = SectionMarkerMode.neither;
+
+  render(): TemplateResult {
+    return html`
+      <div class="container mode-${this.markerMode}">
+        <div class="left-arrow arrow">${nextSectionImage}</div>
+        <div class="center-divider"></div>
+        <div class="right-arrow arrow">${prevSectionImage}</div>
+      </div>
+    `;
+  }
+
+  static get styles(): CSSResult {
+    const animationSpeed: CSSResult = css`0.1s`;
+    const markerHeightCollapsedCss = css`var(--markerHeightCollapsed, 10px)`;
+    const markerHeightExpandedCss = css`var(--markerHeightExpanded, 25px)`;
+
+    return css`
+      .container {
+        display: flex;
+        justify-content: center;
+        height: 100%;
+      }
+
+      .arrow {
+        padding-top: 10px;
+        opacity: 1;
+        transition: opacity ${animationSpeed} ease-out, padding-top ${animationSpeed} ease-out;
+      }
+
+      .right-arrow {
+        visibility: hidden;
+      }
+
+      .arrow {
+        visibility: hidden;
+      }
+
+      .container.mode-left .right-arrow {
+        opacity: 0;
+      }
+
+      .container.mode-right .left-arrow {
+        opacity: 0;
+      }
+
+      .container.mode-neither .left-arrow, .container.mode-neither .right-arrow {
+        opacity: 0;
+        padding-top: 75%;
+      }
+
+      .container.mode-neither .center-divider {
+        height: ${markerHeightCollapsedCss};
+      }
+
+      .center-divider {
+        border-left: 1px solid white;
+        width: 1px;
+        left: 50%;
+        height: ${markerHeightExpandedCss};
+        align-self: flex-end;
+        transition: height ${animationSpeed} ease-out;
+      }
+    `;
+  }
+}
+
+export { SectionMarkerMode, SectionMarker };

--- a/packages/scrubber-bar/test/promised-sleep.js
+++ b/packages/scrubber-bar/test/promised-sleep.js
@@ -1,0 +1,3 @@
+export default function promisedSleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/scrubber-bar/test/scrubber-bar.test.js
+++ b/packages/scrubber-bar/test/scrubber-bar.test.js
@@ -1,6 +1,7 @@
 import { html, fixture, expect, oneEvent } from '@open-wc/testing';
 
 import '../index';
+import promisedSleep from './promised-sleep';
 
 /* eslint-disable no-unused-expressions */
 
@@ -158,5 +159,58 @@ describe('ScrubberBar', () => {
     el.value = 20;
 
     expect(rangeSlider.value).to.equal('0');
+  });
+
+  it('properly lays out section markers', async() => {
+    const el = await fixture(html`
+      <scrubber-bar
+        sectionMarkerPercentages='[10, 11, 25, 30, 50, 75]'>
+      </scrubber-bar>
+    `);
+
+    const sectionMarkers = el.shadowRoot.querySelectorAll('section-marker');
+    expect(sectionMarkers.length).to.equal(6);
+
+    const testMarker = sectionMarkers[1];
+    expect(testMarker.style.left).to.equal('11%');
+  });
+
+  it('sets the marker flag values properly', async() => {
+    const el = await fixture(html`
+      <scrubber-bar
+        sectionMarkerPercentages='[10, 11, 25, 30, 50, 75]'
+        value='37'
+        expandSectionMarkers='true'>
+      </scrubber-bar>
+    `);
+
+    const sectionMarkers = el.shadowRoot.querySelectorAll('section-marker');
+    const prevMarker = sectionMarkers[2];
+    const leftMarker = sectionMarkers[3];
+    const rightMarker = sectionMarkers[4];
+    const nextMarker = sectionMarkers[5];
+    expect(prevMarker.markerMode).to.equal('neither');
+    expect(leftMarker.markerMode).to.equal('right');
+    expect(rightMarker.markerMode).to.equal('left');
+    expect(nextMarker.markerMode).to.equal('neither');
+  });
+
+  it('sets does not set the section markers if `expandSectionMarkers` is `false`', async() => {
+    const el = await fixture(html`
+      <scrubber-bar
+        sectionMarkerPercentages='[10, 11, 25, 30, 50, 75]'
+        value='37'>
+      </scrubber-bar>
+    `);
+
+    const sectionMarkers = el.shadowRoot.querySelectorAll('section-marker');
+    const prevMarker = sectionMarkers[2];
+    const leftMarker = sectionMarkers[3];
+    const rightMarker = sectionMarkers[4];
+    const nextMarker = sectionMarkers[5];
+    expect(prevMarker.markerMode).to.equal('neither');
+    expect(leftMarker.markerMode).to.equal('neither');
+    expect(rightMarker.markerMode).to.equal('neither');
+    expect(nextMarker.markerMode).to.equal('neither');
   });
 });

--- a/packages/scrubber-bar/test/section-marker.test.js
+++ b/packages/scrubber-bar/test/section-marker.test.js
@@ -1,0 +1,15 @@
+import { html, fixture, expect, oneEvent } from '@open-wc/testing';
+
+import '../index';
+
+/* eslint-disable no-unused-expressions */
+
+describe('SectionMarker', () => {
+  it('marker mode defaults to `neither`', async () => {
+    const el = await fixture(html`
+      <section-marker></section-marker>
+    `);
+
+    expect(el.markerMode).to.equal("neither");
+  });
+});


### PR DESCRIPTION
**Description**

> This adds optional section markers to the scrubber that denote different sections in the playback.

**Technical**

> n/a

**Testing**

> Run `yarn install`, `yarn test` to run the tests. Run `yarn start` to play with it in the browser.

**Evidence**

> ![Screen Shot 2019-10-29 at 3 48 01 PM](https://user-images.githubusercontent.com/51138/67815302-d42dfa00-fa63-11e9-92d5-21913a23276d.png)
