### PR TITLE
Adds searchQuery property on config object

### DIFF
--- a/packages/ia-topnav/README.md
+++ b/packages/ia-topnav/README.md
@@ -91,6 +91,8 @@ export default IATopNav;
   eventCategory: "MobileTopNav", // Google Analytics event category
   waybackPagesArchived: "425 billion", // Copy to display for number of pages archived at the top of the Wayback search form
   isAdmin: true, // User admin flag. Boolean.
+  uploadURL: 'https://archive.org/create', // Full URL to upload path. Differs on Petabox if user is admin && in category page
+  searchQuery: 'atari', // If already viewing search results, prepopulates search with this string
   hiddenSearchOptions: [], // Array of strings representing the values of options that should be hidden from search options
   hideSearch: true, // Hides search functionality
 }

--- a/packages/ia-topnav/base64_encoded_menus.html
+++ b/packages/ia-topnav/base64_encoded_menus.html
@@ -41,6 +41,7 @@
         waybackPagesArchived: '424 billion',
         isAdmin: true,
         uploadURL: 'https://archive.org/create',
+        searchQuery: 'atari',
         hiddenSearchOptions: [],
       };
       const menus = Object.assign({}, baseMenus, {

--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -39,6 +39,7 @@
         waybackPagesArchived: '424 billion',
         isAdmin: true,
         uploadURL: 'https://archive.org/create',
+        searchQuery: 'atari',
         hiddenSearchOptions: [],
       };
       const topnav = document.createElement('ia-topnav');

--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -78,6 +78,7 @@ class NavSearch extends TrackedElement {
           placeholder="Search"
           autocomplete="off"
           @focus=${this.toggleSearchMenu}
+          value=${this.config.searchQuery || ''}
         />
         <input type='hidden' name='sin' value='${this.searchIn}' />
         <button type="submit" class="search" data-event-click-tracking="${this.config.eventCategory}|NavSearchClose">

--- a/packages/ia-topnav/test/nav-search.test.js
+++ b/packages/ia-topnav/test/nav-search.test.js
@@ -41,4 +41,13 @@ describe('<nav-search>', () => {
     expect(locationHandler.callCount).to.equal(1);
     expect(locationHandler.firstArg).to.contain(`/details/tv?q=${query}`);
   });
+
+  it('prefills the search query when present in config', async () => {
+    const config = {
+      searchQuery: 'bananas'
+    };
+    const el = await fixture(html`<nav-search .config=${config}></nav-search>`);
+
+    expect(el.shadowRoot.querySelector('[name="query"]').value).to.equal(config.searchQuery);
+  });
 });


### PR DESCRIPTION
When `config.searchQuery` is set, the value of the search input will be populated with its value. This is to be used to prepopulate the search form with an existing search query in Petabox. See https://webarchive.jira.com/browse/WEBDEV-3594 for details.