### PR TITLE
Fix Tests by Setting Test Concurrency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,10 @@
     "packages/*"
   ],
   "version": "independent",
-  "npmClient": "yarn"
+  "npmClient": "yarn",
+  "command": {
+    "run": {
+      "concurrency": 1
+    }
+  }
 }

--- a/packages/ia-topnav/karma.conf.js
+++ b/packages/ia-topnav/karma.conf.js
@@ -16,6 +16,7 @@ module.exports = (config) => {
 
       esm: {
         nodeResolve: true,
+        preserveSymlinks: true
       },
       // you can overwrite/extend the config further
     }),


### PR DESCRIPTION
**Description**

> Test if setting the test concurrency fixes the unit test failures.

**Technical**

> The reason the tests were failing is because `lerna` tries to run the tests in parallel, but if you have too many test runners running all at once, they conflict with one another. Setting the concurrency to 1 slows it down, but the tests pass.

**Testing**

> No testing needed. The unit tests should pass.

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
