### PR TITLE
Sets max height on dropdowns

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -45,6 +45,9 @@ export default css`
     padding: 0.4rem 0 0.7rem 0;
     margin: 0;
     list-style: none;
+    max-height: calc(100vh - 7.2rem + 1px);
+    overflow: auto;
+    box-sizing: border-box;
   }
 
   .divider {
@@ -94,6 +97,10 @@ export default css`
 
     h3 {
       display: none;
+    }
+
+    ul {
+      max-height: calc(100vh - 8.5rem + 1px);
     }
 
     .divider {

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -45,6 +45,7 @@ export default css`
     padding: 0.4rem 0 0.7rem 0;
     margin: 0;
     list-style: none;
+    /* viewport height - nav height + bottom nav border */
     max-height: calc(100vh - 7.2rem + 1px);
     overflow: auto;
     box-sizing: border-box;
@@ -100,6 +101,7 @@ export default css`
     }
 
     ul {
+      /* viewport height - nav height + bottom nav border */
       max-height: calc(100vh - 8.5rem + 1px);
     }
 


### PR DESCRIPTION
Sets a max height and overflow on dropdowns so they scroll when the list exceeds the viewport height. This is necessary for instances when the topnav is set in a fixed position as it is in the TV archive pages.
