### PR TITLE
Renders truncated screen name in topnav

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/primary-nav.js
+++ b/packages/ia-topnav/src/primary-nav.js
@@ -62,12 +62,19 @@ class PrimaryNav extends TrackedElement {
     }));
   }
 
+  get truncatedScreenName() {
+    if (this.config.screenName.length > 10) {
+      return `${this.config.screenName.substr(0, 9)}…`;
+    }
+    return this.config.screenName;
+  }
+
   get userIcon() {
     const userMenuClass = this.openMenu === 'user' ? 'active' : '';
 
     return html`<button class="user-menu ${userMenuClass}" @click="${this.toggleUserMenu}" data-event-click-tracking="${this.config.eventCategory}|NavUserMenu">
       <img src="https://archive.org/services/img/user/profile?${+(new Date())}" alt="${this.config.username}" />
-      <span class="username">${this.config.username}</span>
+      <span class="username">${this.truncatedScreenName}</span>
     </button>`;
   }
 

--- a/packages/ia-topnav/test/ia-topnav.test.js
+++ b/packages/ia-topnav/test/ia-topnav.test.js
@@ -187,7 +187,10 @@ describe('<ia-topnav>', () => {
   });
 
   it('toggles user menu when search user avatar clicked', async () => {
-    const el = await fixture(container({ username: 'shaneriley' }));
+    const el = await fixture(container({
+      username: 'shaneriley',
+      screenName: 'shaneriley',
+    }));
 
     el.shadowRoot.querySelector('primary-nav').shadowRoot.querySelector('.user-menu').click();
     await el.updateComplete;

--- a/packages/ia-topnav/test/primary-nav.test.js
+++ b/packages/ia-topnav/test/primary-nav.test.js
@@ -20,6 +20,7 @@ describe('<primary-nav>', () => {
     const el = await fixture(component({
       baseHost: 'archive.org',
       username: 'shaneriley',
+      screenName: 'shaneriley',
       hideSearch: true,
     }));
 


### PR DESCRIPTION
To eliminate the need to send in two values for screen name (one for display, one for URL building), the screen name truncation is now moved from Petabox to the nav component.