### PR TITLE
iaux player - pass base host through to item-navigator

### DIFF
--- a/packages/ia-components/components/audio-players/audio-player-main.jsx
+++ b/packages/ia-components/components/audio-players/audio-player-main.jsx
@@ -135,7 +135,9 @@ export default class TheatreAudioPlayer extends Component {
    * Render function - determines whether or not we render liner notes
    */
   showLinerNotes() {
-    const { linerNotes, userSignedIn, albumMetadataStr } = this.props;
+    const {
+      linerNotes, userSignedIn, albumMetadataStr, baseHost
+    } = this.props;
     const { mediaSource } = this.state;
 
     // may have linerNotes with just {metadata} if bookreader jsia call fails
@@ -150,6 +152,7 @@ export default class TheatreAudioPlayer extends Component {
         <BookReaderWrapper
           options={{ ...linerNotes.data.brOptions }}
           userSignedIn={userSignedIn}
+          baseHost={baseHost}
           item={albumMetadataStr}
           style={{
             position: 'absolute',
@@ -200,7 +203,8 @@ TheatreAudioPlayer.defaultProps = {
   urlExtensions: '',
   linerNotes: null,
   albumMetadataStr: '',
-  userSignedIn: false
+  userSignedIn: false,
+  baseHost: ''
 };
 
 TheatreAudioPlayer.propTypes = {
@@ -221,5 +225,6 @@ TheatreAudioPlayer.propTypes = {
   linerNotes: PropTypes.object,
   playlist: PropTypes.array.isRequired,
   albumMetadataStr: PropTypes.string,
-  userSignedIn: PropTypes.bool
+  userSignedIn: PropTypes.bool,
+  baseHost: PropTypes.string
 };

--- a/packages/ia-components/components/bookreader-component/bookreader-wrapper-main.jsx
+++ b/packages/ia-components/components/bookreader-component/bookreader-wrapper-main.jsx
@@ -110,12 +110,12 @@ export default class BookReaderWrapper extends Component {
   }
 
   render() {
-    const { userSignedIn, item } = this.props;
+    const { userSignedIn, item, baseHost } = this.props;
     const base64item = btoa(item);
     return (
       <section className="bookreader-wrapper liner-notes" {...this.props}>
         <item-navigator
-          baseHost="https://archive.org"
+          baseHost={baseHost}
           itemtype="bookreader"
           signedIn={userSignedIn}
           item={base64item}
@@ -134,11 +134,13 @@ BookReaderWrapper.displayName = 'BookReaderWrapper';
 BookReaderWrapper.defaultProps = {
   options: {},
   userSignedIn: false,
-  item: null
+  item: null,
+  baseHost: ''
 };
 
 BookReaderWrapper.propTypes = {
   options: PropTypes.object,
   userSignedIn: PropTypes.bool,
-  item: PropTypes.object
+  item: PropTypes.object,
+  baseHost: PropTypes.string
 };

--- a/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -333,9 +333,8 @@ class AudioPlayerWithYoutubeSpotify extends Component {
 
   render() {
     const {
-      jwplayerPlaylist, linerNotes, albumMetadataStr, userSignedIn
+      jwplayerPlaylist, linerNotes, albumMetadataStr, userSignedIn, baseHost
     } = this.props;
-
     const { tracklistToShow, channelToPlay, albumData } = this.state;
     const {
       albumMetadaToDisplay,
@@ -387,6 +386,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
             linerNotes={linerNotes}
             albumMetadataStr={albumMetadataStr}
             userSignedIn={userSignedIn}
+            baseHost={baseHost}
             jwplayerPlaylistChange={this.jwplayerPlaylistChange}
             jwplayerStartingPoint={this.jwplayerStartingPoint}
             youtubePlaylistChange={this.youtubePlaylistChange}
@@ -439,6 +439,7 @@ AudioPlayerWithYoutubeSpotify.defaultProps = {
   userSignedIn: false,
   albumMetadataStr: '',
   albumMetadata: null,
+  baseHost: 'archive.org'
 };
 
 AudioPlayerWithYoutubeSpotify.propTypes = {
@@ -448,6 +449,7 @@ AudioPlayerWithYoutubeSpotify.propTypes = {
   playFullIAAudio: PropTypes.bool,
   linerNotes: PropTypes.object,
   userSignedIn: PropTypes.bool,
+  baseHost: PropTypes.string
 };
 
 export default AudioPlayerWithYoutubeSpotify;


### PR DESCRIPTION
pass `baseHost` as prop through iaux-music-player so bookreader web component can hook into it