### PR TITLE
Extracts base host to prop

### DIFF
--- a/packages/ia-topnav/README.md
+++ b/packages/ia-topnav/README.md
@@ -78,14 +78,13 @@ export default IATopNav;
   }
 </style>
 
-<ia-topnav></ia-topnav>
+<ia-topnav baseHost="archive.org" config=${config} menus=${menus}></ia-topnav>
 ```
 
 **Config object:**
 
 ```js
 {
-  baseHost: "archive.org", // domain used to build most links
   screenName: "really_long_screen_name_that_may_be_truncated_on_mobile", // full screen name displayed in user menu
   username: "shaneriley", // short user name used for desktop nav and some link building
   eventCategory: "MobileTopNav", // Google Analytics event category

--- a/packages/ia-topnav/base64_encoded_menus.html
+++ b/packages/ia-topnav/base64_encoded_menus.html
@@ -34,7 +34,6 @@
       import * as baseMenus from './src/data/menus.js';
 
       const config = {
-        baseHost: 'archive.org',
         screenName: 'really_long_screen_name_that_may_be_truncated_on_mobile',
         username: 'shaneriley',
         eventCategory: 'MobileTopNav',
@@ -56,7 +55,7 @@
         web: baseMenus.wayback,
       });
       render(html`
-        <ia-topnav config=${btoa(JSON.stringify(config))} menus=${btoa(JSON.stringify(menus))}></ia-topnav>
+        <ia-topnav baseHost="archive.org" config=${btoa(JSON.stringify(config))} menus=${btoa(JSON.stringify(menus))}></ia-topnav>
       `, document.getElementById('topnav'));
 
       const topnav = document.querySelector('ia-topnav');

--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -32,13 +32,12 @@
       import * as baseMenus from './src/data/menus.js';
 
       const config = {
-        baseHost: 'archive.org',
         screenName: 'really_long_screen_name_that_may_be_truncated_on_mobile',
         username: 'shaneriley',
         eventCategory: 'MobileTopNav',
         waybackPagesArchived: '424 billion',
         isAdmin: true,
-        uploadURL: 'https://archive.org/create',
+        uploadURL: '/create',
         searchQuery: 'atari',
         hiddenSearchOptions: [],
       };
@@ -55,6 +54,7 @@
         web: baseMenus.wayback,
       });
       Object.assign(topnav, {
+        baseHost: 'archive.onion',
         config,
         menus,
       });

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -28,7 +28,7 @@
     "storybook:build": "build-storybook -o _site -s storybook-static"
   },
   "dependencies": {
-    "@internetarchive/ia-wayback-search": "0.1.1",
+    "@internetarchive/ia-wayback-search": "0.2.0",
     "lit-element": "^2.2.1",
     "lit-html": "^1.0.0"
   },

