### PR TITLE
Transcript Scrolling Fix

### DIFF
--- a/packages/radio-player/package.json
+++ b/packages/radio-player/package.json
@@ -40,7 +40,7 @@
     "@internetarchive/expandable-search-bar": "0.0.1-alpha.530",
     "@internetarchive/playback-controls": "0.0.1-alpha.530",
     "@internetarchive/scrubber-bar": "0.0.1-alpha.530",
-    "@internetarchive/transcript-view": "0.0.1-alpha.533",
+    "@internetarchive/transcript-view": "0.0.1-alpha.504",
     "@internetarchive/waveform-progress": "0.0.1-alpha.530",
     "lit-element": "^2.2.1",
     "lit-html": "^1.0.0"

--- a/packages/radio-player/yarn.lock
+++ b/packages/radio-player/yarn.lock
@@ -1080,10 +1080,10 @@
     lit-element "^2.2.1"
     lit-html "^1.0.0"
 
-"@internetarchive/transcript-view@0.0.1-alpha.533":
-  version "0.0.1-alpha.533"
-  resolved "https://registry.yarnpkg.com/@internetarchive/transcript-view/-/transcript-view-0.0.1-alpha.533.tgz#ad270d8b6d6a99ebeb37edfac58db8e6090b131f"
-  integrity sha512-UmcdVC9EKLebPzWeon2H5cwnOGPZyDtAjPQhh5blXkmdV2mE9eyoozDDpPf1daSJMStc2oVbv5teG+T1mbjGVw==
+"@internetarchive/transcript-view@0.0.1-alpha.504":
+  version "0.0.1-alpha.504"
+  resolved "https://registry.yarnpkg.com/@internetarchive/transcript-view/-/transcript-view-0.0.1-alpha.504.tgz#3f8e46f09a0faefc46b15b7a3f7fff1f65ef0d6b"
+  integrity sha512-nucAmfBzOsPpnH9Fk9srpTzb6Ok8bWnuK/DfbL3h77H9EqLMtgVQrcTEHCcAS/StgMh1kZr91a4HxtADVtY1yA==
   dependencies:
     lit-element "^2.2.1"
     lit-html "^1.0.0"

--- a/packages/transcript-view/src/transcript-view.ts
+++ b/packages/transcript-view/src/transcript-view.ts
@@ -302,6 +302,7 @@ export default class TranscriptView extends LitElement {
 
   private handleCurrentTimeChange(): void {
     const entries = this.transcriptEntries;
+
     if (entries.length === 0) {
       return;
     }
@@ -312,13 +313,55 @@ export default class TranscriptView extends LitElement {
     );
 
     // this method gets called for every time update, which happens several times per second, but
-    // we only want to update the UI if the `currentEntry` has actually changed
+    // we only want to update the UI if the `currentEntries` have actually changed
     // (ie, their ids don't match)
-    if (this.currentEntries === activeEntries) {
+    const entriesMatch = this.entryArraysMatch(activeEntries, this.currentEntries);
+    if (entriesMatch) {
       return;
     }
 
+    this.dispatchEvent(new Event('currentEntriesUpdated'));
+
     this.currentEntries = activeEntries;
+  }
+
+  /**
+   * Compare two arrays of TranscriptEntryConfigs.
+   *
+   * This is useful for minimizing the amount of UI updates needed above in the
+   * `handleCurrentTimeChange` method above so it only updates when the entries
+   * have actually changed.
+   *
+   * @private
+   * @param {TranscriptEntryConfig[]} entryArrayA
+   * @param {TranscriptEntryConfig[]} entryArrayB
+   * @returns {boolean}
+   * @memberof TranscriptView
+   */
+  private entryArraysMatch(
+    entryArrayA: TranscriptEntryConfig[],
+    entryArrayB: TranscriptEntryConfig[]
+  ): boolean {
+
+    if (entryArrayA.length !== entryArrayB.length) {
+      return false;
+    }
+
+    const entryArrayAIds = entryArrayA.map(entry => entry.id).sort();
+    const entryArrayBIds = entryArrayB.map(entry => entry.id).sort();
+
+    let arraysMatch = true;
+    entryArrayAIds.forEach((value: number, index: number) => {
+      if (entryArrayBIds[index] !== value) {
+        arraysMatch = false;
+      }
+    });
+
+    if (arraysMatch) {
+      return true;
+    }
+
+    return false;
   }
 
   // This finds the transcript entry that is closest to a given time.

--- a/packages/transcript-view/test/transcript-view.test.js
+++ b/packages/transcript-view/test/transcript-view.test.js
@@ -135,35 +135,11 @@ describe('TranscriptView', () => {
     expect(el.currentEntries.length).to.equal(1);
     expect(el.currentEntries[0]).to.equal(entry1);
 
-    el.currentTime = 69;
-
-    await promisedSleep(1);
-
+    setTimeout(() => { el.currentTime = 69; });
+    const response = await oneEvent(el, 'currentEntriesUpdated');
+    expect(response).to.exist;
     expect(el.currentEntries.length).to.equal(1);
     expect(el.currentEntries[0]).to.equal(entry2);
-  });
-
-  it('does not change the current entry if the id has not changed', async () => {
-    const entry1 = new TranscriptEntryConfig(1, 64, 67, 'foo', undefined);
-    const entry2 = new TranscriptEntryConfig(2, 68, 73, 'bar', undefined);
-    const entry3 = new TranscriptEntryConfig(3, 74, 78, 'baz', undefined);
-
-    const config = new TranscriptConfig([entry1, entry2, entry3])
-
-    const el = await fixture(html`
-      <transcript-view
-        .config=${config}
-        currentTime='65'>
-      </transcript-view>
-    `);
-
-    expect(el.currentEntries[0]).to.equal(entry1);
-
-    el.currentTime = 66;
-
-    await promisedSleep(1);
-
-    expect(el.currentEntries[0]).to.equal(entry1);
   });
 
   it('finds multiple current entries if they are active', async () => {


### PR DESCRIPTION
**Description**

> This fixes a bug in the transcript scroll where it would sometimes look like it was stuttering while it was scrolling.

**Technical**

> The cause of this issue is the revamped search code. We can now have more than one transcript entry highlighted at a time and the logic to determine which entry to highlight was basically causing the "scroll target" to constantly change so it would stutter while it was adjusting the scroll speed and duration.

**Testing**

1. Go to https://58-review-radio-play-lpp4ra.archive.org/details/Euronews_Radio_English_20190427_170000
2. Hit the Play Button
3. Scroll to the bottom of the transcript
4. Tap "Scroll text with audio"
5. Expected: It should not stutter while it scrolls.

**Evidence**

![SmoothScroll](https://user-images.githubusercontent.com/51138/75192456-1e20a700-5709-11ea-9d3c-9041a9591a79.gif)
