### PR TITLE
WEBDEV-3319 Radio Archive Transcript Search Fix

### DIFF
--- a/packages/radio-player/demo/radio-player-controller.ts
+++ b/packages/radio-player/demo/radio-player-controller.ts
@@ -45,7 +45,7 @@ export default class RadioPlayerController extends LitElement {
 
   private fileName = '';
 
-  private baseUrl = 'https://58-review-radio-arch-bsdafk.archive.org';
+  private baseUrl = 'https://archive.org';
 
   private searchServicePath = '/services/radio-archive/search/service.php';
 

--- a/packages/radio-player/src/search-handler/search-handler.ts
+++ b/packages/radio-player/src/search-handler/search-handler.ts
@@ -149,18 +149,19 @@ export class SearchHandler implements SearchHandlerInterface {
     const searchRanges: Range[] = await this.searchBackend.getSearchRanges(query);
     const { mergedTranscript } = this.transcriptIndex;
 
-    // Sort the search range results from start to end
-    // The search engine may return results in any order but while processing the results here,
-    // we are going from start to finish. If the search results are out of order, it rebuilds
-    // incorrect blocks of search results.
-    searchRanges.sort((a: Range, b: Range) => (a.startIndex > b.startIndex ? 1 : -1));
-
     // if there's no search results, just return a single SearchResult that is the full
     // transcript marked as not a match.
     if (searchRanges.length === 0) {
       const range = new Range(0, mergedTranscript.length);
       return new Promise(resolve => resolve([new SearchResult(range, mergedTranscript, false)]));
     }
+
+
+    // Sort the search range results from start to end
+    // The search engine may return results in any order but while processing the results here,
+    // we are going from start to finish. If the search results are out of order, it rebuilds
+    // incorrect blocks of search results.
+    searchRanges.sort((a: Range, b: Range) => (a.startIndex - b.startIndex));
 
     const transcriptEntries: SearchResult[] = [];
     let startIndex = 0;

--- a/packages/radio-player/src/search-handler/search-handler.ts
+++ b/packages/radio-player/src/search-handler/search-handler.ts
@@ -149,6 +149,12 @@ export class SearchHandler implements SearchHandlerInterface {
     const searchRanges: Range[] = await this.searchBackend.getSearchRanges(query);
     const { mergedTranscript } = this.transcriptIndex;
 
+    // Sort the search range results from start to end
+    // The search engine may return results in any order but while processing the results here,
+    // we are going from start to finish. If the search results are out of order, it rebuilds
+    // incorrect blocks of search results.
+    searchRanges.sort((a: Range, b: Range) => (a.startIndex > b.startIndex ? 1 : -1));
+
     // if there's no search results, just return a single SearchResult that is the full
     // transcript marked as not a match.
     if (searchRanges.length === 0) {


### PR DESCRIPTION
**Description**

> Fixes an issue in the Radio Archive search where we wouldn't rebuild the transcript properly.

**Technical**

> The search engine didn't always return search results in order from start to end, but when we rebuild the transcript, we do so from start to end. This would cause the transcript rebuild to stick parts of the transcript in the wrong spot. The solution was to sort the results.

**Testing**

> For certain queries, the transcript should be correct now