### PR TITLE
Hides upload and user labels below 990px

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.8-alpha.00a935",
+  "version": "0.2.8-alpha.a350d11",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.7",
+  "version": "0.2.8-alpha.00a935",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/primary-nav.js
+++ b/packages/ia-topnav/src/primary-nav.js
@@ -114,7 +114,10 @@ class PrimaryNav extends TrackedElement {
       <nav>
         <a class="link-home" href="https://${this.config.baseHost}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|NavHome">${icons.iaLogo}${logoWordmark}</a>
         ${this.searchMenu}
-        <a href="https://${this.config.baseHost}/upload/" class="upload">${icons.upload}Upload</a>
+        <a href="https://${this.config.baseHost}/upload/" class="upload">
+          ${icons.upload}
+          <span>Upload</span>
+        </a>
         <div class="user-info">
           ${this.config.username ? this.userIcon : this.loginIcon}
         </div>

--- a/packages/ia-topnav/src/styles/primary-nav.js
+++ b/packages/ia-topnav/src/styles/primary-nav.js
@@ -87,6 +87,10 @@ export default css`
     display: none;
   }
 
+  .upload span {
+    display: none;
+  }
+
   .user-info {
     -ms-grid-row: 1;
     -ms-grid-column: 4;
@@ -181,10 +185,6 @@ export default css`
       vertical-align: middle;
     }
 
-    .username {
-      display: inline-block;
-    }
-
     .upload {
       display: block;
       float: right;
@@ -221,6 +221,16 @@ export default css`
     login-button {
       display: block;
       margin-right: 1rem;
+    }
+  }
+
+  @media (min-width: 990px) {
+    .username {
+      display: inline-block;
+    }
+
+    .upload span {
+      display: inline;
     }
   }
 `;

--- a/packages/ia-topnav/src/styles/signed-out-dropdown.js
+++ b/packages/ia-topnav/src/styles/signed-out-dropdown.js
@@ -5,6 +5,20 @@ export default css`
     .initial,
     .closed,
     .open {
+      right: 33.7rem;
+    }
+
+    .search-hidden.initial,
+    .search-hidden.closed,
+    .search-hidden.open {
+      right: 18.3rem;
+    }
+  }
+
+  @media (min-width: 990px) {
+    .initial,
+    .closed,
+    .open {
       right: 39.7rem;
     }
 

--- a/packages/ia-topnav/src/styles/user-menu.js
+++ b/packages/ia-topnav/src/styles/user-menu.js
@@ -5,6 +5,20 @@ export default css`
     .initial,
     .closed,
     .open {
+      right: 21.3rem;
+    }
+
+    .search-hidden.initial,
+    .search-hidden.closed,
+    .search-hidden.open {
+      right: 5.8rem;
+    }
+  }
+
+  @media (min-width: 990px) {
+    .initial,
+    .closed,
+    .open {
       right: 27.5rem;
     }
 

--- a/packages/ia-topnav/test/nav-search.test.js
+++ b/packages/ia-topnav/test/nav-search.test.js
@@ -1,9 +1,4 @@
-import {
-  html,
-  fixture,
-  expect,
-  oneEvent,
-} from '@open-wc/testing';
+import { html, fixture, expect } from '@open-wc/testing';
 import sinon from 'sinon';
 
 import '../src/nav-search';


### PR DESCRIPTION
In order to provide enough horizontal space for all nav items, at < 990px viewport width the upload and username text labels should be hidden. This behavior exists on the current live nav, and provides just enough room for the signed out version of nav.