### PR TITLE
Positions timestamp from right side of time column

### DIFF
--- a/packages/radio-player/demo/index.html
+++ b/packages/radio-player/demo/index.html
@@ -17,7 +17,7 @@
       color: white;
 
       --timeColor: white;
-      --timeColumnWidth: 3rem;
+      --timeColumnWidth: 4rem;
       --transcriptHeight: 400px;
 
       --autoScrollButtonFontColor: black;

--- a/packages/radio-player/demo/radio-player-controller.ts
+++ b/packages/radio-player/demo/radio-player-controller.ts
@@ -16,7 +16,7 @@ export default class RadioPlayerController extends LitElement {
 
   @property({ type: TranscriptConfig }) transcriptConfig: TranscriptConfig | undefined = undefined;
 
-  @property({ type: String }) itemId: string | undefined = 'WFMD_930_AM_20190803_170000';
+  @property({ type: String }) itemId: string | undefined = 'VOA_Global_English_20200228_090000';
 
   private startPlaybackAt: number | undefined = undefined;
 

--- a/packages/transcript-view/src/transcript-view.ts
+++ b/packages/transcript-view/src/transcript-view.ts
@@ -216,6 +216,7 @@ export default class TranscriptView extends LitElement {
       .time-display {
         position: absolute;
         top: 0;
+        right: 5px;
         font-size: ${timeFontSizeCss};
         line-height: ${timeLineHeightCss};
         transition: top 1s;


### PR DESCRIPTION
When timestamp exceeds 1 hour (01:00:00), in the demo and on archive.org the timestamp exceeds the width of the time column and interferes with the transcript column. The timestamp is now positioned from the right edge of the column, allowing it to grow from right to left, and the demo has been updated to provide an example radio item that exceeds an hour as well as an increase in the time column width to accommodate times that exceed 1 hour.

Note that once this is published, the width of the time column on archive.org's implementation will need to be increased in kind for this fix to fully take effect.

**Description**

Fixes [WEBDEV-3189](https://webarchive.jira.com/browse/WEBDEV-3189)

**Testing**

Unable to fully test until the transcript-view component is published and radio-player is updated to use the newer version.