### PR TITLE
Changes ms-grid-columns syntax to get around bug in Less compilation

### DIFF
--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
@@ -76,7 +76,7 @@
   @media (min-width: @audio-player-desktop-min-width) {
     display: -ms-grid;
     display: grid;
-    -ms-grid-columns: (1fr)[12];
+    -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
     grid-template-columns: repeat(12, 1fr);
     grid-auto-rows: minmax(100px, auto);
     grid-template-areas: "md md md md md md hd hd hd hd hd hd" "md md md md md md hd hd hd hd hd hd" "md md md md md md hd hd hd hd hd hd";


### PR DESCRIPTION
**Description**

The Less compiler reads a compressed definition of grid-columns as a media query and fails. Instead, a hard-coded repeated value for grid columns needs to be used.

https://git.archive.org/ia/petabox/-/jobs/251748 shows an example of it failing.
