### PR TITLE
fix expandable search bar issue w/ the dropdown options (quick search)

### DIFF
--- a/packages/expandable-search-bar/demo/index.html
+++ b/packages/expandable-search-bar/demo/index.html
@@ -132,7 +132,6 @@
 
     function quickSearchSelected(e) {
       console.log('quickSearchSelected', e.detail.quickSearchEntry);
-      document.getElementById('expanding-search-bar').searchTerm = e.detail.quickSearchEntry.displayText;
     }
   </script>
 </body>

--- a/packages/expandable-search-bar/src/expandable-search-bar.ts
+++ b/packages/expandable-search-bar/src/expandable-search-bar.ts
@@ -29,6 +29,8 @@ export default class ExpandableSearchBar extends LitElement {
 
   @property({ type: Boolean }) showsDisclosure = false;
 
+  // TODO: searchTerm should be single source of state;
+  //       searchInput.value should not also affect state
   @property({ type: String }) searchTerm = '';
 
   @property({ type: Array }) quickSearches: QuickSearchEntry[] = [];
@@ -165,6 +167,11 @@ export default class ExpandableSearchBar extends LitElement {
    * @memberof ExpandableSearchBar
    */
   private quickSearchSelected(e: CustomEvent): void {
+    this.searchTerm = e.detail.searchEntry.displayText;
+    /* istanbul ignore else */
+    if (this.searchInput) {
+      this.searchInput.value = e.detail.searchEntry.displayText;
+    }
     const event = new CustomEvent('quickSearchSelected', {
       detail: { quickSearchEntry: e.detail.searchEntry },
     });

--- a/packages/expandable-search-bar/src/expandable-search-bar.ts
+++ b/packages/expandable-search-bar/src/expandable-search-bar.ts
@@ -86,7 +86,7 @@ export default class ExpandableSearchBar extends LitElement {
    *
    * @memberof ExpandableSearchBar
    */
-  updated(props: PropertyValues) {
+  updated(props: PropertyValues): void {
     if (props.has('searchTerm') && this.searchInput) {
       this.searchInput.value = this.searchTerm;
     }
@@ -100,6 +100,10 @@ export default class ExpandableSearchBar extends LitElement {
    */
   private clearSearch(): void {
     this.searchTerm = '';
+    /* istanbul ignore else */
+    if (this.searchInput) {
+      this.searchInput.focus();
+    }
     this.emitSearchClearedEvent();
   }
 

--- a/packages/expandable-search-bar/src/expandable-search-bar.ts
+++ b/packages/expandable-search-bar/src/expandable-search-bar.ts
@@ -6,6 +6,7 @@ import {
   property,
   CSSResult,
   TemplateResult,
+  PropertyValues,
 } from 'lit-element';
 
 import magnifyingGlassIcon from './assets/img/magnifying-glass';
@@ -81,16 +82,14 @@ export default class ExpandableSearchBar extends LitElement {
   }
 
   /**
-   * Workaround for lit-element 2.2.1 not reflecting this.searchTerm 
-   * in the HTML element. updated is called when this.searchTerm's value
-   * is changed.
+   * Update the DOM element after the value of `this.searchTerm` changes
    *
    * @memberof ExpandableSearchBar
    */
-  updated() {
-      if (this.searchInput) {
-        this.searchInput.value = this.searchTerm;
-      }
+  updated(props: PropertyValues) {
+    if (props.has('searchTerm') && this.searchInput) {
+      this.searchInput.value = this.searchTerm;
+    }
   }
 
   /**

--- a/packages/expandable-search-bar/src/expandable-search-bar.ts
+++ b/packages/expandable-search-bar/src/expandable-search-bar.ts
@@ -29,8 +29,6 @@ export default class ExpandableSearchBar extends LitElement {
 
   @property({ type: Boolean }) showsDisclosure = false;
 
-  // TODO: searchTerm should be single source of state;
-  //       searchInput.value should not also affect state
   @property({ type: String }) searchTerm = '';
 
   @property({ type: Array }) quickSearches: QuickSearchEntry[] = [];
@@ -83,6 +81,19 @@ export default class ExpandableSearchBar extends LitElement {
   }
 
   /**
+   * Workaround for lit-element 2.2.1 not reflecting this.searchTerm 
+   * in the HTML element. updated is called when this.searchTerm's value
+   * is changed.
+   *
+   * @memberof ExpandableSearchBar
+   */
+  updated() {
+      if (this.searchInput) {
+        this.searchInput.value = this.searchTerm;
+      }
+  }
+
+  /**
    * Called when then user clicks the X button to clear the search
    *
    * @private
@@ -90,11 +101,6 @@ export default class ExpandableSearchBar extends LitElement {
    */
   private clearSearch(): void {
     this.searchTerm = '';
-    /* istanbul ignore else */
-    if (this.searchInput) {
-      this.searchInput.value = '';
-      this.searchInput.focus();
-    }
     this.emitSearchClearedEvent();
   }
 
@@ -168,10 +174,6 @@ export default class ExpandableSearchBar extends LitElement {
    */
   private quickSearchSelected(e: CustomEvent): void {
     this.searchTerm = e.detail.searchEntry.displayText;
-    /* istanbul ignore else */
-    if (this.searchInput) {
-      this.searchInput.value = e.detail.searchEntry.displayText;
-    }
     const event = new CustomEvent('quickSearchSelected', {
       detail: { quickSearchEntry: e.detail.searchEntry },
     });


### PR DESCRIPTION
**Description**

This PR addresses issue #528. The issue was actually broader than described. The expandable search bar was actually unable to use the dropdown options after any user input keystrokes. This PR fixes that and it now works as intended.

**Technical**

The existing code didn't work because it tried to modify a LitElement component from outside the component. LitElement, like similar frameworks, updates the DOM based on changes to state inside components. Also, the previous implementation placed a non-documented obligation on the consumer to know that they must write this supporting code.

This implementation fixes this by changing state from within the component.

I also would like to note that I discovered another pre-existing problem while fixing this, but that goes beyond the scope of this PR. Both `this.searchTerm` and `this.searchInput.value` hold overlapping state information for text in the search bar. I tried to see if there was a simple fix by looking at LitElement's documentation, but it seemed like it would take more digging or someone with more experience with that framework. A simple solution might be converting this to React. I can file an issue if need be.

**Testing**

See if the expandable search bar correctly takes new input after from the drop-down menu/the expandable search bar works in general.

**Evidence**


https://user-images.githubusercontent.com/34525444/115131511-85ed1d80-9fad-11eb-8a2e-593d73874ad0.mov


