### PR TITLE
Wayback Logo URL in topnav

### DIFF
--- a/packages/ia-wayback-search/index.html
+++ b/packages/ia-wayback-search/index.html
@@ -39,7 +39,7 @@
 
       render(html`<ia-wayback-search
         waybackPagesArchived="32 trillion pages"
-        .baseHost=${'archive.org'}
+        .baseHost=${'https://archive.org'}
         .queryHandler=${queryHandler}
       ></ia-wayback-search>`, document.getElementById('root'));
 

--- a/packages/ia-wayback-search/src/ia-wayback-search.js
+++ b/packages/ia-wayback-search/src/ia-wayback-search.js
@@ -61,7 +61,7 @@ class WaybackSearch extends LitElement {
           <a
             @click=${this.emitWaybackMachineLogoLinkClicked}
             data-event-click-tracking="TopNav|WaybackMachineLogoLink"
-            href=${`https://${this.baseHost}/web/`}
+            href=${`${this.baseHost}/web/`}
             >${logo}</a>
           <label for="url">Search the Wayback Machine</label>
           <div class="search-field">


### PR DESCRIPTION
**Description**

> Clicking on the Wayback Machine logo in the topnav takes you to the wrong url (https://https://archive.org/web/, double `https`).
See here for more information: https://webarchive.jira.com/browse/WEBDEV-4360

**Testing**

