### PR TITLE
Bootstrap version update in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ in `v2mocks` there is code that is pulled from IA "View Source" and converted to
 `https://magic.reactjs.net/htmltojsx.htm`
 
 
-Archive.org v2 uses [Bootstrap](https://getbootstrap.com) 3.0. Docs can be found here: http://bootstrapdocs.com/v3.0.0/docs/css/#overview
+Archive.org v2 uses [Bootstrap](https://getbootstrap.com) 3.1.5. Docs can be found here: https://bootstrapdocs.com/v3.1.1/docs/css/#overview
 
 ## License
 


### PR DESCRIPTION
**Description**

> This PR resolves obsolete documentation in the project README. The Bootstrap version, as managed by lerna, seen in yarn.lock and used in project is 3.1.5 whereas the README mentions bootstrap 3.0 and even leads developers to Bootstrap 3.0 documentation instead of Bootstrap 3.1.1 documentation 

> This PR does 2 things 
1. Updates "3.0" to "3.1.5" in project README
2. Updates link to now point to documentation of Bootstrap 3.1.1 which has changes to use v3.1.5

**Technical**

> Since this is a documentation update PR, there is no technical specification point 

**Testing**

> Just read the documentation of project README and access the updated link 

