### PR TITLE
Temporarily ignoring selenium tests in Jest

### DIFF
--- a/packages/ia-components/jest.config.js
+++ b/packages/ia-components/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
   clearMocks: true,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: '<rootDir>/jest-test-utils/jest-test-coverage'
+  coverageDirectory: '<rootDir>/jest-test-utils/jest-test-coverage',
+
+  modulePathIgnorePatterns: ['<rootDir>/integration/']
 };

--- a/packages/ia-components/jest.config.js
+++ b/packages/ia-components/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
   // The directory where Jest should output its coverage files
   coverageDirectory: '<rootDir>/jest-test-utils/jest-test-coverage',
 
+  // ignore test files in these directories
   modulePathIgnorePatterns: ['<rootDir>/integration/']
 };


### PR DESCRIPTION

**Description**

This will allow for unit tests to pass through CI


**Technical**

- updating jest config file to ignore directory

**Testing**

pull down branch, run: `yarn run test:watch` => all tests pass

**Evidence**

![Screen Shot 2020-01-07 at 12 56 11 PM](https://user-images.githubusercontent.com/7840857/71928878-3f273b80-314d-11ea-86d0-c67bb20b9e8c.png)
