### PR TITLE
Minor UI fixes

### DIFF
--- a/packages/expandable-search-bar/src/expandable-search-bar.ts
+++ b/packages/expandable-search-bar/src/expandable-search-bar.ts
@@ -285,6 +285,15 @@ export default class ExpandableSearchBar extends LitElement {
         background: none;
       }
 
+      #disclosure-button {
+        outline: none;
+        box-shadow: none;
+      }
+
+      #disclosure-button:hover {
+        cursor: pointer;
+      }
+
       #search-input {
         border-top: ${expandableSearchBarBorderCss};
         border-bottom: ${expandableSearchBarBorderCss};


### PR DESCRIPTION
**Description**

Removes focus when the disclosure button in the expandable search bar is clicked and changes cursor to pointer when the button is hovered over.





**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.




https://user-images.githubusercontent.com/53232360/111373882-746cd900-86c2-11eb-9c08-fb23fa9c02be.mp4





It would also be better for UX if the entire disclosure button is made clickable, instead of a relatively small portion inside its wrapper `div`, like it is now. Adding the click event to the wrapper `div` gets the job done, however, it fails a test. So I didn't include that change.
