### PR TITLE
Releases ia-topnav 0.2.8

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.8-alpha.a350d11",
+  "version": "0.2.8",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Publishes new release of ia-topnav.

* Design changes to address viewport width causing media menu to break to new line