### PR TITLE
Moves search menu offscreen at desktop breakpoint

### DIFF
--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -14,7 +14,6 @@
         height: 100%;
         margin: 0px;
         padding: 0px;
-        overflow-x: hidden;
       }
       ia-topnav {
         --baseColor: #999;

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.1.1-alpha.579+a6a062e",
+  "version": "0.2.0",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -120,7 +120,6 @@ export default css`
 
     .initial,
     .closed {
-      left: 100%;
       opacity: 0;
       transition-duration: .2s;
     }

--- a/packages/ia-topnav/src/styles/search-menu.js
+++ b/packages/ia-topnav/src/styles/search-menu.js
@@ -52,7 +52,7 @@ export default css`
   @media (min-width: 890px) {
     .search-menu {
       overflow: visible;
-      top: calc(100% + 7px);
+      top: -400px;
       right: 2rem;
       left: auto;
       z-index: 5;
@@ -81,7 +81,6 @@ export default css`
 
     .initial,
     .closed {
-      left: 100%;
       opacity: 0;
       transition-duration: .2s;
     }


### PR DESCRIPTION
**Description**

Adjusts search menu styles and removes example HTML overflow to catch any unexpected container overflow. The existing closed state of the search menu positions it left 100%, which always extends the effective topnav width (and the entire page) by at least 40px, causing a horizontal scrollbar to appear. Instead, the initial top value is set to position it off top top of the document until open.
