### PR TITLE
Increases desktop max and widescreen min widths

### DIFF
--- a/packages/ia-components/variables.less
+++ b/packages/ia-components/variables.less
@@ -3,8 +3,8 @@
 @audio-player-tablet-min-width: 481px;
 @audio-player-tablet-max-width: 767px;
 @audio-player-desktop-min-width: 768px;
-@audio-player-desktop-max-width: 992px;
-@audio-player-widescreen-min-width: 993px;
+@audio-player-desktop-max-width: 1200px;
+@audio-player-widescreen-min-width: 1201px;
 @audio-player-extra-widescreen-min-width: 1600px;
 @audio-player-desktop-break: 950px;
 


### PR DESCRIPTION
**Description**

This increases the width range of the desktop breakpoint to account for both BookReader controls being visible and track lists being rendered nicely when long track names are present. Closes [WEBDEV-3056](https://webarchive.jira.com/browse/WEBDEV-3056)

**Testing**

See Jira ticket
