### PR TITLE
Webdev 3733 fixes safari fullscreen

### DIFF
--- a/packages/ia-components/bin/copy_bookreader.js
+++ b/packages/ia-components/bin/copy_bookreader.js
@@ -1,4 +1,4 @@
 const { execSync } = require('child_process');
 
 execSync('mkdir -p public');
-execSync('cp -r node_modules/bookreader/BookReader public/');
+execSync('cp -r node_modules/@internetarchive/bookreader/BookReader public/');

--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -27,7 +27,7 @@
         "@storybook/react": "^4.1.4",
         "axios": "^0.19.0",
         "babel-loader": "^8.0.5",
-        "bookreader": "git://github.com/internetarchive/bookreader.git#^4.8.0",
+        "@internetarchive/bookreader": "4.15.0",
         "chromedriver": "^78.0.0",
         "css-loader": "^2.1.0",
         "http-proxy-middleware": "^1.0.3",

--- a/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
+++ b/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
@@ -79,7 +79,7 @@ export default class BookReaderWrapper extends Component {
 
   render() {
     return (
-      <section id="IABookReaderWrapper" {...this.props}>
+      <section className="bookreader-wrapper" {...this.props}>
         {!this.props.jsia ? null :
           <div id="IABookReaderMessageWrapper" style={{display: "none"}}></div>
         }

--- a/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
+++ b/packages/ia-components/sandbox/theatres/with-youtube-spotify/audio-with-youtube-spotify.less
@@ -6,7 +6,7 @@
   padding: .5rem;
   overflow: hidden;
   color: @f-white;
-  
+
   .submenu {
     position: absolute;
     right: 6px;
@@ -262,5 +262,14 @@
         }
       }
     }
+  }
+
+  .bookreader-wrapper {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0.1px 0 0 0;
+    overflow: hidden;
+    background-color: black;
   }
 }

--- a/packages/ia-components/yarn.lock
+++ b/packages/ia-components/yarn.lock
@@ -1161,6 +1161,13 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@internetarchive/bookreader@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/bookreader/-/bookreader-4.15.0.tgz#5032e0c0cd3bec2175fc29c5455f227c6a763813"
+  integrity sha512-orNlJ6y9BTsxokH0SvuV9eFQ8y3KxhVN79aagvEGop0orDQ8oyqfp7ddl0Sn+cSkwE6Dfdjrdios7MDWFqNStQ==
+  dependencies:
+    jquery "3.4.1"
+
 "@internetarchive/ia-js-client@0.0.0-alpha.350":
   version "0.0.0-alpha.350"
   resolved "https://registry.yarnpkg.com/@internetarchive/ia-js-client/-/ia-js-client-0.0.0-alpha.350.tgz#05462c3314bfc16d9ff8cb735e00eade153c5c54"
@@ -2832,12 +2839,6 @@ body-parser@1.18.3:
     qs "6.5.2"
     raw-body "2.3.3"
     type-is "~1.6.16"
-
-"bookreader@git://github.com/internetarchive/bookreader.git#^4.8.0":
-  version "4.8.0"
-  resolved "git://github.com/internetarchive/bookreader.git#dd449403412857ac83a8ba58de5528eb46b423af"
-  dependencies:
-    jquery "^3.4.1"
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
@@ -6183,10 +6184,10 @@ jest@^24.7.1:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
 
-jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-beautify@^1.8.8:
   version "1.9.0"

--- a/packages/radio-player/yarn.lock
+++ b/packages/radio-player/yarn.lock
@@ -1842,62 +1842,6 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@internetarchive/audio-element@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/audio-element/-/audio-element-0.0.1.tgz#cfc67997b216c9817533d3da5053788eac784572"
-  integrity sha512-iLKQTwJLOkrg3agbpBsvMczUS1PXmHOUulBamZEujAwJ/nV44cgT1oK5xvpF2OtSk1UB9gmr4qroaI9XXCOwmg==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
-"@internetarchive/expandable-search-bar@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/expandable-search-bar/-/expandable-search-bar-0.0.1.tgz#8ca13de069a2556683ebdc5e62cfdd9baca5dd59"
-  integrity sha512-cLD4xeyT4sV/brHLw87kWELHSPA8Y8VI4r8WhN+5E9QN5JNk+/fFrIGsdv5N+cK1JDZ7sMyO29SJuU1phNcEXw==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
-"@internetarchive/ia-activity-indicator@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.1.tgz#cff0efcfa025d282be99c8981cec1527c0321ba7"
-  integrity sha512-+l7p1v4QuojgvQwFaIVnHOq9WfeARv9+jBbY/xmj6S8v1QTxW8+OwOkx8GaNuLN57e09uYTlo+EPP7BScOc+tA==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.1.2"
-
-"@internetarchive/playback-controls@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/playback-controls/-/playback-controls-0.0.1.tgz#e8f262026a8187f234960ff68338c0938222ea7d"
-  integrity sha512-15sd9hdG72f+3hSYhNf7HSJoLQlOo07CqcN2w5wM8Blk0RDwG+5WJ+UVxaYRJgc+I+Zxu4xt8P5hgNLeRNzTYw==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
-"@internetarchive/scrubber-bar@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/scrubber-bar/-/scrubber-bar-0.0.1.tgz#5fb3879124b51eb81b4553f09944e2871d492874"
-  integrity sha512-0KJWLPNNWxu3PG17OHe204rBbCkWT1pXFDGi2UE/+JSjH9r+HA2R11F1X5yiXtqZXqi8GmFJvpf/9O73vD8E3Q==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
-"@internetarchive/transcript-view@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/transcript-view/-/transcript-view-0.0.1.tgz#4d0157e553dacd577f9b09506869a69aab76c94c"
-  integrity sha512-2nWxeV5/SdjafLH2cl7a45Of784Usqg06A+a5v0Z7fJmZ+t0bVwHVUrWP/bEO9ZBY6731HI2s41tdyWHh7XyBw==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
-"@internetarchive/waveform-progress@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/waveform-progress/-/waveform-progress-0.0.1.tgz#6ec6070d87f7e5fe17f68b935a84a2d9ef9a5a50"
-  integrity sha512-pokWbjyRoE6TUlbfq+HdcoOscXHhn5+7h+nr+li9Gm1kyw0yC036P9YkwwI4Axe6pdJ9nDcgNfXCnpoWcP9/+g==
-  dependencies:
-    lit-element "^2.2.1"
-    lit-html "^1.0.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -11809,11 +11753,6 @@ lit-html@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.1.2.tgz#2e3560a7075210243649c888ad738eaf0daa8374"
   integrity sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA==
-
-lit-html@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.2.1.tgz#1fb933dc1e2ddc095f60b8086277d4fcd9d62cc8"
-  integrity sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
**Description**

Replaces the Petabox inherited styles for the BookReader wrapper with component-specific styles. Fixes [WEBDEV-3733](https://webarchive.jira.com/browse/WEBDEV-3733)

**Technical**

Upgrades BookReader to latest version in dev dependencies.

**Testing**

Run Storybook, view the audio player theater in Safari, and toggle fullscreen in BookReader. The full theater area should be used for BookReader.

**Evidence**

![liner-notes-fullscreen](https://user-images.githubusercontent.com/39553/93113677-7c9e7a00-f687-11ea-8380-f37260b3ae5f.gif)

