### PR TITLE
Dispatch Events from the Playback Controls to the Radio Player Consumer

### DIFF
--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -628,6 +628,11 @@ export default class RadioPlayer extends LitElement {
     }
     this.transcriptView.selectedSearchResultIndex = searchResultIndex;
     this.transcriptView.scrollToSelectedSearchResult();
+
+    const event = new CustomEvent('highlightedSearchResultChanged', {
+      detail: { searchResultIndex },
+    });
+    this.dispatchEvent(event);
   }
 
   /**

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -742,6 +742,7 @@ export default class RadioPlayer extends LitElement {
       return;
     }
     this.playbackRate = detail.playbackRate;
+
     const event = new CustomEvent('playbackRateChanged', {
       detail: { playbackRate: this.playbackRate },
     });

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -657,6 +657,8 @@ export default class RadioPlayer extends LitElement {
     }
     this.searchTerm = term;
     this.isSearching = true;
+    const event = new Event('searchExecuted');
+    this.dispatchEvent(event);
     this.searchResultsTranscript = await this.searchHandler.search(term);
     this.isSearching = false;
   }

--- a/packages/radio-player/src/radio-player.ts
+++ b/packages/radio-player/src/radio-player.ts
@@ -742,6 +742,10 @@ export default class RadioPlayer extends LitElement {
       return;
     }
     this.playbackRate = detail.playbackRate;
+    const event = new CustomEvent('playbackRateChanged', {
+      detail: { playbackRate: this.playbackRate },
+    });
+    this.dispatchEvent(event);
   }
 
   /**
@@ -758,6 +762,11 @@ export default class RadioPlayer extends LitElement {
       return;
     }
     this.volume = e.detail.volume;
+
+    const event = new CustomEvent('volumeChanged', {
+      detail: { volume: this.volume },
+    });
+    this.dispatchEvent(event);
   }
 
   /**
@@ -771,6 +780,9 @@ export default class RadioPlayer extends LitElement {
     if (this.audioElement) {
       this.audioElement.seekBy(-10);
     }
+
+    const event = new Event('jumpBackButtonPressed');
+    this.dispatchEvent(event);
   }
 
   /**
@@ -791,6 +803,11 @@ export default class RadioPlayer extends LitElement {
     } else {
       this.audioElement.pause();
     }
+
+    const event = new CustomEvent('playPauseButtonPressed', {
+      detail: { isPlaying: this.isPlaying },
+    });
+    this.dispatchEvent(event);
   }
 
   /**
@@ -804,6 +821,9 @@ export default class RadioPlayer extends LitElement {
     if (this.audioElement) {
       this.audioElement.seekBy(10);
     }
+
+    const event = new Event('jumpForwardButtonPressed');
+    this.dispatchEvent(event);
   }
 
   /**
@@ -824,6 +844,9 @@ export default class RadioPlayer extends LitElement {
     const closestUpper = Math.min(...percentsGreaterThanValue);
     const seekTo: number = this.duration * (closestUpper / 100) + 0.1;
     this.audioElement.seekTo(seekTo);
+
+    const event = new Event('nextSectionButtonPressed');
+    this.dispatchEvent(event);
   }
 
   /**
@@ -844,6 +867,9 @@ export default class RadioPlayer extends LitElement {
     const closestLower = Math.max(...percentsLessThanValue);
     const seekTo: number = this.duration * (closestLower / 100) - 0.1;
     this.audioElement.seekTo(seekTo);
+
+    const event = new Event('prevSectionButtonPressed');
+    this.dispatchEvent(event);
   }
 
   /**

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -1044,11 +1044,11 @@ describe('Radio Player', () => {
       `);
 
       const event = new CustomEvent('foo', {
-        detail: { searchResultIndex: 2 },
+        detail: { searchResultIndex: 3 },
       });
       setTimeout(() => { el.searchResultIndexChanged(event); });
       const response = await oneEvent(el, 'highlightedSearchResultChanged');
-      expect(response.detail.searchResultIndex).to.equal(2);
+      expect(response.detail.searchResultIndex).to.equal(3);
     });
   });
 });

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -1050,5 +1050,24 @@ describe('Radio Player', () => {
       const response = await oneEvent(el, 'highlightedSearchResultChanged');
       expect(response.detail.searchResultIndex).to.equal(3);
     });
+
+    it('emits searchExecuted event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      class MockSearchHandler {
+        search() {
+          return new Promise(resolve => resolve());
+        }
+      }
+      const searchHandler = new MockSearchHandler();
+
+      el.searchHandler = searchHandler;
+
+      setTimeout(() => { el.executeSearch('foo'); });
+      const response = await oneEvent(el, 'searchExecuted');
+      expect(response).to.exist;
+    });
   });
 });

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -873,13 +873,11 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('playback-rate-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const event = new CustomEvent('foo', {
+        detail: { playbackRate: 1.25 },
+      });
+      setTimeout(() => { el.changePlaybackRate(event); });
       const response = await oneEvent(el, 'playbackRateChanged');
-      expect(response).to.exist;
       expect(response.detail.playbackRate).to.equal(1.25);
     });
 
@@ -888,14 +886,12 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('volume-control-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const event = new CustomEvent('foo', {
+        detail: { volume: 0.5 },
+      });
+      setTimeout(() => { el.volumeChanged(event); });
       const response = await oneEvent(el, 'volumeChanged');
-      expect(response).to.exist;
-      expect(response.detail.volume).to.equal(0);
+      expect(response.detail.volume).to.equal(0.5);
     });
 
     it('emits jumpBackButtonPressed event', async () => {
@@ -903,11 +899,7 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('back-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      setTimeout(() => { el.backButtonHandler(); });
       const response = await oneEvent(el, 'jumpBackButtonPressed');
       expect(response).to.exist;
     });
@@ -917,11 +909,7 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('forward-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      setTimeout(() => { el.forwardButtonHandler(); });
       const response = await oneEvent(el, 'jumpForwardButtonPressed');
       expect(response).to.exist;
     });
@@ -931,13 +919,8 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('play-pause-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      setTimeout(() => { el.playPauseButtonHandler(); });
       const response = await oneEvent(el, 'playPauseButtonPressed');
-      expect(response).to.exist;
       expect(response.detail.isPlaying).to.equal(true);
     });
 
@@ -946,11 +929,7 @@ describe('Radio Player', () => {
         <radio-player></radio-player>
       `);
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('next-section-btn');
-
-      const clickEvent = new MouseEvent('click');
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      setTimeout(() => { el.nextSectionButtonHandler(); });
       const response = await oneEvent(el, 'nextSectionButtonPressed');
       expect(response).to.exist;
     });
@@ -963,12 +942,7 @@ describe('Radio Player', () => {
       // needed to be able to press the prev section button
       el.percentComplete = 35;
 
-      const playbackControls = el.shadowRoot.querySelector('playback-controls');
-      const button = playbackControls.shadowRoot.getElementById('prev-section-btn');
-
-      const clickEvent = new MouseEvent('click');
-
-      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      setTimeout(() => { el.prevSectionButtonHandler(); });
       const response = await oneEvent(el, 'prevSectionButtonPressed');
       expect(response).to.exist;
     });
@@ -980,8 +954,88 @@ describe('Radio Player', () => {
 
       setTimeout(() => { el.currentTime = 5; });
       const response = await oneEvent(el, 'currentTimeChanged');
-      expect(response).to.exist;
       expect(response.detail.currentTime).to.equal(5);
+    });
+
+    it('emits searchCleared event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      setTimeout(() => { el.searchCleared(); });
+      const response = await oneEvent(el, 'searchCleared');
+      expect(response).to.exist;
+    });
+
+    it('emits searchTermChanged event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const event = new CustomEvent('foo', {
+        detail: { value: 'boop' },
+      });
+      setTimeout(() => { el.updateSearchTerm(event); });
+      const response = await oneEvent(el, 'searchTermChanged');
+      expect(response.detail.searchTerm).to.equal('boop');
+    });
+
+    it('emits playbackPaused event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      setTimeout(() => { el.playbackPaused(); });
+      const response = await oneEvent(el, 'playbackPaused');
+      expect(response).to.exist;
+    });
+
+    it('emits playbackStarted event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      setTimeout(() => { el.playbackStarted(); });
+      const response = await oneEvent(el, 'playbackStarted');
+      expect(response).to.exist;
+    });
+
+    it('emits canplay event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      setTimeout(() => { el.canplay(); });
+      const response = await oneEvent(el, 'canplay');
+      expect(response).to.exist;
+    });
+
+    it('emits timeChangedFromScrub event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      el.duration = 100;
+
+      const event = new CustomEvent('foo', {
+        detail: { value: 35 },
+      });
+      setTimeout(() => { el.valueChangedFromScrub(event); });
+      const response = await oneEvent(el, 'timeChangedFromScrub');
+      expect(response.detail.newTime).to.equal(35);
+    });
+
+    it('emits transcriptEntrySelected event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const event = new CustomEvent('foo', {
+        detail: { entry: { start: 35 } },
+      });
+      setTimeout(() => { el.transcriptEntrySelected(event); });
+      const response = await oneEvent(el, 'transcriptEntrySelected');
+      expect(response.detail.newTime).to.equal(35);
     });
   });
 });

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -866,4 +866,122 @@ describe('Radio Player', () => {
       expect(quickSearches[2].displayText).to.equal('baz');
     });
   });
+
+  describe('Events', () => {
+    it('emits playbackRateChanged event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('playback-rate-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'playbackRateChanged');
+      expect(response).to.exist;
+      expect(response.detail.playbackRate).to.equal(1.25);
+    });
+
+    it('emits volumeChanged event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('volume-control-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'volumeChanged');
+      expect(response).to.exist;
+      expect(response.detail.volume).to.equal(0);
+    });
+
+    it('emits jumpBackButtonPressed event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('back-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'jumpBackButtonPressed');
+      expect(response).to.exist;
+    });
+
+    it('emits jumpForwardButtonPressed event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('forward-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'jumpForwardButtonPressed');
+      expect(response).to.exist;
+    });
+
+    it('emits playPauseButtonPressed event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('play-pause-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'playPauseButtonPressed');
+      expect(response).to.exist;
+      expect(response.detail.isPlaying).to.equal(true);
+    });
+
+    it('emits nextSectionButtonPressed event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('next-section-btn');
+
+      const clickEvent = new MouseEvent('click');
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'nextSectionButtonPressed');
+      expect(response).to.exist;
+    });
+
+    it('emits prevSectionButtonPressed event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      // needed to be able to press the prev section button
+      el.percentComplete = 35;
+
+      const playbackControls = el.shadowRoot.querySelector('playback-controls');
+      const button = playbackControls.shadowRoot.getElementById('prev-section-btn');
+
+      const clickEvent = new MouseEvent('click');
+
+      setTimeout(() => { button.dispatchEvent(clickEvent); });
+      const response = await oneEvent(el, 'prevSectionButtonPressed');
+      expect(response).to.exist;
+    });
+
+    it('emits currentTimeChanged event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      setTimeout(() => { el.currentTime = 5; });
+      const response = await oneEvent(el, 'currentTimeChanged');
+      expect(response).to.exist;
+      expect(response.detail.currentTime).to.equal(5);
+    });
+  });
 });

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -1062,7 +1062,6 @@ describe('Radio Player', () => {
         }
       }
       const searchHandler = new MockSearchHandler();
-
       el.searchHandler = searchHandler;
 
       setTimeout(() => { el.executeSearch('foo'); });

--- a/packages/radio-player/test/radio-player.test.js
+++ b/packages/radio-player/test/radio-player.test.js
@@ -1037,5 +1037,18 @@ describe('Radio Player', () => {
       const response = await oneEvent(el, 'transcriptEntrySelected');
       expect(response.detail.newTime).to.equal(35);
     });
+
+    it('emits highlightedSearchResultChanged event', async () => {
+      const el = await fixture(html`
+        <radio-player></radio-player>
+      `);
+
+      const event = new CustomEvent('foo', {
+        detail: { searchResultIndex: 2 },
+      });
+      setTimeout(() => { el.searchResultIndexChanged(event); });
+      const response = await oneEvent(el, 'highlightedSearchResultChanged');
+      expect(response.detail.searchResultIndex).to.equal(2);
+    });
   });
 });


### PR DESCRIPTION
**Description**

> We were dispatching events from several of the components like scrubber bar scrubs and transcript entry selections, but not the playback controls.

This adds some event dispatches and tests for them.

**Technical**

> It is mainly re-dispatching events for the consumer to handle or track.

**Testing**

> Nothing to test. There are unit tests verifying that the events are being emitted.