### PR TITLE
IA jwplayer 8.22 update patch

### DIFF
--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -95,7 +95,6 @@ class ArchiveAudioPlayer extends Component {
     const playersCurrTrack = jwplayerInstance.getPlaylistIndex();
     const playerIncomingTrack = index - 1;
     const nextTrackPlaying = playersCurrTrack === playerIncomingTrack;
-    console.log('**** Rx - should we play? playersCurrTrack, prevIndex, index ', { playersCurrTrack, prevIndex, index});
 
     const isOnSameTrack = playerPlaylistIndex === index;
     const playerStatus = jwplayerInstance.getState();

--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -141,7 +141,6 @@ class ArchiveAudioPlayer extends Component {
     const { playerPlaylistIndex } = stateToUpdate;
     const { player } = this.state;
     this.setState(stateToUpdate, () => {
-      console.log('**** Rx playTrack - will play this player Index: ', playerPlaylistIndex);
       player.playN(playerPlaylistIndex);
     });
   }

--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -92,13 +92,17 @@ class ArchiveAudioPlayer extends Component {
       return;
     }
     const incomingTrackChange = index !== prevIndex;
+    const playersCurrTrack = jwplayerInstance.getPlaylistIndex();
+    const playerIncomingTrack = index - 1;
+    const nextTrackPlaying = playersCurrTrack === playerIncomingTrack;
+    log('**** Rx - should we play? playersCurrTrack, prevIndex, index ', { playersCurrTrack, prevIndex, index});
 
     const isOnSameTrack = playerPlaylistIndex === index;
     const playerStatus = jwplayerInstance.getState();
     const playCurrentTrack = isOnSameTrack && (playerStatus === 'idle');
     const playTrack = indexIsNumber && (playCurrentTrack || incomingTrackChange);
-    if (playTrack) {
-      this.playTrack({ playerPlaylistIndex: index - 1 || 0 });
+    if (!nextTrackPlaying && playTrack) {
+      this.playTrack({ playerPlaylistIndex: playerIncomingTrack || 0 });
     }
   }
 
@@ -138,6 +142,7 @@ class ArchiveAudioPlayer extends Component {
     const { playerPlaylistIndex } = stateToUpdate;
     const { player } = this.state;
     this.setState(stateToUpdate, () => {
+      log('**** Rx playTrack - will play this player Index: ', playerPlaylistIndex);
       player.playN(playerPlaylistIndex);
     });
   }

--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -95,7 +95,7 @@ class ArchiveAudioPlayer extends Component {
     const playersCurrTrack = jwplayerInstance.getPlaylistIndex();
     const playerIncomingTrack = index - 1;
     const nextTrackPlaying = playersCurrTrack === playerIncomingTrack;
-    log('**** Rx - should we play? playersCurrTrack, prevIndex, index ', { playersCurrTrack, prevIndex, index});
+    console.log('**** Rx - should we play? playersCurrTrack, prevIndex, index ', { playersCurrTrack, prevIndex, index});
 
     const isOnSameTrack = playerPlaylistIndex === index;
     const playerStatus = jwplayerInstance.getState();
@@ -142,7 +142,7 @@ class ArchiveAudioPlayer extends Component {
     const { playerPlaylistIndex } = stateToUpdate;
     const { player } = this.state;
     this.setState(stateToUpdate, () => {
-      log('**** Rx playTrack - will play this player Index: ', playerPlaylistIndex);
+      console.log('**** Rx playTrack - will play this player Index: ', playerPlaylistIndex);
       player.playN(playerPlaylistIndex);
     });
   }

--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -149,7 +149,7 @@ class ArchiveAudioPlayer extends Component {
     }
 
     const playerStatus = jwplayerInstance.getState();
-    const incomingTrackChange = incomingTrackNum > prevIndex || (trackNumber !== incomingTrackNum);
+    const incomingTrackChange = (incomingTrackNum > prevIndex) || (trackNumber !== incomingTrackNum);
     const autoplaying = incomingTrackChange && (playerStatus === 'idle');
 
     if (!playerEverStarted) {

--- a/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
+++ b/packages/ia-components/components/audio-players/archive-audio-jwplayer-wrapper.jsx
@@ -92,16 +92,17 @@ class ArchiveAudioPlayer extends Component {
       return;
     }
     const incomingTrackChange = index !== prevIndex;
-    const playersCurrTrack = jwplayerInstance.getPlaylistIndex();
-    const playerIncomingTrack = index - 1;
-    const nextTrackPlaying = playersCurrTrack === playerIncomingTrack;
+    const jwplayerTrack = jwplayerInstance.getPlaylistIndex();
+    const incomingTrackAsJwpTrack = index - 1;
+    /** look out for IA player automatically advancing to next track */
+    const autoAdvanceHappening = jwplayerTrack === incomingTrackAsJwpTrack;
 
     const isOnSameTrack = playerPlaylistIndex === index;
     const playerStatus = jwplayerInstance.getState();
     const playCurrentTrack = isOnSameTrack && (playerStatus === 'idle');
     const playTrack = indexIsNumber && (playCurrentTrack || incomingTrackChange);
-    if (!nextTrackPlaying && playTrack) {
-      this.playTrack({ playerPlaylistIndex: playerIncomingTrack || 0 });
+    if (!autoAdvanceHappening && playTrack) {
+      this.playTrack({ playerPlaylistIndex: incomingTrackAsJwpTrack || 0 });
     }
   }
 

--- a/packages/ia-components/components/pagination/pagination-with-flexbox.jsx
+++ b/packages/ia-components/components/pagination/pagination-with-flexbox.jsx
@@ -125,10 +125,9 @@ class Paginator extends Component {
       const isColumn = viewport.className === 'flexbox-pagination column';
       if (!isColumn && (numberOfPages.length <= 1)) return;
 
-      let itemToView = null;
+      const itemToView = viewport.querySelector('.selected.track');
       if (scrollItemIntoView) {
         // focus on item but keep page position
-        itemToView = viewport.querySelector(itemInViewClass);
         if (itemToView) {
           const currentX = window.pageXOffset;
           const currentY = window.pageYOffset;
@@ -136,7 +135,7 @@ class Paginator extends Component {
           window.scrollTo(currentX, currentY);
         }
       }
-      const viewportFlush = scrollItemIntoView
+      const viewportFlush = scrollItemIntoView && itemToView
         ? (itemToView.clientWidth + itemToView.offsetLeft)
         : viewport.scrollLeft;
       const pageToShow = getPageToShow({ currentPage, viewportFlush, scrollThresholds });

--- a/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -312,7 +312,7 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   jwplayerPlaylistChange(playlistItem) {
     const { newTrackIndex } = playlistItem;
-    this.setState({ trackSelected: newTrackIndex + 1 });
+    this.setState({ trackSelected: newTrackIndex });
   }
 
   /**

--- a/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify-main.jsx
@@ -172,7 +172,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
       }
     });
     audioSource = trackInfo || head(tracklistToShow);
-    console.log('!!!! audo source', audioSource);
     return audioSource || {};
   }
 
@@ -185,7 +184,6 @@ class AudioPlayerWithYoutubeSpotify extends Component {
    */
   getTrackToHighlight(audioSource) {
     const { trackSelected, trackStartingPoint } = this.state;
-    console.log('^^^^^ getTrackToHighlight', { audioSource, trackSelected, trackStartingPoint });
     if (parseInt(audioSource.index, 10) >= 0) {
       // has available track number to refer to, archive player
       return audioSource.index;

--- a/packages/ia-components/components/track-lists/track-list.jsx
+++ b/packages/ia-components/components/track-lists/track-list.jsx
@@ -19,7 +19,6 @@ const TheatreTrackList = (props) => {
   const trackNumberToHighlight = selectedTrack === null ? 0 : selectedTrack;
 
   const itemToViewClass = `[data-track-number="${trackNumberToHighlight}"]`;
-  console.log('TRACK LIST ', { trackNumberToHighlight, selectedTrack, itemToViewClass });
   return (
     <div className="audio-track-list">
       <FlexboxPagination

--- a/packages/ia-components/components/track-lists/track-list.jsx
+++ b/packages/ia-components/components/track-lists/track-list.jsx
@@ -11,17 +11,15 @@ import OneTrack from './track';
  */
 const TheatreTrackList = (props) => {
   const {
-    selectedTrack, onSelected, tracks, displayTrackNumbers, creator: albumCreator, albumName
+    selectedTrack = 0, onSelected, tracks, displayTrackNumbers, creator: albumCreator, albumName
   } = props;
 
   if (!tracks.length) return <p className="no-tracks">No tracks to display.</p>;
 
-  const [firstTrack = {}] = tracks;
-  const { trackNumber: firstTrackNumber } = firstTrack;
-  const trackNumberToHighlight = Number.isInteger(selectedTrack)
-    ? selectedTrack
-    : firstTrackNumber;
+  const trackNumberToHighlight = selectedTrack === null ? 0 : selectedTrack;
+
   const itemToViewClass = `[data-track-number="${trackNumberToHighlight}"]`;
+  console.log('TRACK LIST ', { trackNumberToHighlight, selectedTrack, itemToViewClass });
   return (
     <div className="audio-track-list">
       <FlexboxPagination
@@ -36,6 +34,7 @@ const TheatreTrackList = (props) => {
             const trackProps = {
               thisTrack, onSelected, selected, displayTrackNumbers, albumCreator, albumName
             };
+
             return <OneTrack {...trackProps} key={key} />;
           })
         }

--- a/packages/ia-components/components/track-lists/track.jsx
+++ b/packages/ia-components/components/track-lists/track.jsx
@@ -95,7 +95,7 @@ const OneTrack = ({
   return (
     <button
       type="button"
-      data-track-number={trackNumber}
+      data-track-number={trackNumber || 0}
       className={trackButtonClass}
       onClick={onSelected}
       data-event-click-tracking="TrackList|Item"
@@ -123,7 +123,8 @@ OneTrack.propTypes = {
     PropTypes.string,
     PropTypes.array
   ]),
-  albumName: PropTypes.string
+  albumName: PropTypes.string,
+  trackIdx: PropTypes.number
 };
 
 export default OneTrack;

--- a/packages/ia-components/package.json
+++ b/packages/ia-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-components",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "source": true,
   "license": "AGPL-3.0-only",
   "scripts": {


### PR DESCRIPTION
more deterministic check on autoplay.

problem: when jwp changes tracks, the state is `idle`. this metric is not enough to determine if play8 is running autoplay.

solution: check jwp for its current track. if so, then record state to move tracklist's active state.