### PR TITLE
[bookreader-component] getPageURI fixes

### DIFF
--- a/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
+++ b/packages/ia-components/sandbox/bookreader-component/bookreader-wrapper-main.jsx
@@ -59,7 +59,8 @@ export default class BookReaderWrapper extends Component {
        * @param {Number} rotate - degrees of rotation
        */
       getPageURI: (index, reduce = 1, rotate = 0) => {
-        const brReduce = this.bookreader.reduce || reduce;
+        // IA only supports power of 2 reduces
+        const brReduce = Math.pow(2, Math.floor(Math.log2(Math.max(1, reduce))));
         let uri = originalGetPageURI.call(this.bookreader, index, brReduce, rotate);
         uri += (uri.indexOf('?') > -1 ? '&' : '?');
         uri = `${uri}scale=${brReduce}&rotate=${rotate}`;


### PR DESCRIPTION
**Description**

- getPageURI should use argument instead of internal bookreader property
- getPageURI should only use powers of 2 for reduce

**Technical**

Blocker for https://github.com/internetarchive/bookreader/pull/646

**Testing**

Available for testing with https://github.com/internetarchive/bookreader/pull/646 at e.g. https://ia-petabox-drini.archive.org/details/lp_chant-of-the-jungle_august-colon . Things to note:

1) Zooming in loads higher res copies.
2) Urls for images only are powers of 2.
3) As you zoom in, fewer requests need to be made since using powers of 2 now.

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
