### PR TITLE
WEBDEV-4189 Removed extra URL encoding for wayback search component

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/ia-topnav/src/lib/query-handler.js
+++ b/packages/ia-topnav/src/lib/query-handler.js
@@ -2,6 +2,6 @@
 
 export default {
   performQuery(query) {
-    window.location = `https://web.archive.org/web/*/${encodeURIComponent(query)}`;
+    window.location = `https://web.archive.org/web/*/${query}`;
   }
 };


### PR DESCRIPTION
**Description**

> Top nav Wayback search form doesn't handle encoding correctly. when you enter URL https://whitehouse.gov/ in search field and hit enter, you will be landed on wayback search page but URL shows encoded resulting not result.
Refer to this JIRA: https://webarchive.jira.com/browse/WEBDEV-4189 for more information