### PR TITLE
Change NEL back to "Books to Borrow"

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -3,9 +3,9 @@ import { prodHost } from '../constants';
 const texts = (baseHost = prodHost) => ({
   heading: 'Books',
   iconLinks: [{
-    title: 'National Emergency Library',
-    icon: `https://${baseHost}/images/national-emergency-library-logo-padded.png`,
-    url: `https://${baseHost}/details/nationalemergencylibrary`,
+    title: 'Books to Borrow',
+    icon: `https://${baseHost}/images/book-lend.png`,
+    url: `https://${baseHost}/details/inlibrary?sort=-publicdate`,
   }, {
     title: 'Open Library',
     icon: `https://${baseHost}/images/widgetOL.png`,


### PR DESCRIPTION
Changes the NEL link back to "Books to Borrow"

<img width="1181" alt="Screen Shot 2020-06-16 at 11 22 37 AM" src="https://user-images.githubusercontent.com/51138/84812788-ca8dde00-afc3-11ea-8bdd-21c716602811.png">
