### PR TITLE
Conditionally renders sin input

### DIFF
--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -1,3 +1,4 @@
+import { nothing } from 'lit-html';
 import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import navSearchCSS from './styles/nav-search';
@@ -66,6 +67,10 @@ class NavSearch extends TrackedElement {
     }));
   }
 
+  get searchInsideInput() {
+    return this.searchIn ? html`<input type='hidden' name='sin' value='${this.searchIn}' />` : nothing;
+  }
+
   render() {
     const searchMenuClass = this.open ? 'flex' : 'search-inactive';
 
@@ -80,7 +85,7 @@ class NavSearch extends TrackedElement {
           @focus=${this.toggleSearchMenu}
           value=${this.config.searchQuery || ''}
         />
-        <input type='hidden' name='sin' value='${this.searchIn}' />
+        ${this.searchInsideInput}
         <button type="submit" class="search" data-event-click-tracking="${this.config.eventCategory}|NavSearchClose">
           ${icons.search}
         </button>

--- a/packages/ia-topnav/test/nav-search.test.js
+++ b/packages/ia-topnav/test/nav-search.test.js
@@ -50,4 +50,15 @@ describe('<nav-search>', () => {
 
     expect(el.shadowRoot.querySelector('[name="query"]').value).to.equal(config.searchQuery);
   });
+
+  it('conditionally renders `sin` input based on `searchIn` truthiness', async () => {
+    const el = await fixture(component);
+
+    expect(el.shadowRoot.querySelector('[name="sin"]')).to.be.null;
+
+    el.searchIn = 'TV';
+    await el.updateComplete;
+
+    expect(el.shadowRoot.querySelector('[name="sin"]')).not.to.be.null;
+  });
 });


### PR DESCRIPTION
**Description**

The `sin` param should not be sent with a metadata (default) search. This conditionally renders the hidden field based on the presence of a `searchIn` property being set. Fixes [WEBDEV-3595](https://webarchive.jira.com/browse/WEBDEV-3595)

**Testing**

Run the demo server and submit a metadata search. The `sin` param should not be present in the resulting archive.org redirect. Choose a different search in value and submit a search. The `sin` param should be filled in for other values excepting TV. TV has a unique URL structure that remains unchanged.

**Evidence**

![search_in](https://user-images.githubusercontent.com/39553/93137196-14fa2600-f6ab-11ea-91a9-55cde2581ec3.gif)

