### PR TITLE
Adds base64 decoding converter to config property

### DIFF
--- a/packages/ia-topnav/base64_encoded_menus.html
+++ b/packages/ia-topnav/base64_encoded_menus.html
@@ -56,7 +56,7 @@
         web: baseMenus.wayback,
       });
       render(html`
-        <ia-topnav config=${JSON.stringify(config)} menus=${btoa(JSON.stringify(menus))}></ia-topnav>
+        <ia-topnav config=${btoa(JSON.stringify(config))} menus=${btoa(JSON.stringify(menus))}></ia-topnav>
       `, document.getElementById('topnav'));
 
       const topnav = document.querySelector('ia-topnav');

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -16,17 +16,17 @@ export default class IATopNav extends LitElement {
 
   static get properties() {
     return {
-      config: { type: Object },
+      config: {
+        type: Object,
+        converter(value) {
+          return JSON.parse(atob(value));
+        }
+      },
       mediaSliderOpen: { type: Boolean },
       menus: {
         type: Object,
-        converter: {
-          fromAttribute: value => (
-            JSON.parse(atob(value))
-          ),
-          toAttribute: value => (
-            btoa(JSON.stringify(value))
-          )
+        converter(value) {
+          return JSON.parse(atob(value));
         }
       },
       openMenu: { type: String },


### PR DESCRIPTION
To make it easier to transport the data from Petabox to the nav, base64 encoding has been added on the Petabox side. This adds the same type of property converter to config that is already present on the menus.