### PR TITLE
Radio Player Mute Fix

### DIFF
--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -716,7 +716,7 @@ export default class RadioPlayer extends LitElement {
     if (detail.volume === undefined) {
       return;
     }
-    this.volume = e.detail.volume;
+    this.volume = e.detail.volume
   }
 
   /**

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -716,7 +716,7 @@ export default class RadioPlayer extends LitElement {
     if (detail.volume === undefined) {
       return;
     }
-    this.volume = e.detail.volume
+    this.volume = e.detail.volume;
   }
 
   /**

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -713,7 +713,7 @@ export default class RadioPlayer extends LitElement {
    */
   private volumeChanged(e: CustomEvent): void {
     const detail = e.detail || {};
-    if (!detail.volume) {
+    if (detail.volume === undefined) {
       return;
     }
     this.volume = e.detail.volume;


### PR DESCRIPTION
**Description**

> Fix the mute setting in the volume control.

**Technical**

> Since the volume can be `0`, we have to specifically check for `undefined` instead of just falsey.

**Testing**

1. With an admin archive.org email user
2. Visit https://58-review-radio-play-lpp4ra.archive.org/details/VOA_Global_English_20170803_190000?start=0
3. Play and make sure you can mute the volume.

**Evidence**

> n/a