### PR TITLE
updated use of var to 'let' and 'const'

### DIFF
--- a/packages/ia-prototype-apps/lib/helpers/url.js
+++ b/packages/ia-prototype-apps/lib/helpers/url.js
@@ -1,6 +1,6 @@
 export function getUrlParameter(name) {
   name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
-  var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
-  var results = regex.exec(location.search);
+  const regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+  const results = regex.exec(location.search);
   return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
 }

--- a/packages/playback-controls/src/playback-controls.ts
+++ b/packages/playback-controls/src/playback-controls.ts
@@ -65,7 +65,7 @@ export default class PlaybackControls extends LitElement {
   }
 
   get playPauseButtonImage() {
-    var image = playImage;
+    let image = playImage;
     switch (this.playbackMode) {
       case PlaybackMode.playing:
         image = pauseImage;
@@ -78,7 +78,7 @@ export default class PlaybackControls extends LitElement {
   }
 
   get volumeButtonImage(): TemplateResult {
-    var image = volumeMediumImage;
+    let image = volumeMediumImage;
     if (this.volume === 0) {
       image = volumeMuteImage;
     }

--- a/packages/transcript-view/demo/index.html
+++ b/packages/transcript-view/demo/index.html
@@ -113,7 +113,7 @@
     }
 
     function transcriptEntrySelected(e) {
-      var newStart = e.detail.entry.start;
+      const newStart = e.detail.entry.start;
       document.querySelector('transcript-view-dev-options').currentTime = newStart;
       document.querySelector('transcript-view').currentTime = newStart;
     }

--- a/packages/transcript-view/test/transcript-view.test.js
+++ b/packages/transcript-view/test/transcript-view.test.js
@@ -28,7 +28,7 @@ describe('TranscriptView', () => {
   });
 
   it('autoscroll button enables autoscroll', async () => {
-    var scrollToClosestEntryCalled = false;
+    let scrollToClosestEntryCalled = false;
 
     const el = await fixture(html`
       <transcript-view>


### PR DESCRIPTION
**Description**

> This PR will update all the unecessary usage of the keyword "var" (used to declare and define variables) to the modern ES6 syntax - "let"  and "const" and thus it helps : 

1. Bring uniformity in the codebase
2. Comply with [Airbnb styleguide](https://github.com/airbnb/javascript) as mentioned in the [project README.md](https://github.com/internetarchive/iaux/blob/master/README.md)

**Technical**

> No such details required.

**Testing**

> Just run the code. Since all this PR does is a module update for style of writing JS, there will be no changes to the codebase  

