### PR TITLE
Radio Player: Don't Display the Waveform if one is not Available

### DIFF
--- a/packages/radio-player/demo/radio-player-controller.ts
+++ b/packages/radio-player/demo/radio-player-controller.ts
@@ -114,7 +114,11 @@ export default class RadioPlayerController extends LitElement {
         file.format.toLowerCase() === 'png' && file.original === originalAudioFile.name,
     );
 
-    const waveFormImageUrl = `https://archive.org/download/${this.itemId}/${waveFormImageFile.name}`;
+    let waveFormImageUrl;
+
+    if (waveFormImageFile) {
+      waveFormImageUrl = `https://archive.org/download/${this.itemId}/${waveFormImageFile.name}`;
+    }
 
     this.radioPlayerConfig = new RadioPlayerConfig(
       metadata.metadata.contributor,

--- a/packages/radio-player/src/models/radio-player-config.ts
+++ b/packages/radio-player/src/models/radio-player-config.ts
@@ -13,7 +13,7 @@ export default class RadioPlayerConfig {
 
   logoUrl: string;
 
-  waveformUrl: string;
+  waveformUrl: string | undefined;
 
   audioSources: AudioSource[];
 
@@ -33,7 +33,7 @@ export default class RadioPlayerConfig {
     title: string,
     date: string,
     logoUrl: string,
-    waveformUrl: string,
+    waveformUrl: string | undefined,
     audioSources: AudioSource[],
     quickSearches: string[] = [],
   ) {

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -274,7 +274,7 @@ export default class RadioPlayer extends LitElement {
    * @memberof RadioPlayer
    */
   private get waveFormProgressTemplate(): TemplateResult {
-    return html`
+    return this.waveformUrl ? html`
       <waveform-progress
         interactive="true"
         .waveformUrl=${this.waveformUrl}
@@ -282,7 +282,7 @@ export default class RadioPlayer extends LitElement {
         @valuechange=${this.valueChangedFromScrub}
       >
       </waveform-progress>
-    `;
+    ` : html``;
   }
 
   /**

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -273,7 +273,7 @@ export default class RadioPlayer extends LitElement {
    * @type {TemplateResult}
    * @memberof RadioPlayer
    */
-  private get waveFormProgressTemplate(): TemplateResult {
+  private get waveFormProgressTemplate(): TemplateResult | undefined {
     return this.waveformUrl ? html`
       <waveform-progress
         interactive="true"
@@ -282,7 +282,7 @@ export default class RadioPlayer extends LitElement {
         @valuechange=${this.valueChangedFromScrub}
       >
       </waveform-progress>
-    ` : html``;
+    ` : undefined;
   }
 
   /**
@@ -324,7 +324,7 @@ export default class RadioPlayer extends LitElement {
    * @type {string}
    * @memberof RadioPlayer
    */
-  private get waveformUrl(): string {
+  private get waveformUrl(): string | undefined {
     return this.config ? this.config.waveformUrl : '';
   }
 

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -26,7 +26,6 @@ describe('Radio Player', () => {
 
     const shadowRoot = el.shadowRoot;
 
-    expect(shadowRoot.querySelectorAll('waveform-progress').length).to.equal(1);
     expect(shadowRoot.querySelectorAll('transcript-view').length).to.equal(1);
     expect(shadowRoot.querySelectorAll('.collection-logo').length).to.equal(1);
     expect(shadowRoot.querySelectorAll('.title-date').length).to.equal(1);
@@ -36,7 +35,7 @@ describe('Radio Player', () => {
   });
 
   it('can be configured with a title and date', async () => {
-    const config = new RadioPlayerConfig('foo-title', 'bar-date', '', '', []);
+    const config = new RadioPlayerConfig('foo-title', 'bar-date', '', undefined, []);
 
     const el = await fixture(html`
       <radio-player .config=${config}></radio-player>
@@ -47,6 +46,16 @@ describe('Radio Player', () => {
 
     expect(titleDisplay.innerText).to.equal('foo-title');
     expect(dateDisplay.innerText).to.equal('bar-date');
+  });
+
+  it('does not render the waveform if one is not passed in', async () => {
+    const config = new RadioPlayerConfig('foo-title', 'bar-date', '', undefined, []);
+
+    const el = await fixture(html`
+      <radio-player .config=${config}></radio-player>
+    `);
+
+    expect(el.shadowRoot.querySelectorAll('waveform-progress').length).to.equal(0);
   });
 
   it('can play audio', async () => {

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -48,6 +48,16 @@ describe('Radio Player', () => {
     expect(dateDisplay.innerText).to.equal('bar-date');
   });
 
+  it('does renders the waveform if one is passed in', async () => {
+    const config = new RadioPlayerConfig('foo-title', 'bar-date', '', 'waveform.png', []);
+
+    const el = await fixture(html`
+      <radio-player .config=${config}></radio-player>
+    `);
+
+    expect(el.shadowRoot.querySelectorAll('waveform-progress').length).to.equal(1);
+  });
+
   it('does not render the waveform if one is not passed in', async () => {
     const config = new RadioPlayerConfig('foo-title', 'bar-date', '', undefined, []);
 


### PR DESCRIPTION
**Description**

> If the radio program does not have a waveform image, don't display the waveform component.

**Technical**

> n/a

**Testing**

> Go to https://58-review-radio-play-lpp4ra.archive.org/details/BBC_Radio_5_Live_20191029_000000 and you shouldn't see a broken waveform

**Evidence**

> 
![Screen Shot 2020-02-25 at 10 22 01 AM](https://user-images.githubusercontent.com/51138/75275031-b6299980-57b8-11ea-8b20-eba8eedefc9b.png)

![Screen Shot 2020-02-25 at 10 22 14 AM](https://user-images.githubusercontent.com/51138/75275042-b9248a00-57b8-11ea-82c7-1eac316903a9.png)