--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -7,7 +7,7 @@ const texts = {
   iconLinks: [{
     title: 'Books to Borrow',
     icon: `https://${baseHost}/images/book-lend.png`,
-    url: `https://${baseHost}/details/inlibrary`,
+    url: '/details/inlibrary',
   }, {
     title: 'Open Library',
     icon: `https://${baseHost}/images/widgetOL.png`,
@@ -15,53 +15,53 @@ const texts = {
   }],
   featuredLinks: [{
     title: 'All Books',
-    url: `https://${baseHost}/details/books`,
+    url: '/details/books',
   }, {
     title: 'All Texts',
-    url: `https://${baseHost}/details/texts`,
+    url: '/details/texts',
   }, {
     title: 'This Just In',
-    url: `https://${baseHost}/search.php?query=mediatype:texts&sort=-publicdate`,
+    url: '/search.php?query=mediatype:texts&sort=-publicdate',
   }, {
     title: 'Smithsonian Libraries',
-    url: `https://${baseHost}/details/smithsonian`,
+    url: '/details/smithsonian',
   }, {
     title: 'FEDLINK (US)',
-    url: `https://${baseHost}/details/fedlink`,
+    url: '/details/fedlink',
   }, {
     title: 'Genealogy',
-    url: `https://${baseHost}/details/genealogy`,
+    url: '/details/genealogy',
   }, {
     title: 'Lincoln Collection',
-    url: `https://${baseHost}/details/lincolncollection`,
+    url: '/details/lincolncollection',
   }],
   links: [{
     title: 'American Libraries',
-    url: `https://${baseHost}/details/americana`,
+    url: '/details/americana',
   }, {
     title: 'Canadian Libraries',
-    url: `https://${baseHost}/details/toronto`,
+    url: '/details/toronto',
   }, {
     title: 'Universal Library',
-    url: `https://${baseHost}/details/universallibrary`,
+    url: '/details/universallibrary',
   }, {
     title: 'Community Texts',
-    url: `https://${baseHost}/details/opensource`,
+    url: '/details/opensource',
   }, {
     title: 'Project Gutenberg',
-    url: `https://${baseHost}/details/gutenberg`,
+    url: '/details/gutenberg',
   }, {
     title: 'Biodiversity Heritage Library',
-    url: `https://${baseHost}/details/biodiversity`,
+    url: '/details/biodiversity',
   }, {
     title: 'Children\'s Library',
-    url: `https://${baseHost}/details/iacl`,
+    url: '/details/iacl',
   }, {
     title: 'Books by Language',
-    url: `https://${baseHost}/details/booksbylanguage`,
+    url: '/details/booksbylanguage',
   }, {
     title: 'Additional Collections',
-    url: `https://${baseHost}/details/additional_collections`,
+    url: '/details/additional_collections',
   }],
 };
 
@@ -70,73 +70,73 @@ const video = {
   iconLinks: [{
     icon: `https://${baseHost}/services/img/tv`,
     title: 'TV News',
-    url: `https://${baseHost}/details/tv`,
+    url: '/details/tv',
   }, {
     icon: `https://${baseHost}/services/img/911`,
     title: 'Understanding 9/11',
-    url: `https://${baseHost}/details/911`,
+    url: '/details/911',
   }],
   featuredLinks: [{
     title: 'All video',
-    url: `https://${baseHost}/details/movies`,
+    url: '/details/movies',
   }, {
     title: 'This Just In',
-    url: `https://${baseHost}/search.php?query=mediatype:movies&sort=-publicdate`,
+    url: '/search.php?query=mediatype:movies&sort=-publicdate',
   }, {
     title: 'Prelinger Archives',
-    url: `https://${baseHost}/details/prelinger`,
+    url: '/details/prelinger',
   }, {
     title: 'Democracy Now!',
-    url: `https://${baseHost}/details/democracy_now_vid`,
+    url: '/details/democracy_now_vid',
   }, {
     title: 'Occupy Wall Street',
-    url: `https://${baseHost}/details/occupywallstreet`,
+    url: '/details/occupywallstreet',
   }, {
     title: 'TV NSA Clip Library',
-    url: `https://${baseHost}/details/nsa`,
+    url: '/details/nsa',
   }],
   links: [{
     title: 'Animation & Cartoons',
-    url: `https://${baseHost}/details/animationandcartoons`,
+    url: '/details/animationandcartoons',
   }, {
     title: 'Arts & Music',
-    url: `https://${baseHost}/details/artsandmusicvideos`,
+    url: '/details/artsandmusicvideos',
   }, {
     title: 'Computers & Technology',
-    url: `https://${baseHost}/details/computersandtechvideos`,
+    url: '/details/computersandtechvideos',
   }, {
     title: 'Cultural & Academic Films',
-    url: `https://${baseHost}/details/culturalandacademicfilms`,
+    url: '/details/culturalandacademicfilms',
   }, {
     title: 'Ephemeral Films',
-    url: `https://${baseHost}/details/ephemera`,
+    url: '/details/ephemera',
   }, {
     title: 'Movies',
-    url: `https://${baseHost}/details/moviesandfilms`,
+    url: '/details/moviesandfilms',
   }, {
     title: 'News & Public Affairs',
-    url: `https://${baseHost}/details/newsandpublicaffairs`,
+    url: '/details/newsandpublicaffairs',
   }, {
     title: 'Spirituality & Religion',
-    url: `https://${baseHost}/details/spiritualityandreligion`,
+    url: '/details/spiritualityandreligion',
   }, {
     title: 'Sports Videos',
-    url: `https://${baseHost}/details/sports`,
+    url: '/details/sports',
   }, {
     title: 'Television',
-    url: `https://${baseHost}/details/television`,
+    url: '/details/television',
   }, {
     title: 'Videogame Videos',
-    url: `https://${baseHost}/details/gamevideos`,
+    url: '/details/gamevideos',
   }, {
     title: 'Vlogs',
-    url: `https://${baseHost}/details/vlogs`,
+    url: '/details/vlogs',
   }, {
     title: 'Youth Media',
-    url: `https://${baseHost}/details/youth_media`,
+    url: '/details/youth_media',
   }, {
     title: 'Norton Media Center',
-    url: `https://${baseHost}/details/nmcma`,
+    url: '/details/nmcma',
   }]
 };
 
@@ -145,55 +145,55 @@ const audio = {
   iconLinks: [{
     icon: `https://${baseHost}/services/img/etree`,
     title: 'Live Music Archive',
-    url: `https://${baseHost}/details/etree`,
+    url: '/details/etree',
   }, {
     icon: `https://${baseHost}/services/img/librivoxaudio`,
     title: 'Librivox Free Audio',
-    url: `https://${baseHost}/details/librivoxaudio`,
+    url: '/details/librivoxaudio',
   }],
   featuredLinks: [{
     title: 'All audio',
-    url: `https://${baseHost}/details/audio`,
+    url: '/details/audio',
   }, {
     title: 'This Just In',
-    url: `https://${baseHost}/search.php?query=mediatype:audio&sort=-publicdate`,
+    url: '/search.php?query=mediatype:audio&sort=-publicdate',
   }, {
     title: 'Grateful Dead',
-    url: `https://${baseHost}/details/GratefulDead`,
+    url: '/details/GratefulDead',
   }, {
     title: 'Netlabels',
-    url: `https://${baseHost}/details/netlabels`,
+    url: '/details/netlabels',
   }, {
     title: 'Old Time Radio',
-    url: `https://${baseHost}/details/oldtimeradio`,
+    url: '/details/oldtimeradio',
   }, {
     title: '78 RPMs and Cylinder Recordings',
-    url: `https://${baseHost}/details/78rpm`,
+    url: '/details/78rpm',
   }],
   links: [{
     title: 'Audio Books & Poetry',
-    url: `https://${baseHost}/details/audio_bookspoetry`,
+    url: '/details/audio_bookspoetry',
   }, {
     title: 'Community Audio',
-    url: `https://${baseHost}/details/opensource_audio`,
+    url: '/details/opensource_audio',
   }, {
     title: 'Computers, Technology and Science',
-    url: `https://${baseHost}/details/audio_tech`,
+    url: '/details/audio_tech',
   }, {
     title: 'Music, Arts & Culture',
-    url: `https://${baseHost}/details/audio_music`,
+    url: '/details/audio_music',
   }, {
     title: 'News & Public Affairs',
-    url: `https://${baseHost}/details/audio_news`,
+    url: '/details/audio_news',
   }, {
     title: 'Non-English Audio',
-    url: `https://${baseHost}/details/audio_foreign`,
+    url: '/details/audio_foreign',
   }, {
     title: 'Spirituality & Religion',
-    url: `https://${baseHost}/details/audio_religion`,
+    url: '/details/audio_religion',
   }, {
     title: 'Podcasts',
-    url: `https://${baseHost}/details/podcasts`,
+    url: '/details/podcasts',
   }],
 };
 
@@ -202,76 +202,76 @@ const software = {
   iconLinks: [{
     icon: `https://${baseHost}/services/img/internetarcade`,
     title: 'Internet Arcade',
-    url: `https://${baseHost}/details/internetarcade`,
+    url: '/details/internetarcade',
   }, {
     icon: `https://${baseHost}/services/img/consolelivingroom`,
     title: 'Console Living Room',
-    url: `https://${baseHost}/details/consolelivingroom`,
+    url: '/details/consolelivingroom',
   }],
   featuredLinks: [{
     title: 'All software',
-    url: `https://${baseHost}/details/software`,
+    url: '/details/software',
   }, {
     title: 'This Just In',
-    url: `https://${baseHost}/search.php?query=mediatype:software&sort=-publicdate`,
+    url: '/search.php?query=mediatype:software&sort=-publicdate',
   }, {
     title: 'Old School Emulation',
-    url: `https://${baseHost}/details/tosec`,
+    url: '/details/tosec',
   }, {
     title: 'MS-DOS Games',
-    url: `https://${baseHost}/details/softwarelibrary_msdos_games`,
+    url: '/details/softwarelibrary_msdos_games',
   }, {
     title: 'Historical Software',
-    url: `https://${baseHost}/details/historicalsoftware`,
+    url: '/details/historicalsoftware',
   }, {
     title: 'Classic PC Games',
-    url: `https://${baseHost}/details/classicpcgames`,
+    url: '/details/classicpcgames',
   }, {
     title: 'Software Library',
-    url: `https://${baseHost}/details/softwarelibrary`,
+    url: '/details/softwarelibrary',
   }],
   links: [{
     title: 'Kodi Archive and Support File',
-    url: `https://${baseHost}/details/kodi_archive`,
+    url: '/details/kodi_archive',
   }, {
     title: 'Community Software',
-    url: `https://${baseHost}/details/open_source_software`,
+    url: '/details/open_source_software',
   }, {
     title: 'Vintage Software',
-    url: `https://${baseHost}/details/vintagesoftware`,
+    url: '/details/vintagesoftware',
   }, {
     title: 'APK',
-    url: `https://${baseHost}/details/apkarchive`,
+    url: '/details/apkarchive',
   }, {
     title: 'MS-DOS',
-    url: `https://${baseHost}/details/softwarelibrary_msdos`,
+    url: '/details/softwarelibrary_msdos',
   }, {
     title: 'CD-ROM Software',
-    url: `https://${baseHost}/details/cd-roms`,
+    url: '/details/cd-roms',
   }, {
     title: 'CD-ROM Software Library',
-    url: `https://${baseHost}/details/cdromsoftware`,
+    url: '/details/cdromsoftware',
   }, {
     title: 'Software Sites',
-    url: `https://${baseHost}/details/softwaresites`,
+    url: '/details/softwaresites',
   }, {
     title: 'Tucows Software Library',
-    url: `https://${baseHost}/details/tucows`,
+    url: '/details/tucows',
   }, {
     title: 'Shareware CD-ROMs',
-    url: `https://${baseHost}/details/cdbbsarchive`,
+    url: '/details/cdbbsarchive',
   }, {
     title: 'Software Capsules Compilation',
-    url: `https://${baseHost}/details/softwarecapsules`,
+    url: '/details/softwarecapsules',
   }, {
     title: 'CD-ROM Images',
-    url: `https://${baseHost}/details/cdromimages`,
+    url: '/details/cdromimages',
   }, {
     title: 'ZX Spectrum',
-    url: `https://${baseHost}/details/softwarelibrary_zx_spectrum`,
+    url: '/details/softwarelibrary_zx_spectrum',
   }, {
     title: 'DOOM Level CD',
-    url: `https://${baseHost}/details/doom-cds`,
+    url: '/details/doom-cds',
   }],
 };
 
@@ -280,40 +280,40 @@ const images = {
   iconLinks: [{
     icon: `https://${baseHost}/services/img/metropolitanmuseumofart-gallery`,
     title: 'Metropolitan Museum',
-    url: `https://${baseHost}/details/metropolitanmuseumofart-gallery`,
+    url: '/details/metropolitanmuseumofart-gallery',
   }, {
     icon: `https://${baseHost}/services/img/brooklynmuseum`,
     title: 'Brooklyn Museum',
-    url: `https://${baseHost}/details/brooklynmuseum`,
+    url: '/details/brooklynmuseum',
   }],
   featuredLinks: [{
     title: 'All images',
-    url: `https://${baseHost}/details/image`,
+    url: '/details/image',
   }, {
     title: 'This Just In',
-    url: `https://${baseHost}/search.php?query=mediatype:image&sort=-publicdate`,
+    url: '/search.php?query=mediatype:image&sort=-publicdate',
   }, {
     title: 'Flickr Commons',
-    url: `https://${baseHost}/details/flickrcommons`,
+    url: '/details/flickrcommons',
   }, {
     title: 'Occupy Wall Street Flickr',
-    url: `https://${baseHost}/details/flickr-ows`,
+    url: '/details/flickr-ows',
   }, {
     title: 'Cover Art',
-    url: `https://${baseHost}/details/coverartarchive`,
+    url: '/details/coverartarchive',
   }, {
     title: 'USGS Maps',
-    url: `https://${baseHost}/details/maps_usgs`,
+    url: '/details/maps_usgs',
   }],
   links: [{
     title: 'NASA Images',
-    url: `https://${baseHost}/details/nasa`,
+    url: '/details/nasa',
   }, {
     title: 'Solar System Collection',
-    url: `https://${baseHost}/details/solarsystemcollection`,
+    url: '/details/solarsystemcollection',
   }, {
     title: 'Ames Research Center',
-    url: `https://${baseHost}/details/amesresearchcenterimagelibrary`,
+    url: '/details/amesresearchcenterimagelibrary',
   }]
 };
 
@@ -326,27 +326,27 @@ const user = ({
   biblio,
 }) => {
   const generalLinks = [{
-    url: `https://${baseHost}/create`,
+    url: '/create',
     title: 'Upload',
     analyticsEvent: 'UserUpload',
   }, {
-    url: `https://${baseHost}/details/@${username}`,
+    url: `/details/@${username}`,
     title: 'My library',
     analyticsEvent: 'UserLibrary',
   }, {
-    url: `https://${baseHost}/details/@${username}?tab=loans`,
+    url: `/details/@${username}?tab=loans`,
     title: 'My loans',
     analyticsEvent: 'UserLoans',
   }, {
-    url: `https://${baseHost}/details/fav-${username}`,
+    url: `/details/fav-${username}`,
     title: 'My favorites',
     analyticsEvent: 'UserFavorites',
   }, {
-    url: `https://${baseHost}/details/@${username}/web-archive`,
+    url: `/details/@${username}/web-archive`,
     title: 'My web archive',
     analyticsEvent: 'UserWebArchive',
   }, {
-    url: `https://${baseHost}/account/index.php?settings=1`,
+    url: '/account/index.php?settings=1',
     title: 'Edit settings',
     analyticsEvent: 'UserSettings',
   }, {
@@ -354,7 +354,7 @@ const user = ({
     title: 'Get help',
     analyticsEvent: 'UserHelp',
   }, {
-    url: `https://${baseHost}/account/logout`,
+    url: '/account/logout',
     title: 'Log out',
     analyticsEvent: 'UserLogOut',
   }];
@@ -364,19 +364,19 @@ const user = ({
   }, {
     title: 'item:'
   }, {
-    url: `https://${baseHost}/editxml/${identifier}`,
+    url: `/editxml/${identifier}`,
     title: 'edit xml',
     analyticsEvent: 'AdminUserEditXML',
   }, {
-    url: `https://${baseHost}/edit.php?redir=1&identifier=${identifier}`,
+    url: `/edit.php?redir=1&identifier=${identifier}`,
     title: 'edit files',
     analyticsEvent: 'AdminUserEditFiles',
   }, {
-    url: `https://${baseHost}/download/${identifier}/`,
+    url: `/download/${identifier}/`,
     title: 'download',
     analyticsEvent: 'AdminUserDownload',
   }, {
-    url: `https://${baseHost}/metadata/${identifier}/`,
+    url: `/metadata/${identifier}/`,
     title: 'metadata',
     analyticsEvent: 'AdminUserMetadata',
   }, {
@@ -384,19 +384,19 @@ const user = ({
     title: 'history',
     analyticsEvent: 'AdminUserHistory',
   }, {
-    url: `https://${baseHost}/manage/${identifier}`,
+    url: `/manage/${identifier}`,
     title: 'manage',
     analyticsEvent: 'AdminUserManager',
   }, {
-    url: `https://${baseHost}/manage/${identifier}#make_dark`,
+    url: `/manage/${identifier}#make_dark`,
     title: 'curate',
     analyticsEvent: 'AdminUserCurate',
   }, {
-    url: `https://${baseHost}/manage/${identifier}#modify_xml`,
+    url: `/manage/${identifier}#modify_xml`,
     title: 'modify xml',
     analyticsEvent: 'AdminUserModifyXML',
   }, {
-    url: `https://${baseHost}/services/flags/admin.php?identifier=${identifier}`,
+    url: `/services/flags/admin.php?identifier=${identifier}`,
     title: 'manage flags',
     analyticsEvent: 'AdminUserManageFlags',
   }];
@@ -406,11 +406,11 @@ const user = ({
     title: 'biblio',
     analyticsEvent: 'AdminUserBiblio',
   }, {
-    url: `https://${baseHost}/bookview.php?mode=debug&identifier=${identifier}`,
+    url: `/bookview.php?mode=debug&identifier=${identifier}`,
     title: 'bookview',
     analyticsEvent: 'AdminUserBookView',
   }, {
-    url: `https://${baseHost}/download/${identifier}/format=Single Page Processed JP2 ZIP`,
+    url: `/download/${identifier}/format=Single Page Processed JP2 ZIP`,
     title: 'jp2 zip',
     analyticsEvent: 'AdminUserJP2Zip',
   }];
@@ -420,11 +420,11 @@ const user = ({
   }, {
     title: uploader,
   }, {
-    url: `https://${baseHost}/admins/useradmin.php?searchUser=${uploader}&ignore=${identifier}`,
+    url: `/admins/useradmin.php?searchUser=${uploader}&ignore=${identifier}`,
     title: 'user admin',
     analyticsEvent: 'AdminUserUserAdmin',
   }, {
-    url: `https://${baseHost}/admins/setadmin.php?user=${uploader}&ignore=${identifier}`,
+    url: `/admins/setadmin.php?user=${uploader}&ignore=${identifier}`,
     title: 'user privs',
     analyticsEvent: 'AdminUserUserPrivs',
   }];
@@ -446,25 +446,25 @@ const user = ({
 };
 
 const signedOut = [{
-  url: `https://${baseHost}/account/signup`,
+  url: '/account/signup',
   title: 'Sign up for free',
   analyticsEvent: 'SignUpDropdown',
 }, {
-  url: `https://${baseHost}/account/login`,
+  url: '/account/login',
   title: 'Log in',
   analyticsEvent: 'LogInDropdown',
 }];
 
 const more = [
-  { title: 'About', url: `https://${baseHost}/about/` },
+  { title: 'About', url: '/about/' },
   { title: 'Blog', url: 'https://blog.archive.org/' },
-  { title: 'Projects', url: `https://${baseHost}/projects/` },
-  { title: 'Help', url: `https://${baseHost}/about/faqs.php` },
-  { title: 'Donate', url: `https://${baseHost}/donate/` },
-  { title: 'Contact', url: `https://${baseHost}/about/contact.php` },
-  { title: 'Jobs', url: `https://${baseHost}/about/jobs.php` },
-  { title: 'Volunteer', url: `https://${baseHost}/about/volunteerpositions.php` },
-  { title: 'People', url: `https://${baseHost}/about/bios.php` },
+  { title: 'Projects', url: '/projects/' },
+  { title: 'Help', url: '/about/faqs.php' },
+  { title: 'Donate', url: '/donate/' },
+  { title: 'Contact', url: '/about/contact.php' },
+  { title: 'Jobs', url: '/about/jobs.php' },
+  { title: 'Volunteer', url: '/about/volunteerpositions.php' },
+  { title: 'People', url: '/about/bios.php' },
 ];
 
 const wayback = {

--- a/packages/ia-topnav/src/desktop-subnav.js
+++ b/packages/ia-topnav/src/desktop-subnav.js
@@ -2,6 +2,7 @@ import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import desktopSubnavCSS from './styles/desktop-subnav';
 import icons from './assets/img/icons';
+import formatUrl from './lib/formatUrl';
 
 class DesktopSubnav extends TrackedElement {
   static get styles() {
@@ -19,7 +20,7 @@ class DesktopSubnav extends TrackedElement {
     return this.menuItems.map(link => (
       html`
         <li>
-          <a class="${link.title.toLowerCase()}" href="${link.url}">${link.title}${DesktopSubnav.iconFor(link.title)}</a>
+          <a class="${link.title.toLowerCase()}" href="${formatUrl(link.url, this.baseHost)}">${link.title}${DesktopSubnav.iconFor(link.title)}</a>
         </li>
       `
     ));

--- a/packages/ia-topnav/src/dropdown-menu.js
+++ b/packages/ia-topnav/src/dropdown-menu.js
@@ -1,6 +1,7 @@
 import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import dropdownMenuCSS from './styles/dropdown-menu';
+import formatUrl from './lib/formatUrl';
 
 class DropdownMenu extends TrackedElement {
   static get styles() {
@@ -9,6 +10,7 @@ class DropdownMenu extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       menuItems: { type: Array },
       animate: { type: Boolean },
@@ -47,7 +49,7 @@ class DropdownMenu extends TrackedElement {
   }
 
   dropdownLink(link) {
-    return html`<a href="${link.url}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}">${link.title}</a>`;
+    return html`<a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}">${link.title}</a>`;
   }
 
   static dropdownText(item) {

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -16,6 +16,7 @@ export default class IATopNav extends LitElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: {
         type: Object,
         converter(value) {
@@ -37,6 +38,7 @@ export default class IATopNav extends LitElement {
 
   constructor() {
     super();
+    this.baseHost = 'archive.org';
     this.config = {};
     this.mediaSliderOpen = false;
     this.menus = {};
@@ -129,6 +131,7 @@ export default class IATopNav extends LitElement {
   get userMenu() {
     return html`
       <user-menu
+        .baseHost=${this.baseHost}
         .config=${this.config}
         .menuItems=${this.userMenuItems}
         .open=${this.openMenu === 'user'}
@@ -167,6 +170,7 @@ export default class IATopNav extends LitElement {
     return html`
       <div class='topnav'>
         <primary-nav
+          .baseHost=${this.baseHost}
           .config=${this.config}
           .searchIn=${this.searchIn}
           .selectedMenuOption=${this.selectedMenuOption}
@@ -178,14 +182,16 @@ export default class IATopNav extends LitElement {
           @menuToggled=${this.menuToggled}
         ></primary-nav>
         <media-slider
+          .baseHost=${this.baseHost}
           .config=${this.config}
           .selectedMenuOption=${this.selectedMenuOption}
           .mediaSliderOpen=${this.mediaSliderOpen}
           .menus=${this.menus}
         ></media-slider>
       </div>
-      <desktop-subnav .baseHost=${this.config.baseHost} .menuItems=${this.desktopSubnavMenuItems}></desktop-subnav>
+      <desktop-subnav .baseHost=${this.baseHost} .menuItems=${this.desktopSubnavMenuItems}></desktop-subnav>
       <search-menu
+        .baseHost=${this.baseHost}
         .config=${this.config}
         .openMenu=${this.openMenu}
         tabindex="${this.searchMenuTabIndex}"

--- a/packages/ia-topnav/src/lib/formatUrl.js
+++ b/packages/ia-topnav/src/lib/formatUrl.js
@@ -1,0 +1,3 @@
+export default (url, baseHost) => (
+  /^https?:/.test(url) ? url : `https://${baseHost}${url}`
+);

--- a/packages/ia-topnav/src/login-button.js
+++ b/packages/ia-topnav/src/login-button.js
@@ -2,6 +2,7 @@ import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import icons from './assets/img/icons';
 import loginButtonCSS from './styles/login-button';
+import formatUrl from './lib/formatUrl';
 
 class LoginButton extends TrackedElement {
   static get styles() {
@@ -10,6 +11,7 @@ class LoginButton extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       openMenu: { type: String },
     };
@@ -22,11 +24,11 @@ class LoginButton extends TrackedElement {
   }
 
   get signupPath() {
-    return `https://${this.config.baseHost}/account/signup`;
+    return formatUrl('/account/signup', this.baseHost);
   }
 
   get loginPath() {
-    return `https://${this.config.baseHost}/account/login`;
+    return formatUrl('/account/login', this.baseHost);
   }
 
   get analyticsEvent() {

--- a/packages/ia-topnav/src/media-button.js
+++ b/packages/ia-topnav/src/media-button.js
@@ -3,7 +3,6 @@ import TrackedElement from './tracked-element';
 import icons from './assets/img/icons';
 import toSentenceCase from './lib/toSentenceCase';
 import mediaButtonCSS from './styles/media-button';
-import { prodHost } from './constants';
 
 class MediaButton extends TrackedElement {
   static get styles() {
@@ -95,7 +94,7 @@ class MediaButton extends TrackedElement {
   render() {
     return html`
       <a
-        href="https://${this.config.baseHost || prodHost}${this.href}"
+        href="${this.href}"
         class="menu-item ${this.mediatype} ${this.buttonClass}"
         @click=${this.followable ? this.trackClick : this.onClick}
         data-event-click-tracking="${this.analyticsEvent}"

--- a/packages/ia-topnav/src/media-menu.js
+++ b/packages/ia-topnav/src/media-menu.js
@@ -2,6 +2,7 @@ import { LitElement, html } from 'lit-element';
 
 import './media-button';
 import mediaMenuCSS from './styles/media-menu';
+import formatUrl from './lib/formatUrl';
 
 const menuSelection = [
   {
@@ -62,6 +63,7 @@ class MediaMenu extends LitElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       openMenu: { type: String },
       selectedMenuOption: { type: String },
@@ -88,7 +90,7 @@ class MediaMenu extends LitElement {
         <media-button
           .config=${this.config}
           .icon=${icon}
-          .href=${href}
+          .href=${formatUrl(href, this.baseHost)}
           .followable=${followable}
           .label=${label}
           .mediatype=${menu}

--- a/packages/ia-topnav/src/media-slider.js
+++ b/packages/ia-topnav/src/media-slider.js
@@ -9,6 +9,7 @@ class MediaSlider extends LitElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       mediaSliderOpen: { type: Boolean },
       menus: { type: Object },
@@ -45,7 +46,12 @@ class MediaSlider extends LitElement {
       <div class="overflow-clip ${sliderDetailsClass}">
         <div class="information-menu ${sliderDetailsClass}">
           <div class="info-box">
-            <media-subnav .config=${this.config} .menu=${this.selectedMenuOption} .menuItems=${this.selectedMenuItems}></media-subnav>
+            <media-subnav
+              .baseHost=${this.baseHost}
+              .config=${this.config}
+              .menu=${this.selectedMenuOption}
+              .menuItems=${this.selectedMenuItems}
+            ></media-subnav>
           </div>
         </div>
       </div>

--- a/packages/ia-topnav/src/media-subnav.js
+++ b/packages/ia-topnav/src/media-subnav.js
@@ -4,6 +4,7 @@ import './wayback-slider';
 import './more-slider';
 import mediaSubnavCSS from './styles/media-subnav';
 import toSentenceCase from './lib/toSentenceCase';
+import formatUrl from './lib/formatUrl';
 
 class MediaSubnav extends TrackedElement {
   static get styles() {
@@ -12,6 +13,7 @@ class MediaSubnav extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       menu: { type: String },
       menuItems: { type: Array },
@@ -29,12 +31,13 @@ class MediaSubnav extends TrackedElement {
     this.links = MediaSubnav.defaultLinks;
     this.templates = {
       web: () => html`<wayback-slider
+        .baseHost=${this.baseHost}
         .config=${this.config}
         .archiveItLinks=${this.menuItems.archiveItLinks}
         .browserExtensionsLinks=${this.menuItems.browserExtensionsLinks}
         .mobileAppsLinks=${this.menuItems.mobileAppsLinks}
       ></wayback-slider>`,
-      more: () => html`<more-slider .config=${this.config} .menuItems=${this.menuItems}></more-slider>`,
+      more: () => html`<more-slider .baseHost=${this.baseHost} .config=${this.config} .menuItems=${this.menuItems}></more-slider>`,
     };
   }
 
@@ -56,7 +59,7 @@ class MediaSubnav extends TrackedElement {
   get iconLinks() {
     return this.links.iconLinks.map(link => (
       html`
-        <a href="${link.url}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}"><img src="${link.icon}" />${link.title}</a>
+        <a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}"><img src="${link.icon}" />${link.title}</a>
       `
     ));
   }
@@ -64,7 +67,7 @@ class MediaSubnav extends TrackedElement {
   renderLinks(category) {
     return this.links[category].map(link => (
       html`
-        <li><a href="${link.url}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}">${link.title}</a></li>
+        <li><a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}">${link.title}</a></li>
       `
     ));
   }

--- a/packages/ia-topnav/src/more-slider.js
+++ b/packages/ia-topnav/src/more-slider.js
@@ -2,10 +2,12 @@ import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import toSentenceCase from './lib/toSentenceCase';
 import moreSliderCSS from './styles/more-slider';
+import formatUrl from './lib/formatUrl';
 
 class MoreSlider extends TrackedElement {
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       menuItems: { type: Array },
     };
@@ -15,10 +17,6 @@ class MoreSlider extends TrackedElement {
     return moreSliderCSS;
   }
 
-  get baseUrl() {
-    return `https://${this.config.baseHost}`;
-  }
-
   analyticsEvent(title) {
     return `${this.config.eventCategory}|NavMore${toSentenceCase(title)}`;
   }
@@ -26,7 +24,7 @@ class MoreSlider extends TrackedElement {
   render() {
     return html`
       <ul>
-        ${this.menuItems.map(item => html`<li><a @click=${this.trackClick} href="${item.url}" data-event-click-tracking="${this.analyticsEvent(item.title)}">${item.title}</a></li>`)}
+        ${this.menuItems.map(item => html`<li><a @click=${this.trackClick} href=${formatUrl(item.url, this.baseHost)} data-event-click-tracking="${this.analyticsEvent(item.title)}">${item.title}</a></li>`)}
       </ul>
     `;
   }

--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -3,6 +3,7 @@ import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import navSearchCSS from './styles/nav-search';
 import icons from './assets/img/icons';
+import formatUrl from './lib/formatUrl';
 
 class NavSearch extends TrackedElement {
   static get styles() {
@@ -11,6 +12,7 @@ class NavSearch extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       locationHandler: { type: Function },
       open: { type: Boolean },
@@ -45,7 +47,7 @@ class NavSearch extends TrackedElement {
 
     // TV search points to a detail page with a q param instead
     if (this.searchIn === 'TV') {
-      this.locationHandler(`https://${this.config.baseHost}/details/tv?q=${query}`);
+      this.locationHandler(formatUrl(`/details/tv?q=${query}`, this.baseHost));
       e.preventDefault();
       return false;
     }
@@ -75,7 +77,7 @@ class NavSearch extends TrackedElement {
     const searchMenuClass = this.open ? 'flex' : 'search-inactive';
 
     return html`<div class="search-activated fade-in ${searchMenuClass}">
-      <form id="nav-search" class="highlight" action="https://${this.config.baseHost}/search.php" method="get" @submit=${this.search} data-event-submit-tracking="${this.config.eventCategory}|NavSearchSubmit">
+      <form id="nav-search" class="highlight" action=${formatUrl('/search.php', this.baseHost)} method="get" @submit=${this.search} data-event-submit-tracking="${this.config.eventCategory}|NavSearchSubmit">
         <input
           type="text"
           name="query"

--- a/packages/ia-topnav/src/primary-nav.js
+++ b/packages/ia-topnav/src/primary-nav.js
@@ -8,6 +8,7 @@ import './media-menu';
 import logoWordmark from './assets/img/wordmark-narrow-spacing';
 import primaryNavCSS from './styles/primary-nav';
 import locationHandler from './lib/location-handler';
+import formatUrl from './lib/formatUrl';
 
 class PrimaryNav extends TrackedElement {
   static get styles() {
@@ -16,6 +17,7 @@ class PrimaryNav extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       openMenu: { type: String },
       searchIn: { type: String },
@@ -81,6 +83,7 @@ class PrimaryNav extends TrackedElement {
   get loginIcon() {
     return html`
       <login-button
+        .baseHost=${this.baseHost}
         .config=${this.config}
         .dropdownOpen=${this.signedOutMenuOpen}
         .openMenu=${this.openMenu}
@@ -106,6 +109,7 @@ class PrimaryNav extends TrackedElement {
         ${icons.search}
       </button>
       <nav-search
+        .baseHost=${this.baseHost}
         .config=${this.config}
         .locationHandler=${locationHandler}
         .open=${this.searchMenuOpen}
@@ -119,9 +123,9 @@ class PrimaryNav extends TrackedElement {
     const mediaMenuTabIndex = this.openMenu === 'media' ? '' : '-1';
     return html`
       <nav>
-        <a class="link-home" href="https://${this.config.baseHost}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|NavHome">${icons.iaLogo}${logoWordmark}</a>
+        <a class="link-home" href=${formatUrl('/', this.baseHost)} @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|NavHome">${icons.iaLogo}${logoWordmark}</a>
         ${this.searchMenu}
-        <a href="${this.config.uploadURL}" class="upload">
+        <a href="${formatUrl(this.config.uploadURL, this.baseHost)}" class="upload">
           ${icons.upload}
           <span>Upload</span>
         </a>
@@ -129,6 +133,7 @@ class PrimaryNav extends TrackedElement {
           ${this.config.username ? this.userIcon : this.loginIcon}
         </div>
         <media-menu
+          .baseHost=${this.baseHost}
           .config=${this.config}
           ?mediaMenuAnimate="${this.mediaMenuAnimate}"
           tabindex="${mediaMenuTabIndex}"

--- a/packages/ia-topnav/src/search-menu.js
+++ b/packages/ia-topnav/src/search-menu.js
@@ -1,6 +1,7 @@
 import { html } from 'lit-element';
 import TrackedElement from './tracked-element';
 import searchMenuCSS from './styles/search-menu';
+import formatUrl from './lib/formatUrl';
 
 class SearchMenu extends TrackedElement {
   static get styles() {
@@ -9,6 +10,7 @@ class SearchMenu extends TrackedElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       config: { type: Object },
       openMenu: { type: String },
       searchMenuOpen: { type: Boolean },
@@ -95,7 +97,7 @@ class SearchMenu extends TrackedElement {
         aria-expanded="${searchMenuExpanded}"
       >
         ${this.searchTypesTemplate}
-        <a class="advanced-search" href="https://${this.config.baseHost}/advancedsearch.php" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|NavAdvancedSearch">Advanced Search</a>
+        <a class="advanced-search" href="${formatUrl('/advancedsearch.php', this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|NavAdvancedSearch">Advanced Search</a>
       </div>
     `;
   }

--- a/packages/ia-topnav/src/wayback-slider.js
+++ b/packages/ia-topnav/src/wayback-slider.js
@@ -5,6 +5,7 @@ import './save-page-form';
 import queryHandler from './lib/query-handler';
 import waybackSliderCSS from './styles/wayback-slider';
 import toSentenceCase from './lib/toSentenceCase';
+import formatUrl from './lib/formatUrl';
 
 class WaybackSlider extends TrackedElement {
   static get styles() {
@@ -14,6 +15,7 @@ class WaybackSlider extends TrackedElement {
   static get properties() {
     return {
       archiveItLinks: { type: Array },
+      baseHost: { type: String },
       browserExtensionsLinks: { type: Array },
       config: { type: Object },
       mobileAppsLinks: { type: Array },
@@ -42,7 +44,7 @@ class WaybackSlider extends TrackedElement {
 
   linkList(linkType, eventPrefix) {
     return this[linkType].map(link => html`<li>
-      <a href=${link.url} @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(`${eventPrefix}${link.title}`)}" target=${link.external ? '_blank' : ''} rel=${link.external ? 'noreferrer noopener' : ''}>${link.title}</a>
+      <a href=${formatUrl(link.url, this.baseHost)} @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(`${eventPrefix}${link.title}`)}" target=${link.external ? '_blank' : ''} rel=${link.external ? 'noreferrer noopener' : ''}>${link.title}</a>
     </li>`);
   }
 
@@ -53,7 +55,10 @@ class WaybackSlider extends TrackedElement {
   render() {
     return html`
       <div class="grid">
-        <wayback-search waybackPagesArchived=${this.config.waybackPagesArchived} .queryHandler=${queryHandler}></wayback-search>
+        <wayback-search
+          .baseHost=${this.baseHost}
+          waybackPagesArchived=${this.config.waybackPagesArchived}
+          .queryHandler=${queryHandler}></wayback-search>
         <div class="link-lists">
           <div>
             <h4>Mobile Apps</h4>

--- a/packages/ia-topnav/test/ia-topnav.test.js
+++ b/packages/ia-topnav/test/ia-topnav.test.js
@@ -7,8 +7,8 @@ import {
 
 import '../src/ia-topnav';
 
-const container = (config = {}) => (
-  html`<ia-topnav .config=${config}></ia-topnav>`
+const container = (config = {}, baseHost = '') => (
+  html`<ia-topnav .baseHost=${baseHost} .config=${config}></ia-topnav>`
 );
 
 const verifyClosed = (instance) => {
@@ -199,7 +199,7 @@ describe('<ia-topnav>', () => {
   });
 
   it('uses baseHost to render logo link to homepage', async () => {
-    const el = await fixture(container({ baseHost: 'archive.org' }));
+    const el = await fixture(container({}, 'archive.org'));
     const logoLink = el
       .shadowRoot
       .querySelector('primary-nav')

--- a/packages/ia-topnav/test/more-slider.test.js
+++ b/packages/ia-topnav/test/more-slider.test.js
@@ -3,12 +3,10 @@ import '../src/more-slider';
 import { more } from '../src/data/menus';
 
 describe('<more-slider>', () => {
-  it('returns a baseUrl using this.config.baseHost', async () => {
-    const config = {
-      baseHost: 'archive.org'
-    };
-    const el = await fixture(html`<more-slider .config=${config} .menuItems=${more}>`);
+  it('renders links with relative hrefs using baseHost', async () => {
+    const baseHost = 'archive.org';
+    const el = await fixture(html`<more-slider .baseHost=${baseHost} .config=${{}} .menuItems=${more}>`);
 
-    expect(el.baseUrl).to.contain(config.baseHost);
+    expect(el.shadowRoot.querySelector('a').getAttribute('href')).to.contain(baseHost);
   });
 });

--- a/packages/ia-topnav/test/wayback-slider.test.js
+++ b/packages/ia-topnav/test/wayback-slider.test.js
@@ -10,6 +10,7 @@ const component = ({
 }) => (
   html`
     <wayback-slider
+      .baseHost='archive.org'
       .config=${config}
       .archiveItLinks=${archiveItLinks}
       .browserExtensionsLinks=${browserExtensionsLinks}
@@ -19,7 +20,7 @@ const component = ({
 );
 
 const buildDefaults = () => ({
-  config: { baseHost: 'archive.org' },
+  config: {},
   archiveItLinks: [{
     url: '1',
     title: 'first'
@@ -51,7 +52,7 @@ describe('<wayback-slider>', () => {
 
     options.archiveItLinks.forEach((link, i) => {
       expect(anchors[i].innerText).to.equal(link.title);
-      expect(anchors[i].getAttribute('href')).to.equal(link.url);
+      expect(anchors[i].getAttribute('href')).to.contain(link.url);
     });
   });
 
@@ -62,7 +63,7 @@ describe('<wayback-slider>', () => {
 
     options.browserExtensionsLinks.forEach((link, i) => {
       expect(anchors[i].innerText).to.equal(link.title);
-      expect(anchors[i].getAttribute('href')).to.equal(link.url);
+      expect(anchors[i].getAttribute('href')).to.contain(link.url);
     });
   });
 
@@ -73,7 +74,7 @@ describe('<wayback-slider>', () => {
 
     options.mobileAppsLinks.forEach((link, i) => {
       expect(anchors[i].innerText).to.equal(link.title);
-      expect(anchors[i].getAttribute('href')).to.equal(link.url);
+      expect(anchors[i].getAttribute('href')).to.contain(link.url);
     });
   });
 });

--- a/packages/ia-topnav/yarn.lock
+++ b/packages/ia-topnav/yarn.lock
@@ -1018,10 +1018,10 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
-"@internetarchive/ia-wayback-search@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-wayback-search/-/ia-wayback-search-0.1.1.tgz#7b954312ecbf636da5e9d985e17e3105a5f73970"
-  integrity sha512-rypqkahDxsPGKoiJce6S/65DHL24dUqRkLD0uiGANMpjSr9/n2GQyEP6KmYqLpPVxIQHKDrjav8lZZ6NEx0H4Q==
+"@internetarchive/ia-wayback-search@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-wayback-search/-/ia-wayback-search-0.2.0.tgz#1d2f7831c04012ab85d33c7a90630c2dd60dab06"
+  integrity sha512-Hmtv7pm5sp8cUh7JO1ZSsNK5PCKhJSOK8b5rZArMj7XuFMxwm7mG1OR32XXQr2i68BXHGx5wljmiQhSL9lwdFw==
   dependencies:
     lit-element "^2.2.1"
 

--- a/packages/ia-wayback-search/README.md
+++ b/packages/ia-wayback-search/README.md
@@ -4,6 +4,7 @@
 
 ```html
 <ia-wayback-search
+  .baseHost=${'archive.org'}
   waybackPagesArchived="32 trillion pages"
 ></ia-wayback-search>
 ```
@@ -19,6 +20,7 @@ document.querySelector('ia-wayback-search').locationHandler = {
 ### Properties:
 
 ```js
+baseHost: { type: String }, // host used to build the logo href attribute
 locationHandler: { type: Function }, // function called when form submitted. @param url string
 waybackPagesArchived: { type: String }, // Pages archived message, e.g. "428 billion pages"
 ```

--- a/packages/ia-wayback-search/index.html
+++ b/packages/ia-wayback-search/index.html
@@ -39,6 +39,7 @@
 
       render(html`<ia-wayback-search
         waybackPagesArchived="32 trillion pages"
+        .baseHost=${'archive.org'}
         .queryHandler=${queryHandler}
       ></ia-wayback-search>`, document.getElementById('root'));
 

--- a/packages/ia-wayback-search/package.json
+++ b/packages/ia-wayback-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-wayback-search",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Wayback search form component",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-wayback-search/src/ia-wayback-search.js
+++ b/packages/ia-wayback-search/src/ia-wayback-search.js
@@ -10,6 +10,7 @@ class WaybackSearch extends LitElement {
 
   static get properties() {
     return {
+      baseHost: { type: String },
       queryHandler: { type: Object },
       waybackPagesArchived: { type: String },
     };
@@ -60,7 +61,7 @@ class WaybackSearch extends LitElement {
           <a
             @click=${this.emitWaybackMachineLogoLinkClicked}
             data-event-click-tracking="TopNav|WaybackMachineLogoLink"
-            href="https://archive.org/web/"
+            href=${`https://${this.baseHost}/web/`}
             >${logo}</a>
           <label for="url">Search the Wayback Machine</label>
           <div class="search-field">

--- a/packages/ia-wayback-search/test/wayback-search.test.js
+++ b/packages/ia-wayback-search/test/wayback-search.test.js
@@ -10,9 +10,10 @@ import '../src/ia-wayback-search';
 
 const component = (properties = {
   waybackPagesArchived: '32 trillion pages'
-}) => (
+}, baseHost = 'archive.org') => (
   html`
     <ia-wayback-search
+      .baseHost=${baseHost}
       waybackPagesArchived=${properties.waybackPagesArchived}
     ></ia-wayback-search>
   `
@@ -69,5 +70,12 @@ describe('<wayback-search>', () => {
     const response = await oneEvent(el, 'waybackSearchSubmitted');
 
     expect(response).to.exist;
+  });
+
+  it('uses the baseHost property when setting the logo anchor\'s href', async () => {
+    const host = 'archive.onion';
+    const el = await fixture(component({}, host));
+
+    expect(el.shadowRoot.querySelector('fieldset a').getAttribute('href')).to.contain(host);
   });
 });


### PR DESCRIPTION
**Description**

In order to allow the change of the base host for most links in the topnav, a property needs to be added to the ia-topnav component. This is also passed in to the ia-wayback-search component, which receives the same property addition. A function is added to lib to check whether the URL being used is fully qualified or not, and if not, uses the baseHost property to build a full URL.

**Testing**

Visit https://www-shaner5.archive.org/. All URLs that would normally be root relative use the www-shaner5 subdomain. If you then change the property with `document.querySelector('ia-topnav').baseHost = 'archive.onion'`, those same URLs should update to use the new baseHost.
