### PR TITLE
Uses fixed measurement position for media menu on mobile

### DIFF
--- a/packages/ia-topnav/src/styles/media-menu.js
+++ b/packages/ia-topnav/src/styles/media-menu.js
@@ -8,7 +8,7 @@ export default css`
   .media-menu {
     position: absolute;
     z-index: -1;
-    top: -100vh;
+    top: -400px;
     width: 100%;
     background-color: var(--mediaMenuBg);
     margin: 0;
@@ -26,7 +26,7 @@ export default css`
   }
 
   .media-menu.tx-slide.closed {
-    top: -100vh;
+    top: -400px;
   }
 
   .media-menu.tx-slide.closed {


### PR DESCRIPTION
<media-menu> previously used vh units to position off screen for mobile breakpoints. When the viewport height was too short, however, the bottom edge would still be visible. This sets a fixed pixel value that slightly exceeds the height of the media menu to ensure it remains completely off screen when closed.

See animation, which colors the media menu red for demonstration.

![media-menu](https://user-images.githubusercontent.com/39553/84678296-d6af6800-aefd-11ea-835f-1809b141cea7.gif)
