### PR TITLE
[Transcript View] Remove leading 0 in the duration formatter

### DIFF
--- a/packages/transcript-view/demo/transcript.js
+++ b/packages/transcript-view/demo/transcript.js
@@ -678,7 +678,7 @@ export default [
   {
       "id": 100,
       "start": 440.034,
-      "end": 445.02,
       "text": "comparatively new at least in most people's most people's memory Look the reason"
+    end: 6800.02,
   }
 ]

--- a/packages/transcript-view/demo/transcript.js
+++ b/packages/transcript-view/demo/transcript.js
@@ -1,684 +1,684 @@
 export default [
   {
-      "id": 1,
-      "start": 4.058,
-      "end": 6.032,
-      "text": "Hello I'm Steve Miller U.S."
+    id: 1,
+    start: 4.058,
+    end: 6.032,
+    text: "Hello I'm Steve Miller U.S."
   },
   {
-      "id": 2,
-      "start": 6.033,
-      "end": 10.029,
-      "text": "President Donald Trump blame"
+    id: 2,
+    start: 6.033,
+    end: 10.029,
+    text: 'President Donald Trump blame'
   },
   {
-      "id": 2,
-      "start": 6.033,
-      "end": 10.029,
-      "search_match_index": 0,
-      "text": "Congress"
+    id: 2,
+    start: 6.033,
+    end: 10.029,
+    search_match_index: 0,
+    text: 'Congress'
   },
   {
-      "id": 2,
-      "start": 6.033,
-      "end": 10.029,
-      "text": "Thursday for creating new tensions with"
+    id: 2,
+    start: 6.033,
+    end: 10.029,
+    text: 'Thursday for creating new tensions with'
   },
   {
-      "id": 3,
-      "start": 10.03,
-      "end": 14.093,
-      "text": "Russia by approving sanctions against Moscow and the Kremlin agreed that penalties"
+    id: 3,
+    start: 10.03,
+    end: 14.093,
+    text: 'Russia by approving sanctions against Moscow and the Kremlin agreed that penalties'
   },
   {
-      "id": 4,
-      "start": 14.094,
-      "end": 19.098,
-      "text": "would thwart improved relations and you pal cesky has more the president said that"
+    id: 4,
+    start: 14.094,
+    end: 19.098,
+    text: 'would thwart improved relations and you pal cesky has more the president said that'
   },
   {
-      "id": 5,
-      "start": 19.099,
-      "end": 20.037,
-      "text": "the U.S."
+    id: 5,
+    start: 19.099,
+    end: 20.037,
+    text: 'the U.S.'
   },
   {
-      "id": 6,
-      "start": 20.038,
-      "end": 24.065,
-      "text": "Relationship with Russia is at an all time and very dangerous low and said quote"
+    id: 6,
+    start: 20.038,
+    end: 24.065,
+    text: 'Relationship with Russia is at an all time and very dangerous low and said quote'
   },
   {
-      "id": 7,
-      "start": 24.069,
-      "end": 29.045,
-      "text": "You can think"
+    id: 7,
+    start: 24.069,
+    end: 29.045,
+    text: 'You can think'
   },
   {
-    "id": 7,
-    "start": 24.069,
-    "end": 29.045,
-    "search_match_index": 1,
-    "text": "Congress"
+    id: 7,
+    start: 24.069,
+    end: 29.045,
+    search_match_index: 1,
+    text: 'Congress'
   },
   {
-    "id": 7,
-    "start": 24.069,
-    "end": 29.045,
-    "search_match_index": 2,
-    "text": "Congress"
+    id: 7,
+    start: 24.069,
+    end: 29.045,
+    search_match_index: 2,
+    text: 'Congress'
   },
   {
-    "id": 7,
-    "start": 24.069,
-    "end": 29.045,
-    "text": "overwhelmingly voted for the sanctions and Trump"
+    id: 7,
+    start: 24.069,
+    end: 29.045,
+    text: 'overwhelmingly voted for the sanctions and Trump'
   },
   {
-      "id": 8,
-      "start": 29.051,
-      "end": 31.045,
-      "text": "unwilling to risk having lawmakers override"
+    id: 8,
+    start: 29.051,
+    end: 31.045,
+    text: 'unwilling to risk having lawmakers override'
   },
   {
-      "id": 9,
-      "start": 31.046,
-      "end": 36.03,
-      "text": "a veto signed the legislation on Wednesday Russian Prime Minister Dmitry Medvedev"
+    id: 9,
+    start: 31.046,
+    end: 36.03,
+    text: 'a veto signed the legislation on Wednesday Russian Prime Minister Dmitry Medvedev'
   },
   {
-      "id": 10,
-      "start": 36.047,
-      "end": 40.057,
-      "text": "said Trump signing of the package of new Russia sanctions ends hopes for improving"
+    id: 10,
+    start: 36.047,
+    end: 40.057,
+    text: 'said Trump signing of the package of new Russia sanctions ends hopes for improving'
   },
   {
-      "id": 11,
-      "start": 40.058,
-      "end": 43.051,
-      "text": "our relations and repel cesky V.O.A."
+    id: 11,
+    start: 40.058,
+    end: 43.051,
+    text: 'our relations and repel cesky V.O.A.'
   },
   {
-      "id": 12,
-      "start": 43.052,
-      "end": 48.052,
-      "text": "News Venezuela's president has denied allegations that official turnout figures for"
+    id: 12,
+    start: 43.052,
+    end: 48.052,
+    text: "News Venezuela's president has denied allegations that official turnout figures for"
   },
   {
-      "id": 13,
-      "start": 48.053,
-      "end": 53.072,
-      "text": "the election of an all powerful constituent assembly were manipulated to peel away"
+    id: 13,
+    start: 48.053,
+    end: 53.072,
+    text: 'the election of an all powerful constituent assembly were manipulated to peel away'
   },
   {
-      "id": 14,
-      "start": 53.077,
-      "end": 58.074,
-      "text": "",
-      "is_music": true
+    id: 14,
+    start: 53.077,
+    end: 58.074,
+    text: '',
+    is_music: true
   },
   {
-      "id": 15,
-      "start": 58.075,
-      "end": 61.085,
-      "text": "software firm behind the claim of bowing to U.S."
+    id: 15,
+    start: 58.075,
+    end: 61.085,
+    text: 'software firm behind the claim of bowing to U.S.'
   },
   {
-      "id": 16,
-      "start": 61.086,
-      "end": 66.016,
-      "text": "Pressure but there are not only stood by the official count of eight million plus"
+    id: 16,
+    start: 61.086,
+    end: 66.016,
+    text: 'Pressure but there are not only stood by the official count of eight million plus'
   },
   {
-      "id": 17,
-      "start": 66.017,
-      "end": 70.063,
-      "text": "votes cast in Sunday's divisive election but proclaimed that and then additional"
+    id: 17,
+    start: 66.017,
+    end: 70.063,
+    text: "votes cast in Sunday's divisive election but proclaimed that and then additional"
   },
   {
-      "id": 18,
-      "start": 70.064,
-      "end": 74.049,
-      "text": "two million people would have voted if they hadn't been blocked by anti-government"
+    id: 18,
+    start: 70.064,
+    end: 74.049,
+    text: "two million people would have voted if they hadn't been blocked by anti-government"
   },
   {
-      "id": 19,
-      "start": 74.05,
-      "end": 81.04,
-      "text": "protesters. A South African man held by al-Qaeda in Mali since two thousand and"
+    id: 19,
+    start: 74.05,
+    end: 81.04,
+    text: 'protesters. A South African man held by al-Qaeda in Mali since two thousand and'
   },
   {
-      "id": 20,
-      "start": 81.041,
-      "end": 87.04,
-      "text": "eleven has been freed the South African government said on Thursday Stephen McGowan"
+    id: 20,
+    start: 81.041,
+    end: 87.04,
+    text: 'eleven has been freed the South African government said on Thursday Stephen McGowan'
   },
   {
-      "id": 21,
-      "start": 87.068,
-      "end": 92.049,
-      "text": "was the last of three foreign nationals abducted in Timbuktu in November twenty"
+    id: 21,
+    start: 87.068,
+    end: 92.049,
+    text: 'was the last of three foreign nationals abducted in Timbuktu in November twenty'
   },
   {
-      "id": 22,
-      "start": 92.068,
-      "end": 97.022,
-      "text": "seventh to be freed the governments of Mali and South Africa worked together along"
+    id: 22,
+    start: 92.068,
+    end: 97.022,
+    text: 'seventh to be freed the governments of Mali and South Africa worked together along'
   },
   {
-      "id": 23,
-      "start": 97.023,
-      "end": 101.098,
-      "text": "with the N.G.O.s gift of the givers to negotiate his release however the South"
+    id: 23,
+    start: 97.023,
+    end: 101.098,
+    text: 'with the N.G.O.s gift of the givers to negotiate his release however the South'
   },
   {
-      "id": 24,
-      "start": 101.099,
-      "end": 107.047,
-      "text": "African international relations minister said no ransom was paid for additional"
+    id: 24,
+    start: 101.099,
+    end: 107.047,
+    text: 'African international relations minister said no ransom was paid for additional'
   },
   {
-      "id": 25,
-      "start": 107.048,
-      "end": 111.07,
-      "text": "updates follow V.O.A. On social media platforms this is V.O.A."
+    id: 25,
+    start: 107.048,
+    end: 111.07,
+    text: 'updates follow V.O.A. On social media platforms this is V.O.A.'
   },
   {
-      "id": 26,
-      "start": 111.071,
-      "end": 117.055,
-      "text": "News. Australian Prime Minister Malcolm Turnbull said the country's intelligence"
+    id: 26,
+    start: 111.071,
+    end: 117.055,
+    text: "News. Australian Prime Minister Malcolm Turnbull said the country's intelligence"
   },
   {
-      "id": 27,
-      "start": 117.059,
-      "end": 122.072,
-      "text": "agency has downgraded the threat level to aviation after an alleged Islamic"
+    id: 27,
+    start: 117.059,
+    end: 122.072,
+    text: 'agency has downgraded the threat level to aviation after an alleged Islamic'
   },
   {
-      "id": 28,
-      "start": 122.073,
-      "end": 124.043,
-      "text": "inspired plot to bring down"
+    id: 28,
+    start: 122.073,
+    end: 124.043,
+    text: 'inspired plot to bring down'
   },
   {
-      "id": 29,
-      "start": 124.047,
-      "end": 129.017,
-      "text": "a plane was uncovered commission of the federal place Commissioner Andrew Collins"
+    id: 29,
+    start: 124.047,
+    end: 129.017,
+    text: 'a plane was uncovered commission of the federal place Commissioner Andrew Collins'
   },
   {
-      "id": 30,
-      "start": 129.018,
-      "end": 132.047,
-      "text": "advised me that the investigation efforts are going"
+    id: 30,
+    start: 129.018,
+    end: 132.047,
+    text: 'advised me that the investigation efforts are going'
   },
   {
-      "id": 31,
-      "start": 132.089,
-      "end": 138.01,
-      "text": "a proceeding very successfully in terms of the gathering of evidence and that I"
+    id: 31,
+    start: 132.089,
+    end: 138.01,
+    text: 'a proceeding very successfully in terms of the gathering of evidence and that I'
   },
   {
-      "id": 32,
-      "start": 138.011,
-      "end": 142.079,
-      "text": "should expect to strive and should expect charges to be light in due course but"
+    id: 32,
+    start: 138.011,
+    end: 142.079,
+    text: 'should expect to strive and should expect charges to be light in due course but'
   },
   {
-      "id": 33,
-      "start": 142.08,
-      "end": 143.063,
-      "text": "that is of course"
+    id: 33,
+    start: 142.08,
+    end: 143.063,
+    text: 'that is of course'
   },
   {
-      "id": 34,
-      "start": 144,
-      "end": 148.076,
-      "text": "a matter for the place four men were arrested in raids in several suburbs of Sydney"
+    id: 34,
+    start: 144,
+    end: 148.076,
+    text: 'a matter for the place four men were arrested in raids in several suburbs of Sydney'
   },
   {
-      "id": 35,
-      "start": 148.077,
-      "end": 153.073,
-      "text": "Australia is largest city at the weekend and held without charge under special"
+    id: 35,
+    start: 148.077,
+    end: 153.073,
+    text: 'Australia is largest city at the weekend and held without charge under special'
   },
   {
-      "id": 36,
-      "start": 153.074,
-      "end": 157.033,
-      "text": "terror related powers one man has since been released"
+    id: 36,
+    start: 153.074,
+    end: 157.033,
+    text: 'terror related powers one man has since been released'
   },
   {
-      "id": 37,
-      "start": 157.058,
-      "end": 162,
-      "text": "a US official familiar with the arrest told Reuters News Agency that the target"
+    id: 37,
+    start: 157.058,
+    end: 162,
+    text: 'a US official familiar with the arrest told Reuters News Agency that the target'
   },
   {
-      "id": 38,
-      "start": 162.001,
-      "end": 163.02,
-      "text": "appeared to have been"
+    id: 38,
+    start: 162.001,
+    end: 163.02,
+    text: 'appeared to have been'
   },
   {
-      "id": 39,
-      "start": 163.021,
-      "end": 168.06,
-      "text": "a commercial flight from Sydney to the Persian Gulf Pakistan's military chief there"
+    id: 39,
+    start: 163.021,
+    end: 168.06,
+    text: "a commercial flight from Sydney to the Persian Gulf Pakistan's military chief there"
   },
   {
-      "id": 40,
-      "start": 168.061,
-      "end": 170.049,
-      "text": "is a condemned as terrorism"
+    id: 40,
+    start: 168.061,
+    end: 170.049,
+    text: 'is a condemned as terrorism'
   },
   {
-      "id": 41,
-      "start": 170.05,
-      "end": 175.004,
-      "text": "a Taliban attack in neighboring Afghanistan in which two U.S."
+    id: 41,
+    start: 170.05,
+    end: 175.004,
+    text: 'a Taliban attack in neighboring Afghanistan in which two U.S.'
   },
   {
-      "id": 42,
-      "start": 175.005,
-      "end": 180.031,
-      "text": "Troops were killed and four others wounded via ways Robert riffle the remarks came"
+    id: 42,
+    start: 175.005,
+    end: 180.031,
+    text: 'Troops were killed and four others wounded via ways Robert riffle the remarks came'
   },
   {
-      "id": 43,
-      "start": 180.032,
-      "end": 181.037,
-      "text": "on a day when the U.S."
+    id: 43,
+    start: 180.032,
+    end: 181.037,
+    text: 'on a day when the U.S.'
   },
   {
-      "id": 44,
-      "start": 181.038,
-      "end": 184.041,
-      "text": "Special envoy for the region Alice Wells began"
+    id: 44,
+    start: 181.038,
+    end: 184.041,
+    text: 'Special envoy for the region Alice Wells began'
   },
   {
-      "id": 45,
-      "start": 184.042,
-      "end": 189.001,
-      "text": "a two day official visit to Islamabad to discuss ways to end the armed Afghan"
+    id: 45,
+    start: 184.042,
+    end: 189.001,
+    text: 'a two day official visit to Islamabad to discuss ways to end the armed Afghan'
   },
   {
-      "id": 46,
-      "start": 189.002,
-      "end": 194.011,
-      "text": "conflict and other issues the Taliban swiftly took credit for Wednesday's attack in"
+    id: 46,
+    start: 189.002,
+    end: 194.011,
+    text: "conflict and other issues the Taliban swiftly took credit for Wednesday's attack in"
   },
   {
-      "id": 47,
-      "start": 194.012,
-      "end": 198.054,
-      "text": "the southern Afghan city of Kandahar saying one of its suicide bombers drove its"
+    id: 47,
+    start: 194.012,
+    end: 198.054,
+    text: 'the southern Afghan city of Kandahar saying one of its suicide bombers drove its'
   },
   {
-      "id": 48,
-      "start": 198.055,
-      "end": 200.096,
-      "text": "explosives packed car into the convoy"
+    id: 48,
+    start: 198.055,
+    end: 200.096,
+    text: 'explosives packed car into the convoy'
   },
   {
-      "id": 49,
-      "start": 201.027,
-      "end": 206.017,
-      "text": "a Taliban spokesman says fifteen soldiers belonging to quote foreign occupation"
+    id: 49,
+    start: 201.027,
+    end: 206.017,
+    text: 'a Taliban spokesman says fifteen soldiers belonging to quote foreign occupation'
   },
   {
-      "id": 50,
-      "start": 206.018,
-      "end": 210.066,
-      "text": "forces including two high ranking officers were killed however the Taliban"
+    id: 50,
+    start: 206.018,
+    end: 210.066,
+    text: 'forces including two high ranking officers were killed however the Taliban'
   },
   {
-      "id": 51,
-      "start": 210.067,
-      "end": 216.064,
-      "text": "routinely exaggerates casualty figures when making such claims firefighters battled"
+    id: 51,
+    start: 210.067,
+    end: 216.064,
+    text: 'routinely exaggerates casualty figures when making such claims firefighters battled'
   },
   {
-      "id": 52,
-      "start": 216.065,
-      "end": 220.018,
-      "text": "a blaze in Tokyo's soup Keiji market it's"
+    id: 52,
+    start: 216.065,
+    end: 220.018,
+    text: "a blaze in Tokyo's soup Keiji market it's"
   },
   {
-      "id": 53,
-      "start": 220.019,
-      "end": 224.054,
-      "text": "a fish market as large and one of the most popular attractions in the city the fire"
+    id: 53,
+    start: 220.019,
+    end: 224.054,
+    text: 'a fish market as large and one of the most popular attractions in the city the fire'
   },
   {
-      "id": 54,
-      "start": 224.055,
-      "end": 231.004,
-      "text": "broke out just after five pm local time Thursday Yoshi to Matsushita works at"
+    id: 54,
+    start: 224.055,
+    end: 231.004,
+    text: 'broke out just after five pm local time Thursday Yoshi to Matsushita works at'
   },
   {
-      "id": 55,
-      "start": 231.008,
-      "end": 236.07,
-      "text": "a restaurant inside the market filling us. Locals it's tricky to fish market work"
+    id: 55,
+    start: 231.008,
+    end: 236.07,
+    text: "a restaurant inside the market filling us. Locals it's tricky to fish market work"
   },
   {
-      "id": 56,
-      "start": 236.071,
-      "end": 241.008,
-      "text": "really hard for their living we all know they attracted many customers and tourists"
+    id: 56,
+    start: 236.071,
+    end: 241.008,
+    text: 'really hard for their living we all know they attracted many customers and tourists'
   },
   {
-      "id": 57,
-      "start": 241.053,
-      "end": 245.04,
-      "text": "I'm worried about how they'll cope with this incident it must be hard for them with"
+    id: 57,
+    start: 241.053,
+    end: 245.04,
+    text: "I'm worried about how they'll cope with this incident it must be hard for them with"
   },
   {
-      "id": 58,
-      "start": 245.041,
-      "end": 251.045,
-      "text": "such severe damage. When the local the fire affected the so-called outer market"
+    id: 58,
+    start: 245.041,
+    end: 251.045,
+    text: 'such severe damage. When the local the fire affected the so-called outer market'
   },
   {
-      "id": 59,
-      "start": 251.046,
-      "end": 256.084,
-      "text": "where restaurants are located the inner market was not affected. And Israeli police"
+    id: 59,
+    start: 251.046,
+    end: 256.084,
+    text: 'where restaurants are located the inner market was not affected. And Israeli police'
   },
   {
-      "id": 60,
-      "start": 256.085,
-      "end": 260.09,
-      "text": "document says Prime Minister Benjamin Netanyahu is suspected of crimes involving"
+    id: 60,
+    start: 256.085,
+    end: 260.09,
+    text: 'document says Prime Minister Benjamin Netanyahu is suspected of crimes involving'
   },
   {
-      "id": 61,
-      "start": 260.091,
-      "end": 265.013,
-      "text": "breach of trust and bribes into corruption cases the document released to media"
+    id: 61,
+    start: 260.091,
+    end: 265.013,
+    text: 'breach of trust and bribes into corruption cases the document released to media'
   },
   {
-      "id": 62,
-      "start": 265.014,
-      "end": 270.007,
-      "text": "outlets says the cases involving Netanyahu deal with suspicion of bribes and breach"
+    id: 62,
+    start: 265.014,
+    end: 270.007,
+    text: 'outlets says the cases involving Netanyahu deal with suspicion of bribes and breach'
   },
   {
-      "id": 63,
-      "start": 270.008,
-      "end": 272.006,
-      "text": "of trust police have put"
+    id: 63,
+    start: 270.008,
+    end: 272.006,
+    text: 'of trust police have put'
   },
   {
-      "id": 64,
-      "start": 272.007,
-      "end": 276.078,
-      "text": "a gag order on reporting any additional details Netanyahu denies wrong during"
+    id: 64,
+    start: 272.007,
+    end: 276.078,
+    text: 'a gag order on reporting any additional details Netanyahu denies wrong during'
   },
   {
-      "id": 65,
-      "start": 277.019,
-      "end": 278.063,
-      "text": "portraying the accusation as"
+    id: 65,
+    start: 277.019,
+    end: 278.063,
+    text: 'portraying the accusation as'
   },
   {
-      "id": 66,
-      "start": 278.064,
-      "end": 282.096,
-      "text": "a witch hunt against him and his family by hostile media opposed to his political"
+    id: 66,
+    start: 278.064,
+    end: 282.096,
+    text: 'a witch hunt against him and his family by hostile media opposed to his political'
   },
   {
-      "id": 67,
-      "start": 282.097,
-      "end": 289.057,
-      "text": "views I'm Steve Miller in Washington. That's the latest world news from B"
+    id: 67,
+    start: 282.097,
+    end: 289.057,
+    text: "views I'm Steve Miller in Washington. That's the latest world news from B"
   },
   {
-      "id": 68,
-      "start": 289.062,
-      "end": 290.048,
-      "text": "O A."
+    id: 68,
+    start: 289.062,
+    end: 290.048,
+    text: 'O A.'
   },
   {
-      "id": 69,
-      "start": 300.052,
-      "end": 306.012,
-      "text": "It is Thursday August third and this is the OAS international edition I'm Sara"
+    id: 69,
+    start: 300.052,
+    end: 306.012,
+    text: "It is Thursday August third and this is the OAS international edition I'm Sara"
   },
   {
-      "id": 70,
-      "start": 306.013,
-      "end": 310.07,
-      "text": "Williams in Washington coming up President Donald Trump and Moscow agree that"
+    id: 70,
+    start: 306.013,
+    end: 310.07,
+    text: 'Williams in Washington coming up President Donald Trump and Moscow agree that'
   },
   {
-      "id": 71,
-      "start": 310.071,
-      "end": 313.067,
-      "text": "relations between the United States and Russia are at"
+    id: 71,
+    start: 310.071,
+    end: 313.067,
+    text: 'relations between the United States and Russia are at'
   },
   {
-      "id": 72,
-      "start": 313.068,
-      "end": 319.025,
-      "text": "a low point following Washington's imposition of new sanctions from the reader and"
+    id: 72,
+    start: 313.068,
+    end: 319.025,
+    text: "a low point following Washington's imposition of new sanctions from the reader and"
   },
   {
-      "id": 73,
-      "start": 319.026,
-      "end": 324.037,
-      "text": "the"
+    id: 73,
+    start: 319.026,
+    end: 324.037,
+    text: 'the'
   },
   {
-    "id": 73,
-    "start": 319.026,
-    "end": 324.037,
-    "search_match_index": 3,
-    "text": "Congress"
+    id: 73,
+    start: 319.026,
+    end: 324.037,
+    search_match_index: 3,
+    text: 'Congress'
   },
   {
-    "id": 73,
-    "start": 319.026,
-    "end": 324.037,
-    "text": "bill which is now law it because they don't track on"
+    id: 73,
+    start: 319.026,
+    end: 324.037,
+    text: "bill which is now law it because they don't track on"
   },
   {
-      "id": 74,
-      "start": 324.038,
-      "end": 329.083,
-      "text": "a Trump on Russia President Trump wants to change legal immigration to the U.S."
+    id: 74,
+    start: 324.038,
+    end: 329.083,
+    text: 'a Trump on Russia President Trump wants to change legal immigration to the U.S.'
   },
   {
-      "id": 75,
-      "start": 330.01,
-      "end": 332.037,
-      "text": "And we hear why a classic story about"
+    id: 75,
+    start: 330.01,
+    end: 332.037,
+    text: 'And we hear why a classic story about'
   },
   {
-      "id": 76,
-      "start": 332.038,
-      "end": 337.05,
-      "text": "a little girl who lives in New York's Plaza Hotel continues to delight fans it's"
+    id: 76,
+    start: 332.038,
+    end: 337.05,
+    text: "a little girl who lives in New York's Plaza Hotel continues to delight fans it's"
   },
   {
-      "id": 77,
-      "start": 337.051,
-      "end": 342.026,
-      "text": "all ahead. Of U.S."
+    id: 77,
+    start: 337.051,
+    end: 342.026,
+    text: 'all ahead. Of U.S.'
   },
   {
-      "id": 78,
-      "start": 342.027,
-      "end": 346.052,
-      "text": "President Donald Trump blame"
+    id: 78,
+    start: 342.027,
+    end: 346.052,
+    text: 'President Donald Trump blame'
   },
   {
-    "id": 78,
-    "start": 342.027,
-    "end": 346.052,
-    "search_match_index": 4,
-    "text": "Congress"
-},
-{
-  "id": 78,
-  "start": 342.027,
-  "end": 346.052,
-  "text": "Thursday for creating new tensions with"
-},
+    id: 78,
+    start: 342.027,
+    end: 346.052,
+    search_match_index: 4,
+    text: 'Congress'
+  },
+  {
+    id: 78,
+    start: 342.027,
+    end: 346.052,
+    text: 'Thursday for creating new tensions with'
+  },
 
   {
-      "id": 79,
-      "start": 346.053,
-      "end": 351.082,
-      "text": "Russia by approving sanctions against Moscow Tronto to Twitter to say our"
+    id: 79,
+    start: 346.053,
+    end: 351.082,
+    text: 'Russia by approving sanctions against Moscow Tronto to Twitter to say our'
   },
   {
-      "id": 80,
-      "start": 351.083,
-      "end": 357.041,
-      "text": "relationship with Russia is at an. All time and very dangerous low he said"
+    id: 80,
+    start: 351.083,
+    end: 357.041,
+    text: 'relationship with Russia is at an. All time and very dangerous low he said'
   },
   {
-    "id": 80,
-    "start": 351.083,
-    "end": 357.041,
-    "search_match_index": 5,
-    "text": "Congress"
-},
-{
-      "id": 81,
-      "start": 357.042,
-      "end": 362.04,
-      "text": "was to blame and chastise members for failing to support his effort to dismantle"
+    id: 80,
+    start: 351.083,
+    end: 357.041,
+    search_match_index: 5,
+    text: 'Congress'
   },
   {
-      "id": 82,
-      "start": 362.041,
-      "end": 367.032,
-      "text": "the country's health care law championed by his predecessor former President Barack"
+    id: 81,
+    start: 357.042,
+    end: 362.04,
+    text: 'was to blame and chastise members for failing to support his effort to dismantle'
   },
   {
-      "id": 83,
-      "start": 367.033,
-      "end": 368.074,
-      "text": "Obama although"
+    id: 82,
+    start: 362.041,
+    end: 367.032,
+    text: "the country's health care law championed by his predecessor former President Barack"
   },
   {
-      "id": 84,
-      "start": 368.078,
-      "end": 372.093,
-      "text": "a looker is the director of the Russia and Eurasia program at the Center for"
+    id: 83,
+    start: 367.033,
+    end: 368.074,
+    text: 'Obama although'
   },
   {
-      "id": 85,
-      "start": 372.094,
-      "end": 377.07,
-      "text": "Strategic and International Studies I asked her for her opinion on the current"
+    id: 84,
+    start: 368.078,
+    end: 372.093,
+    text: 'a looker is the director of the Russia and Eurasia program at the Center for'
   },
   {
-      "id": 86,
-      "start": 377.071,
-      "end": 383.038,
-      "text": "relationship between Washington and Moscow but relationship is definitely at"
+    id: 85,
+    start: 372.094,
+    end: 377.07,
+    text: 'Strategic and International Studies I asked her for her opinion on the current'
   },
   {
-      "id": 87,
-      "start": 383.043,
-      "end": 389.063,
-      "text": "a low point I still think the Cuban Missile Crisis was worse. Though I suppose one"
+    id: 86,
+    start: 377.071,
+    end: 383.038,
+    text: 'relationship between Washington and Moscow but relationship is definitely at'
   },
   {
-      "id": 88,
-      "start": 389.064,
-      "end": 393.022,
-      "text": "could argue that with the Soviet Union that the post of the Russian Federation but"
+    id: 87,
+    start: 383.043,
+    end: 389.063,
+    text: 'a low point I still think the Cuban Missile Crisis was worse. Though I suppose one'
   },
   {
-      "id": 89,
-      "start": 393.056,
-      "end": 395.018,
-      "text": "now this is definitely"
+    id: 88,
+    start: 389.064,
+    end: 393.022,
+    text: 'could argue that with the Soviet Union that the post of the Russian Federation but'
   },
   {
-      "id": 90,
-      "start": 395.026,
-      "end": 400.059,
-      "text": "a very very challenging point in the relationship between the two countries well in"
+    id: 89,
+    start: 393.056,
+    end: 395.018,
+    text: 'now this is definitely'
   },
   {
-      "id": 91,
-      "start": 400.06,
-      "end": 405.021,
-      "text": "this situation you know"
+    id: 90,
+    start: 395.026,
+    end: 400.059,
+    text: 'a very very challenging point in the relationship between the two countries well in'
   },
   {
-    "id": 91,
-    "start": 400.06,
-    "end": 405.021,
-    "search_match_index": 6,
-    "text": "Congress"
-},
-{
-  "id": 91,
-  "start": 400.06,
-  "end": 405.021,
-  "text": "overwhelmingly voted for the sanctions and Trump"
-},
+    id: 91,
+    start: 400.06,
+    end: 405.021,
+    text: 'this situation you know'
+  },
+  {
+    id: 91,
+    start: 400.06,
+    end: 405.021,
+    search_match_index: 6,
+    text: 'Congress'
+  },
+  {
+    id: 91,
+    start: 400.06,
+    end: 405.021,
+    text: 'overwhelmingly voted for the sanctions and Trump'
+  },
 
   {
-      "id": 92,
-      "start": 405.043,
-      "end": 408.091,
-      "text": "he did not want to risk having lawmakers override"
+    id: 92,
+    start: 405.043,
+    end: 408.091,
+    text: 'he did not want to risk having lawmakers override'
   },
   {
-      "id": 93,
-      "start": 408.092,
-      "end": 414.003,
-      "text": "a veto he went ahead and signed at but he certainly made his his displeasure with"
+    id: 93,
+    start: 408.092,
+    end: 414.003,
+    text: 'a veto he went ahead and signed at but he certainly made his his displeasure with'
   },
   {
-      "id": 94,
-      "start": 414.004,
-      "end": 420.065,
-      "text": "that very evident this comes as admitted his administration is being investigated"
+    id: 94,
+    start: 414.004,
+    end: 420.065,
+    text: 'that very evident this comes as admitted his administration is being investigated'
   },
   {
-      "id": 95,
-      "start": 420.066,
-      "end": 425.019,
-      "text": "for ties during his presidential campaign the Trump presidential campaign and two"
+    id: 95,
+    start: 420.066,
+    end: 425.019,
+    text: 'for ties during his presidential campaign the Trump presidential campaign and two'
   },
   {
-      "id": 96,
-      "start": 425.02,
-      "end": 428.099,
-      "text": "thousand and sixteen for ties to the Russians and then you know this also seems to"
+    id: 96,
+    start: 425.02,
+    end: 428.099,
+    text: 'thousand and sixteen for ties to the Russians and then you know this also seems to'
   },
   {
-      "id": 97,
-      "start": 429,
-      "end": 429.039,
-      "text": "add"
+    id: 97,
+    start: 429,
+    end: 429.039,
+    text: 'add'
   },
   {
-      "id": 98,
-      "start": 429.04,
-      "end": 435.045,
-      "text": "a sort of another dimension that I don't know that we've quite seen in previous White"
+    id: 98,
+    start: 429.04,
+    end: 435.045,
+    text: "a sort of another dimension that I don't know that we've quite seen in previous White"
   },
   {
-      "id": 99,
-      "start": 435.046,
-      "end": 440.011,
-      "text": "Houses Yeah I think the allegations of collusion with the foreign governments are"
+    id: 99,
+    start: 435.046,
+    end: 440.011,
+    text: 'Houses Yeah I think the allegations of collusion with the foreign governments are'
   },
   {
-      "id": 100,
-      "start": 440.034,
-      "text": "comparatively new at least in most people's most people's memory Look the reason"
+    id: 100,
+    start: 440.034,
     end: 6800.02,
+    text: "comparatively new at least in most people's most people's memory Look the reason"
   }
