### PR TITLE
Fixes BookReader CSS reference

### DIFF
--- a/packages/ia-components/.storybook/preview-head.html
+++ b/packages/ia-components/.storybook/preview-head.html
@@ -15,4 +15,4 @@
 <link href="https://archive.org/bookreader/BookReader/mmenu/dist/css/jquery.mmenu.css" rel="stylesheet" type="text/css"/>
 <link href="https://archive.org/bookreader/BookReader/mmenu/dist/addons/navbars/jquery.mmenu.navbars.css" rel="stylesheet" type="text/css"/>
 <link href="https://archive.org/bookreader/BookReader/BookReader.css" rel="stylesheet" type="text/css"/>
-<link href="https://archive.org/bookreader/BookReader/BookReader-ia.css" rel="stylesheet" type="text/css"/>
+<link href="https://archive.org/bookreader/BookReader-ia.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
**Description**

The path to BookReader-ia.css was incorrect.

**Testing**

Run `yarn run storybook` from within packages/ia-components. Open developer tools from the Storybook page. View the resolved request to https://archive.org/bookreader/BookReader-ia.css