### PR TITLE
Hide menus when they are dismissed

### DIFF
--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -26,6 +26,10 @@
       dt {
         font-size: 1.4rem;
       }
+      main {
+        padding: 0 2rem;
+        font-size: 1.4rem;
+      }
 
       .anniv-logo-link {
         display: flex;
@@ -60,7 +64,7 @@
       This is not needed when setting the search query with lit-element bindings.
     -->
     <div class="fake-banner"></div>
-    <ia-topnav searchQuery="J2Zvbyc=">
+    <ia-topnav searchQuery="Zm9v">
       <div slot="opt-sec-logo">
         <a class="anniv-logo-link" href="https://anniversary.archive.org" title="Go to cool page">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 114.6 36.87">

--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -40,6 +40,16 @@
       .anniv-logo-link svg .fill-color {
         fill: var(--primaryTextColor, #fff);
       }
+
+      .fake-banner {
+        background-color: lightblue;
+        height: 0;
+        transition: height 0.2s ease;
+      }
+
+      .fake-banner.open {
+        height: 20rem;
+      }
   }
     </style>
   </head>
@@ -49,7 +59,7 @@
       When passing in a search query through html attributes, base64 encode them.
       This is not needed when setting the search query with lit-element bindings.
     -->
-    <div style="background-color: lightblue; height: 200px;"></div>
+    <div class="fake-banner"></div>
     <ia-topnav searchQuery="J2Zvbyc=">
       <div slot="opt-sec-logo">
         <a class="anniv-logo-link" href="https://anniversary.archive.org" title="Go to cool page">
@@ -108,6 +118,11 @@
           <dd>
             <button id="show-logo2">Show 2nd logo</button>
             <button id="hide-logo2">Hide 2nd logo</button>
+          </dd>
+          <dt>Banner Space</dt>
+          <dd>
+            <button id="show-banner">Add Banner</button>
+            <button id="hide-banner">Hide Banner</button>
           </dd>
         </dl>
       </fieldset>
@@ -217,6 +232,16 @@
       hideLogo2.addEventListener('click', () => {
         topnav.secondIdentitySlotMode = '';
       })
+
+  const showBanner = document.querySelector('#show-banner');
+  showBanner.addEventListener('click', () => {
+    document.querySelector('.fake-banner').classList.add('open');
+  })
+
+  const hideBanner = document.querySelector('#hide-banner');
+  hideBanner.addEventListener('click', () => {
+    document.querySelector('.fake-banner').classList.remove('open');
+  })
     </script>
   </body>
 </html>

--- a/packages/ia-topnav/index.html
+++ b/packages/ia-topnav/index.html
@@ -49,6 +49,7 @@
       When passing in a search query through html attributes, base64 encode them.
       This is not needed when setting the search query with lit-element bindings.
     -->
+    <div style="background-color: lightblue; height: 200px;"></div>
     <ia-topnav searchQuery="J2Zvbyc=">
       <div slot="opt-sec-logo">
         <a class="anniv-logo-link" href="https://anniversary.archive.org" title="Go to cool page">

--- a/packages/ia-topnav/package-lock.json
+++ b/packages/ia-topnav/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.1.5",
+  "version": "1.1.15-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ia-topnav/src/dropdown-menu.js
+++ b/packages/ia-topnav/src/dropdown-menu.js
@@ -81,15 +81,17 @@ class DropdownMenu extends TrackedElement {
 
   render() {
     return html`
-      <nav
-        class="${this.menuClass}"
-        aria-hidden="${this.ariaHidden}"
-        aria-expanded="${this.ariaExpanded}"
-      >
-        <ul>
-          ${this.dropdownItems}
-        </ul>
-      </nav>
+      <div class="nav-container">
+        <nav
+          class="${this.menuClass}"
+          aria-hidden="${this.ariaHidden}"
+          aria-expanded="${this.ariaExpanded}"
+        >
+          <ul>
+            ${this.dropdownItems}
+          </ul>
+        </nav>
+      </div>
     `;
   }
 }

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -229,7 +229,8 @@ export default class IATopNav extends LitElement {
           @trackClick=${this.trackClick}
           @trackSubmit=${this.trackSubmit}
           @menuToggled=${this.menuToggled}
-        >${this.secondLogoSlot}</primary-nav>
+          >${this.secondLogoSlot}</primary-nav
+        >
         <media-slider
           .baseHost=${this.baseHost}
           .config=${this.config}
@@ -239,10 +240,6 @@ export default class IATopNav extends LitElement {
         ></media-slider>
       </div>
       ${this.username ? this.userMenu : this.signedOutDropdown}
-      <desktop-subnav
-        .baseHost=${this.baseHost}
-        .menuItems=${this.desktopSubnavMenuItems}
-      ></desktop-subnav>
       <search-menu
         .baseHost=${this.baseHost}
         .config=${this.config}
@@ -253,6 +250,10 @@ export default class IATopNav extends LitElement {
         @trackClick=${this.trackClick}
         @trackSubmit=${this.trackSubmit}
       ></search-menu>
+      <desktop-subnav
+        .baseHost=${this.baseHost}
+        .menuItems=${this.desktopSubnavMenuItems}
+      ></desktop-subnav>
       <div id="close-layer" class="${this.closeLayerClass}" @click=${this.closeMenus}></div>
     `;
   }

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -238,6 +238,7 @@ export default class IATopNav extends LitElement {
           .menus=${this.menus}
         ></media-slider>
       </div>
+      ${this.username ? this.userMenu : this.signedOutDropdown}
       <desktop-subnav
         .baseHost=${this.baseHost}
         .menuItems=${this.desktopSubnavMenuItems}
@@ -252,7 +253,6 @@ export default class IATopNav extends LitElement {
         @trackClick=${this.trackClick}
         @trackSubmit=${this.trackSubmit}
       ></search-menu>
-      ${this.username ? this.userMenu : this.signedOutDropdown}
       <div id="close-layer" class="${this.closeLayerClass}" @click=${this.closeMenus}></div>
     `;
   }

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -88,6 +88,7 @@ export default class IATopNav extends LitElement {
 
   closeMediaSlider() {
     this.mediaSliderOpen = false;
+    this.openMenu = '';
     this.selectedMenuOption = '';
   }
 

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -229,8 +229,9 @@ export default class IATopNav extends LitElement {
           @trackClick=${this.trackClick}
           @trackSubmit=${this.trackSubmit}
           @menuToggled=${this.menuToggled}
-          >${this.secondLogoSlot}</primary-nav
         >
+          ${this.secondLogoSlot}
+        </primary-nav>
         <media-slider
           .baseHost=${this.baseHost}
           .config=${this.config}

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -88,7 +88,6 @@ export default class IATopNav extends LitElement {
 
   closeMediaSlider() {
     this.mediaSliderOpen = false;
-    this.openMenu = '';
     this.selectedMenuOption = '';
   }
 

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -159,7 +159,7 @@ export default class IATopNav extends LitElement {
         .baseHost=${this.baseHost}
         .config=${this.config}
         .menuItems=${this.userMenuItems}
-        .open=${this.openMenu === 'user'}
+        ?open=${this.openMenu === 'user'}
         .username=${this.username}
         ?hideSearch=${this.hideSearch}
         tabindex="${this.userMenuTabIndex}"

--- a/packages/ia-topnav/src/media-menu.js
+++ b/packages/ia-topnav/src/media-menu.js
@@ -113,15 +113,19 @@ class MediaMenu extends LitElement {
 
   render() {
     return html`
-      <nav
-        class="media-menu tx-slide ${this.menuClass}"
-        aria-hidden="${!this.menuOpened}"
-        aria-expanded="${this.menuOpened}"
-      >
-        <div class="menu-group">
-          ${this.mediaMenuOptionsTemplate}
+      <div class="media-menu-container ${this.menuClass}">
+        <div class="overflow-clip">
+          <nav
+            class="media-menu"
+            aria-hidden="${!this.menuOpened}"
+            aria-expanded="${this.menuOpened}"
+          >
+            <div class="menu-group">
+              ${this.mediaMenuOptionsTemplate}
+            </div>
+          </nav>
         </div>
-      </nav>
+      </div>
     `;
   }
 }

--- a/packages/ia-topnav/src/media-slider.js
+++ b/packages/ia-topnav/src/media-slider.js
@@ -43,15 +43,17 @@ class MediaSlider extends LitElement {
     const sliderDetailsClass = this.mediaSliderOpen ? 'open' : 'closed';
 
     return html`
-      <div class="overflow-clip ${sliderDetailsClass}">
-        <div class="information-menu ${sliderDetailsClass}">
-          <div class="info-box">
-            <media-subnav
-              .baseHost=${this.baseHost}
-              .config=${this.config}
-              .menu=${this.selectedMenuOption}
-              .menuItems=${this.selectedMenuItems}
-            ></media-subnav>
+      <div class="media-slider-container">
+        <div class="overflow-clip ${sliderDetailsClass}">
+          <div class="information-menu ${sliderDetailsClass}">
+            <div class="info-box">
+              <media-subnav
+                .baseHost=${this.baseHost}
+                .config=${this.config}
+                .menu=${this.selectedMenuOption}
+                .menuItems=${this.selectedMenuItems}
+              ></media-subnav>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/ia-topnav/src/search-menu.js
+++ b/packages/ia-topnav/src/search-menu.js
@@ -92,19 +92,21 @@ class SearchMenu extends TrackedElement {
     }
 
     return html`
-      <div
-        class="search-menu tx-slide ${this.menuClass}"
-        aria-hidden="${searchMenuHidden}"
-        aria-expanded="${searchMenuExpanded}"
-      >
-        ${this.searchTypesTemplate}
-        <a
-          class="advanced-search"
-          href="${formatUrl('/advancedsearch.php', this.baseHost)}"
-          @click=${this.trackClick}
-          data-event-click-tracking="${this.config.eventCategory}|NavAdvancedSearch"
-          >Advanced Search</a
+      <div class="menu-wrapper">
+        <div
+          class="search-menu tx-slide ${this.menuClass}"
+          aria-hidden="${searchMenuHidden}"
+          aria-expanded="${searchMenuExpanded}"
         >
+          ${this.searchTypesTemplate}
+          <a
+            class="advanced-search"
+            href="${formatUrl('/advancedsearch.php', this.baseHost)}"
+            @click=${this.trackClick}
+            data-event-click-tracking="${this.config.eventCategory}|NavAdvancedSearch"
+            >Advanced Search</a
+          >
+        </div>
       </div>
     `;
   }

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -5,9 +5,12 @@ export default css`
     --topOffset: -1500px;
   }
 
+  .nav-container {
+    position: relative;
+  }
+
   nav {
     position: absolute;
-    top: var(--topOffset);
     right: 0;
     z-index: 2;
     overflow: hidden;
@@ -28,7 +31,6 @@ export default css`
   }
 
   .open {
-    top: 4rem;
     max-width: 100vw;
     overflow: auto;
   }
@@ -52,7 +54,7 @@ export default css`
   }
 
   .divider {
-    margin: .5rem 0;
+    margin: 0.5rem 0;
     border-bottom: 1px solid var(--dropdownMenuDivider);
   }
 
@@ -65,21 +67,21 @@ export default css`
   }
 
   .info-item {
-    font-size: .8em;
+    font-size: 0.8em;
     color: var(--dropdownMenuInfoItem);
   }
 
   @media (min-width: 890px) {
     nav {
       overflow: visible;
-      top: calc(100% + 7px);
+      top: 0;
       left: auto;
       z-index: 5;
-      transition: opacity .2s ease-in-out;
+      transition: opacity 0.2s ease-in-out;
       font-size: 1.4rem;
       border-radius: 2px;
       background: var(--primaryTextColor);
-      box-shadow: 0 1px 2px 1px rgba(0, 0, 0, .15);
+      box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.15);
     }
 
     nav:after {
@@ -90,7 +92,7 @@ export default css`
       height: 7px;
       box-sizing: border-box;
       color: #fff;
-      content: "";
+      content: '';
       border-bottom: 7px solid currentColor;
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
@@ -110,14 +112,14 @@ export default css`
     }
 
     a {
-      padding: .5rem 2rem;
+      padding: 0.5rem 2rem;
       color: var(--inverseTextColor);
-      transition: background .1s ease-out, color .1s ease-out;
+      transition: background 0.1s ease-out, color 0.1s ease-out;
     }
 
     .info-item {
-      padding: .5rem 2rem;
-      font-size: .8em;
+      padding: 0.5rem 2rem;
+      font-size: 0.8em;
     }
 
     a:hover,
@@ -130,11 +132,10 @@ export default css`
     .initial,
     .closed {
       opacity: 0;
-      transition-duration: .2s;
+      transition-duration: 0.2s;
     }
 
     .open {
-      top: 5.1rem;
       opacity: 1;
       overflow: visible;
     }

--- a/packages/ia-topnav/src/styles/media-menu.js
+++ b/packages/ia-topnav/src/styles/media-menu.js
@@ -38,6 +38,7 @@ export default css`
 
     .overflow-clip {
       position: absolute;
+      z-index: -1; /** needs to be under the navigation, otherwise it intercepts clicks */
       top: 0;
       left: 0;
       height: 0;

--- a/packages/ia-topnav/src/styles/media-menu.js
+++ b/packages/ia-topnav/src/styles/media-menu.js
@@ -6,31 +6,14 @@ export default css`
   }
 
   .media-menu {
-    position: absolute;
     z-index: -1;
-    top: -400px;
-    width: 100%;
+    top: -40rem;
     background-color: var(--mediaMenuBg);
     margin: 0;
     overflow: hidden;
-  }
-
-  .media-menu.tx-slide {
+    transition-duration: 0.2s;
     transition-property: top;
-    transition-duration: 0.2s;
     transition-timing-function: ease;
-  }
-
-  .media-menu.tx-slide.open {
-    top: 100%;
-  }
-
-  .media-menu.tx-slide.closed {
-    top: -400px;
-  }
-
-  .media-menu.tx-slide.closed {
-    transition-duration: 0.2s;
   }
 
   .menu-group {
@@ -38,21 +21,45 @@ export default css`
     line-height: normal;
   }
 
+  /* Mobile view styles */
+  @media (max-width: 889px) {
+    .media-menu-container {
+      position: relative;
+    }
+
+    .media-menu {
+      position: absolute;
+      width: 100%;
+    }
+
+    .open .media-menu {
+      top: 0;
+    }
+
+    .overflow-clip {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 0;
+      width: 100%;
+      overflow: hidden;
+      transition-duration: 0.2s;
+      transition-property: height;
+    }
+
+    .open .overflow-clip {
+      height: 40rem;
+    }
+  }
+
+  /* Desktop view styles */
   @media (min-width: 890px) {
     .media-menu {
       display: inline-block;
       position: static;
       width: auto;
       height: 5rem;
-    }
-
-    .media-menu.tx-slide {
       transition-property: none;
-    }
-
-    .media-menu.tx-slide.open,
-    .media-menu.tx-slide.closed {
-      top: 0;
     }
 
     .menu-group {

--- a/packages/ia-topnav/src/styles/media-slider.js
+++ b/packages/ia-topnav/src/styles/media-slider.js
@@ -36,6 +36,15 @@ export default css`
     padding: 1rem;
   }
 
+  @media (max-width: 889px) {
+    .overflow-clip.open {
+      display: block;
+      height: 367px;
+      left: 4rem;
+      top: 0;
+    }
+  }
+
   @media (min-width: 890px) {
     .overflow-clip {
       display: block;

--- a/packages/ia-topnav/src/styles/media-slider.js
+++ b/packages/ia-topnav/src/styles/media-slider.js
@@ -61,7 +61,7 @@ export default css`
     }
 
     .overflow-clip.open {
-      height: 20rem;
+      height: 22rem;
     }
 
     .information-menu.open {

--- a/packages/ia-topnav/src/styles/media-slider.js
+++ b/packages/ia-topnav/src/styles/media-slider.js
@@ -1,6 +1,10 @@
 import { css } from 'lit-element';
 
 export default css`
+  .media-slider-container {
+    position: relative;
+  }
+
   .overflow-clip {
     display: none;
     position: absolute;
@@ -8,7 +12,8 @@ export default css`
     right: 0;
     left: 4rem;
     height: 368px;
-    overflow-x: hidden;
+    overflow: hidden;
+    outline: 1px solid red;
   }
 
   .information-menu {
@@ -36,10 +41,9 @@ export default css`
       display: block;
       top: 0;
       left: 0;
-      height: auto;
-      overflow-x: visible;
-      transform: translate(0, -100%);
-      transition: transform .2s ease;
+      height: 0;
+      overflow-x: hidden;
+      transition: height 0.2s ease;
     }
 
     .information-menu {
@@ -49,12 +53,13 @@ export default css`
       min-height: 21rem;
       background: var(--mediaSliderDesktopBg);
       transform: translate(0, -100%);
-      transition: transform .2s ease;
+      transition: transform 0.2s ease;
     }
 
     .overflow-clip.open {
-      transform: translate(0, 8rem);
+      height: 21rem;
     }
+
     .information-menu.open {
       transform: translate(0, 0);
     }

--- a/packages/ia-topnav/src/styles/media-slider.js
+++ b/packages/ia-topnav/src/styles/media-slider.js
@@ -8,12 +8,11 @@ export default css`
   .overflow-clip {
     display: none;
     position: absolute;
-    top: 0;
+    top: 3rem;
     right: 0;
     left: 0;
     height: 0;
     overflow: hidden;
-    outline: 1px solid red;
     transition: height 0.2s ease;
   }
 
@@ -53,7 +52,7 @@ export default css`
     }
 
     .overflow-clip.open {
-      height: 21rem;
+      height: 20rem;
     }
 
     .information-menu.open {

--- a/packages/ia-topnav/src/styles/media-slider.js
+++ b/packages/ia-topnav/src/styles/media-slider.js
@@ -8,12 +8,13 @@ export default css`
   .overflow-clip {
     display: none;
     position: absolute;
-    top: 4rem;
+    top: 0;
     right: 0;
-    left: 4rem;
-    height: 368px;
+    left: 0;
+    height: 0;
     overflow: hidden;
     outline: 1px solid red;
+    transition: height 0.2s ease;
   }
 
   .information-menu {
@@ -39,11 +40,6 @@ export default css`
   @media (min-width: 890px) {
     .overflow-clip {
       display: block;
-      top: 0;
-      left: 0;
-      height: 0;
-      overflow-x: hidden;
-      transition: height 0.2s ease;
     }
 
     .information-menu {

--- a/packages/ia-topnav/src/styles/nav-search.js
+++ b/packages/ia-topnav/src/styles/nav-search.js
@@ -16,7 +16,7 @@ export default css`
   }
   .search {
     padding-top: 0;
-    margin-right: .5rem;
+    margin-right: 0.5rem;
   }
   .search svg {
     position: relative;
@@ -30,9 +30,9 @@ export default css`
     display: flex;
     position: absolute;
     top: 0;
-    right: 5rem;
+    right: 4rem;
     bottom: 0;
-    left: 5rem;
+    left: 4rem;
     z-index: 3;
     padding: 0.5rem 0.2rem;
     border-radius: 1rem 1rem 0 0;
@@ -51,7 +51,7 @@ export default css`
     display: -ms-flexbox;
     display: flex;
     width: 100%;
-    margin: 0 .5rem;
+    margin: 0 0.5rem;
   }
   .search-activated .search {
     height: 100%;
@@ -83,7 +83,7 @@ export default css`
     }
   }
   .fade-in {
-    animation: fade-in .2s forwards;
+    animation: fade-in 0.2s forwards;
   }
 
   @media (min-width: 890px) {
@@ -101,7 +101,7 @@ export default css`
     .search-activated {
       display: block;
       position: static;
-      padding: 1.2rem .2rem;
+      padding: 1.2rem 0.2rem;
       background: transparent;
     }
 

--- a/packages/ia-topnav/src/styles/search-menu.js
+++ b/packages/ia-topnav/src/styles/search-menu.js
@@ -5,6 +5,10 @@ export default css`
     --topOffset: -800px;
   }
 
+  .menu-wrapper {
+    position: relative;
+  }
+
   button:focus,
   input:focus {
     outline-color: var(--linkColor);
@@ -13,7 +17,6 @@ export default css`
   }
   .search-menu {
     position: absolute;
-    top: var(--topOffset);
     right: 0;
     left: 0;
     z-index: 2;
@@ -34,9 +37,6 @@ export default css`
   .closed {
     transition-duration: 0.2s;
   }
-  .open {
-    top: 4rem;
-  }
 
   label,
   a {
@@ -52,17 +52,16 @@ export default css`
   @media (min-width: 890px) {
     .search-menu {
       overflow: visible;
-      top: -400px;
       right: 2rem;
       left: auto;
       z-index: 5;
       padding: 1rem 2rem;
-      transition: opacity .2s ease-in-out;
+      transition: opacity 0.2s ease-in-out;
       font-size: 1.4rem;
       color: var(--inverseTextColor);
       border-radius: 2px;
       background: var(--primaryTextColor);
-      box-shadow: 0 1px 2px 1px rgba(0, 0, 0, .15);
+      box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.15);
     }
 
     .search-menu:after {
@@ -73,7 +72,7 @@ export default css`
       height: 7px;
       box-sizing: border-box;
       color: #fff;
-      content: "";
+      content: '';
       border-bottom: 7px solid currentColor;
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
@@ -82,11 +81,10 @@ export default css`
     .initial,
     .closed {
       opacity: 0;
-      transition-duration: .2s;
+      transition-duration: 0.2s;
     }
 
     .open {
-      top: 5.1rem;
       opacity: 1;
     }
 

--- a/packages/ia-topnav/src/user-menu.js
+++ b/packages/ia-topnav/src/user-menu.js
@@ -23,16 +23,18 @@ class UserMenu extends DropdownMenu {
 
   render() {
     return html`
-      <nav
-        class="${this.menuClass}"
-        aria-hidden="${this.ariaHidden}"
-        aria-expanded="${this.ariaExpanded}"
-      >
-        <h3>${this.screenName}</h3>
-        <ul>
-          ${this.dropdownItems}
-        </ul>
-      </nav>
+      <div class="nav-container">
+        <nav
+          class="${this.menuClass}"
+          aria-hidden="${this.ariaHidden}"
+          aria-expanded="${this.ariaExpanded}"
+        >
+          <h3>${this.screenName}</h3>
+          <ul>
+            ${this.dropdownItems}
+          </ul>
+        </nav>
+      </div>
     `;
   }
 }

--- a/packages/ia-topnav/test/media-menu.test.js
+++ b/packages/ia-topnav/test/media-menu.test.js
@@ -34,6 +34,7 @@ describe('<media-menu>', () => {
     mediaMenu.mediaMenuAnimate = true;
     await mediaMenu.updateComplete;
 
-    expect(mediaMenu.shadowRoot.querySelector('nav').classList.contains('closed')).to.be.true;
+    expect(mediaMenu.shadowRoot.querySelector('.media-menu-container').classList.contains('closed'))
+      .to.be.true;
   });
 });


### PR DESCRIPTION
**Description**

> Currently, when the top nav sliding menus are dismissed, they just slide up, but are still visible above the navigation if you put something above the nav. Now it completely hides the sliding menus when they move out of view.

**Technical**

> It's using overflow: hidden and a height change animation to completely hide the menu when it's not supposed to be visible.

**Testing**

> Resize the browser and open and close menus

**Evidence**

> 

https://user-images.githubusercontent.com/51138/133680793-24d4bf39-4ffa-4fbb-ae69-bc1fdf9a857e.mov