-]
+];

--- a/packages/transcript-view/src/duration-formatter.ts
+++ b/packages/transcript-view/src/duration-formatter.ts
@@ -22,7 +22,7 @@ export default class DurationFormatter extends LitElement {
     const seconds = Math.floor(this.seconds % 60);
 
     const hoursString = hours > 0 ? `${hours}` : undefined;
-    const minutesString = hours > 0 && minutes < 10 && minutes > 0 ? `0${minutes}` : `${minutes}`;
+    const minutesString = hours > 0 && minutes < 10 ? `0${minutes}` : `${minutes}`;
     const secondsString = seconds < 10 ? `0${seconds}` : `${seconds}`;
 
     let durationString = `${minutesString}:${secondsString}`;

--- a/packages/transcript-view/src/duration-formatter.ts
+++ b/packages/transcript-view/src/duration-formatter.ts
@@ -21,9 +21,13 @@ export default class DurationFormatter extends LitElement {
     const minutes = Math.floor(this.seconds / 60) % 60;
     const seconds = Math.floor(this.seconds % 60);
 
-    return [hours, minutes, seconds]
-      .map(v => (v < 10 ? `0${v}` : v))
-      .filter((v, i) => v !== '00' || i > 0)
-      .join(':');
+    const hoursString = hours > 0 ? `${hours}` : undefined;
+    const minutesString = hours > 0 && minutes < 10 && minutes > 0 ? `0${minutes}` : `${minutes}`;
+    const secondsString = seconds < 10 ? `0${seconds}` : `${seconds}`;
+
+    let durationString = `${minutesString}:${secondsString}`;
+    durationString = hoursString ? `${hoursString}:${durationString}` : durationString;
+
+    return durationString;
   }
 }

