### PR TITLE
Adds location handler for searching TV captions

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -11,6 +11,7 @@ class NavSearch extends TrackedElement {
   static get properties() {
     return {
       config: { type: Object },
+      locationHandler: { type: Function },
       open: { type: Boolean },
       openMenu: { type: String },
       searchIn: { type: String },
@@ -20,6 +21,7 @@ class NavSearch extends TrackedElement {
   constructor() {
     super();
     this.config = {};
+    this.locationHandler = () => {};
     this.open = false;
     this.openMenu = '';
     this.searchIn = '';
@@ -36,6 +38,13 @@ class NavSearch extends TrackedElement {
     const query = this.shadowRoot.querySelector('[name=query]').value;
 
     if (!query) {
+      e.preventDefault();
+      return false;
+    }
+
+    // TV search points to a detail page with a q param instead
+    if (this.searchIn === 'TV') {
+      this.locationHandler(`https://${this.config.baseHost}/details/tv?q=${query}`);
       e.preventDefault();
       return false;
     }

--- a/packages/ia-topnav/src/primary-nav.js
+++ b/packages/ia-topnav/src/primary-nav.js
@@ -7,6 +7,7 @@ import './nav-search';
 import './media-menu';
 import logoWordmark from './assets/img/wordmark-narrow-spacing';
 import primaryNavCSS from './styles/primary-nav';
+import locationHandler from './lib/location-handler';
 
 class PrimaryNav extends TrackedElement {
   static get styles() {
@@ -99,6 +100,7 @@ class PrimaryNav extends TrackedElement {
       </button>
       <nav-search
         .config=${this.config}
+        .locationHandler=${locationHandler}
         .open=${this.searchMenuOpen}
         .openMenu=${this.openMenu}
         .searchIn=${this.searchIn}

--- a/packages/ia-topnav/test/nav-search.test.js
+++ b/packages/ia-topnav/test/nav-search.test.js
@@ -2,7 +2,9 @@ import {
   html,
   fixture,
   expect,
+  oneEvent,
 } from '@open-wc/testing';
+import sinon from 'sinon';
 
 import '../src/nav-search';
 
@@ -23,5 +25,25 @@ describe('<nav-search>', () => {
     });
 
     expect(result).to.be.false;
+  });
+
+  it('redirects to the TV details page when search inside is TV', async () => {
+    const query = 'bananas';
+    const submitEvent = {
+      type: 'submit',
+      preventDefault: () => {}
+    };
+    const locationHandler = sinon.fake();
+    const el = await fixture(html`<nav-search .locationHandler=${locationHandler}></nav-search>`);
+
+    el.searchIn = 'TV';
+
+    await el.updateComplete;
+
+    el.shadowRoot.querySelector('[name=query]').value = query;
+    el.search(submitEvent);
+
+    expect(locationHandler.callCount).to.equal(1);
+    expect(locationHandler.firstArg).to.contain(`/details/tv?q=${query}`);
   });
 });


### PR DESCRIPTION
TV caption search is handled through a query param from the TV details page rather than search.php. In the event TV is the selected search type, the `locationHandler` function should be used to redirect to the TV details page with the query as a param in the form of `?q=query`
