### PR TITLE
Fix error in import method in scrubber-bar/stories

### DIFF
--- a/packages/scrubber-bar/stories/index.stories.js
+++ b/packages/scrubber-bar/stories/index.stories.js
@@ -7,7 +7,7 @@ import {
   withClassPropertiesKnobs,
 } from '@open-wc/demoing-storybook';
 
-import ScrubberBar from '../index';
+import { ScrubberBar } from '../index';
 
 storiesOf('scrubber-bar', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.

Closes #529 

**Technical**

> What should be noted about the implementation?

The import method used was faulty, which caused the error when demoing scrubber-bar with storybook

**Testing**

> What steps should the reviewer take to verify this PR resolves the issue?

**Evidence**

Demoing scrubber-bar with storybook does not throw up errors anymore.

![Storybook - Google Chrome 17-03-2021 20_24_21](https://user-images.githubusercontent.com/53232360/111489971-a3398c80-8760-11eb-91d8-1fcf407ba0d7.png)


> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