--- a/packages/transcript-view/test/duration-formatter.test.js
+++ b/packages/transcript-view/test/duration-formatter.test.js
@@ -30,7 +30,7 @@ describe('DurationFormatter', () => {
 
     el.seconds = 35;
 
-    expect(el.durationString).to.equal('00:35');
+    expect(el.durationString).to.equal('0:35');
   });
 
   it('returns a properly formatted duration string if seconds less than 10', async () => {
@@ -40,7 +40,7 @@ describe('DurationFormatter', () => {
 
     el.seconds = 7;
 
-    expect(el.durationString).to.equal('00:07');
+    expect(el.durationString).to.equal('0:07');
   });
 
   it('returns a properly formatted duration string if minutes and seconds', async () => {
@@ -50,7 +50,7 @@ describe('DurationFormatter', () => {
 
     el.seconds = 63;
 
-    expect(el.durationString).to.equal('01:03');
+    expect(el.durationString).to.equal('1:03');
   });
 
   it('returns a properly formatted duration string if hours, minutes, and seconds', async () => {
@@ -60,7 +60,6 @@ describe('DurationFormatter', () => {
 
     el.seconds = 3663;
 
-    expect(el.durationString).to.equal('01:01:03');
+    expect(el.durationString).to.equal('1:01:03');
   });
-
 });

--- a/packages/transcript-view/test/duration-formatter.test.js
+++ b/packages/transcript-view/test/duration-formatter.test.js
@@ -59,7 +59,9 @@ describe('DurationFormatter', () => {
     `);
 
     el.seconds = 3663;
-
     expect(el.durationString).to.equal('1:01:03');
+
+    el.seconds = 3601;
+    expect(el.durationString).to.equal('1:00:01');
   });
 });

--- a/packages/transcript-view/test/transcript-view.test.js
+++ b/packages/transcript-view/test/transcript-view.test.js
@@ -67,7 +67,7 @@ describe('TranscriptView', () => {
 
     const durationFormatter = el.shadowRoot.querySelector('duration-formatter');
 
-    expect(durationFormatter.shadowRoot.innerHTML).to.have.string('01:09');
+    expect(durationFormatter.shadowRoot.innerHTML).to.have.string('1:09');
   });
 
   it('emits a `transcriptEntrySelected` event when the user clicks on a transcript entry', async () => {


### PR DESCRIPTION
**Description**

> Removes the leading 0 in the duration formatter. ie: 02:13:43 will now be 2:13:43 and 02:43 will be 2:43

**Testing**

> The unit tests cover the new formats

**Evidence**

> 
<img width="130" alt="Screen Shot 2021-04-15 at 4 01 41 PM" src="https://user-images.githubusercontent.com/51138/114948460-e6d8f200-9e03-11eb-9542-8088df16c3c3.png">

<img width="109" alt="Screen Shot 2021-04-15 at 4 01 46 PM" src="https://user-images.githubusercontent.com/51138/114948466-e9d3e280-9e03-11eb-8006-1b940b8d7f29.png">


