### PR TITLE
Update Topnav Base Host handling

### DIFF
--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -32,6 +32,7 @@
         <legend>Dev Tools</legend>
         <button id="show-logged-in-button">Show Logged-In State</button> |
         <button id="show-logged-out-button">Show Logged-Out State</button>
+        <button id="change-base-host">Change Base Host</button>
       </fieldset>
     </main>
     <script type="module">
@@ -63,7 +64,7 @@
 
         const topnav = document.querySelector('ia-topnav');
         Object.assign(topnav, {
-          baseHost: 'archive.org',
+          baseHost: 'https://archive.org',
           config,
           menus,
         });
@@ -83,6 +84,11 @@
       document.body.insertBefore(topnav, document.body.firstChild);
 
       updateConfig();
+
+      const changeBaseHostButton = document.querySelector('#change-base-host');
+      changeBaseHostButton.addEventListener('click', () => {
+        topnav.baseHost = 'https://foo.net';
+      })
 
       topnav.addEventListener('trackClick', ({ detail }) => {
         console.log(`Analytics click fired: ${detail.event}`);

--- a/packages/ia-topnav/src/constants.js
+++ b/packages/ia-topnav/src/constants.js
@@ -1,1 +1,1 @@
-export const prodHost = 'archive.org';
+export const prodHost = 'https://archive.org';

--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -6,11 +6,11 @@ const texts = {
   heading: 'Books',
   iconLinks: [{
     title: 'Books to Borrow',
-    icon: `https://${baseHost}/images/book-lend.png`,
+    icon: `${baseHost}/images/book-lend.png`,
     url: '/details/inlibrary',
   }, {
     title: 'Open Library',
-    icon: `https://${baseHost}/images/widgetOL.png`,
+    icon: `${baseHost}/images/widgetOL.png`,
     url: 'https://openlibrary.org/',
   }],
   featuredLinks: [{
@@ -68,11 +68,11 @@ const texts = {
 const video = {
   heading: 'Video',
   iconLinks: [{
-    icon: `https://${baseHost}/services/img/tv`,
+    icon: `${baseHost}/services/img/tv`,
     title: 'TV News',
     url: '/details/tv',
   }, {
-    icon: `https://${baseHost}/services/img/911`,
+    icon: `${baseHost}/services/img/911`,
     title: 'Understanding 9/11',
     url: '/details/911',
   }],
@@ -143,11 +143,11 @@ const video = {
 const audio = {
   heading: 'Internet Archive Audio',
   iconLinks: [{
-    icon: `https://${baseHost}/services/img/etree`,
+    icon: `${baseHost}/services/img/etree`,
     title: 'Live Music Archive',
     url: '/details/etree',
   }, {
-    icon: `https://${baseHost}/services/img/librivoxaudio`,
+    icon: `${baseHost}/services/img/librivoxaudio`,
     title: 'Librivox Free Audio',
     url: '/details/librivoxaudio',
   }],
@@ -200,11 +200,11 @@ const audio = {
 const software = {
   heading: 'Software',
   iconLinks: [{
-    icon: `https://${baseHost}/services/img/internetarcade`,
+    icon: `${baseHost}/services/img/internetarcade`,
     title: 'Internet Arcade',
     url: '/details/internetarcade',
   }, {
-    icon: `https://${baseHost}/services/img/consolelivingroom`,
+    icon: `${baseHost}/services/img/consolelivingroom`,
     title: 'Console Living Room',
     url: '/details/consolelivingroom',
   }],
@@ -278,11 +278,11 @@ const software = {
 const images = {
   heading: 'Images',
   iconLinks: [{
-    icon: `https://${baseHost}/services/img/metropolitanmuseumofart-gallery`,
+    icon: `${baseHost}/services/img/metropolitanmuseumofart-gallery`,
     title: 'Metropolitan Museum',
     url: '/details/metropolitanmuseumofart-gallery',
   }, {
-    icon: `https://${baseHost}/services/img/brooklynmuseum`,
+    icon: `${baseHost}/services/img/brooklynmuseum`,
     title: 'Brooklyn Museum',
     url: '/details/brooklynmuseum',
   }],

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -38,7 +38,7 @@ export default class IATopNav extends LitElement {
 
   constructor() {
     super();
-    this.baseHost = 'archive.org';
+    this.baseHost = 'https://archive.org';
     this.config = {};
     this.mediaSliderOpen = false;
     this.menus = {};

--- a/packages/ia-topnav/src/lib/formatUrl.js
+++ b/packages/ia-topnav/src/lib/formatUrl.js
@@ -1,3 +1,1 @@
-export default (url, baseHost) => (
-  /^https?:/.test(url) ? url : `https://${baseHost}${url}`
-);
+export default (url, baseHost) => (/^https?:/.test(url) ? url : `${baseHost}${url}`);

--- a/packages/ia-topnav/src/primary-nav.js
+++ b/packages/ia-topnav/src/primary-nav.js
@@ -82,9 +82,13 @@ class PrimaryNav extends TrackedElement {
         @click="${this.toggleUserMenu}"
         data-event-click-tracking="${this.config.eventCategory}|NavUserMenu"
       >
-      <img src="https://archive.org/services/img/user/profile?${+(new Date())}" alt="${this.config.username}" />
-      <span class="username">${this.truncatedScreenName}</span>
-    </button>`;
+        <img
+          src="${this.baseHost}/services/img/user/profile?${+new Date()}"
+          alt="${this.config.username}"
+        />
+        <span class="username">${this.truncatedScreenName}</span>
+      </button>
+    `;
   }
 
   get loginIcon() {


### PR DESCRIPTION
**Description**

> Previously, the top nav was writing out an `https://` prefix to all of the URLs so we couldn't make the links relative if we wanted to.

**Technical**

> This changes the base URL so the consumer should now pass in the protocol as well

**Testing**

> Checkout the repo, go to `packages/ia-topnav`, run `yarn install`, run `yarn start` and you should see a demo of it. You can click the "Change Base Host" button in the demo and it will change the URLs to use the new base host