### PR TITLE
Only run Travis builds for PRs and master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
   - node
 
+# Only run travis when pushing to master branch (and PRs)
+branches:
+  only:
+    - master
+
 notifications:
   slack:
     secure: tmiJdp/R2JGaS5p4ukdh2KhOo0XNV1+Wcpoz9O0dimYYeDefS6YGNzyjqzCXPM7Vb7kb48OCieoeUsrGuVlpRVLISp7Pk4z8Md2qQFYPZRQh+TBeLyIQXD2c1NOHt3qXrP9z2GNZZD/S4LXS1vsVfdVXEh7XMeujvFJm82zfuCREm12l8W4qUK7cXyDA92S3P0n/JIfL2/G6644EitdNVRSvUy8ZJXJJBalwfbRfeatJThEFDfgHSdm0kqbKhea0UN4R7WcMY02M2YVmdYNW2/GXEaX5nTc3jePjExWzXBnqrPDK2WRDhbSpvaouLaXnF8DyYAusVpMvuALpaXXVhabIcOQFYCFeFoWhdoMOhkVrBhB3s0qxiQyu5ZdBRjjGjtvyBvLwHZApXBeuCNGmBYTh+DlB5co4K5IVmE9JVOII52D11EpH+M/ZDlnYBKlUjZfkQXitxxITJXd4LAbTABnB1lBr4PUsPX8+I25w6GpAR31CkPH7dG7I6EPYKXDI+k6TjE/euSKdsu+drzduW+yfKm0SQCzRSCm4zBx1v0haTXXuqPr66m4ZleyLd9qoiGSzuM0WQpR3uB/EyFQm6qYLcHKISn0rQTRywWOh9c/LtjMXaheadMUanA35JWCZ2AtcpBOwPCeq9YpiiYv4dTr7l8R4oP3ogYzfW6TUI/c=


### PR DESCRIPTION
Currently when you open an PR, Travis does 2 runs: one just for the branch and one for the PR. We don't need the branch run separately since we're interested in the PR run.
