### PR TITLE
liner notes player: use image in item in media window instead of image placeholder

### DIFF
--- a/packages/ia-components/.storybook/theatre-styling.less
+++ b/packages/ia-components/.storybook/theatre-styling.less
@@ -1,3 +1,28 @@
+/* demo style */
+table#examples {
+  border-collapse: collapse;
+  table-layout: auto;
+  width: 100%;
+
+  thead {
+    background-color: peachpuff;
+  }
+
+  td {
+    vertical-align: middle;
+    border-bottom: 1px solid black;
+  }
+
+  tr:nth-child(even) {
+    background-color: lightyellow;
+  }
+}
+
+#liner-notes-list {
+  overflow-x: auto;
+}
+
+/* end */
 .theatre__wrap {
   color: #fff;
 }
@@ -6,7 +31,7 @@
 .theatre__wrap {
   background-color: black;
   position: relative;
-  min-height: 400px;
+  height: calc(100vh - 200px);
 }
 .theatre__wrap #flag-overlay {
   display: none;

--- a/packages/ia-components/components/data-for-stories/album-78-w-one-image.js
+++ b/packages/ia-components/components/data-for-stories/album-78-w-one-image.js
@@ -1,0 +1,59 @@
+const itemInfo = {
+  created: 1641325767,
+  d1: 'ia902303.us.archive.org',
+  d2: 'ia802303.us.archive.org',
+  dir: '/32/items/capitol-15045-b-cigarettes-whiskey-and-wild-wild-women',
+  files: [{
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.afpk', source: 'derivative', format: 'Columbia Peaks', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', mtime: '1627529721', size: '30456', md5: '7bd5bcde9b5dac1bfd376c7669367588', crc32: '53da38d9', sha1: '8b38dcde7141a028b717affaafddcb6dcd26e074'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.flac', source: 'derivative', format: 'Flac', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', mtime: '1627528858', size: '15370165', md5: '68e8a45a8977a1e6a62fcc5eb3acfefb', crc32: 'eef4d922', sha1: '9b8a934852b26f0f9f33eccc78bb1f5399a69935', length: '158.01', height: '0', width: '0'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.mp3', source: 'derivative', creator: 'Red Ingle and the Natural Seven', title: 'Cigareetes, Whuskey, and Wild, Wild Women', track: '1', album: 'Capitol 15045B', bitrate: '119', format: 'VBR MP3', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', mtime: '1627528564', size: '2473291', md5: 'f404c430a6bebed322f8855b14b3f3c8', crc32: '6e349cdc', sha1: 'a4371120bc5d04787f0fda9a2ef4c113a3abad56', length: '158.04', height: '621', width: '640'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.png', source: 'derivative', format: 'PNG', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', mtime: '1627529153', size: '40817', md5: 'f687ef7bd91a920a05d083d7d0798a55', crc32: 'c8d849cc', sha1: 'e611a7617134c254bc2573a5329136b59595ed8c'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', source: 'original', mtime: '1627527993', size: '27872778', md5: '558f0722e973f8726129d2ec8f366d1f', crc32: '4bc0946c', sha1: '2b9526cc9db02e5d10047746a3221858283c6cf1', format: 'WAVE', length: '158.01', height: '0', width: '0', track: '1', title: 'Cigareetes, Whuskey, and Wild, Wild Women', album: 'Capitol 15045B', artist: 'Red Ingle and the Natural Seven'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ_spectrogram.png', source: 'derivative', format: 'Spectrogram', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav', mtime: '1627529450', size: '273335', md5: 'a71e99567e50c3bd6a60e30bc79dce44', crc32: '360c1187', sha1: '4b44b3588af076f129ec6ca48f1e7671de443235'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women.jpg', source: 'original', mtime: '1627528022', size: '2065381', md5: 'd64389ba88f43e64c39efa5d205071bc', crc32: '20ca3ade', sha1: '05528d10c976cd33985f634465b80de686b90bce', format: 'JPEG', rotation: '0'
+  }, {
+    name: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women_thumb.jpg', source: 'derivative', format: 'JPEG Thumb', original: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women.jpg', mtime: '1627528605', size: '8891', md5: '8b5984c770d0d72385d8bc12584ea5db', crc32: '550a1403', sha1: '6203face0ea55e8b47d050f19d582e409e23fe5a'
+  }, {
+    name: '__ia_thumb.jpg', source: 'original', mtime: '1627529920', size: '11394', md5: '1afe42cc8708c0c9a2e533f22814850d', crc32: '961ffdc6', sha1: '54f1ab095b7dccfc186b080a9bc999ef053379fd', format: 'Item Tile', rotation: '0'
+  }, {
+    name: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women_archive.torrent', source: 'metadata', btih: 'bd2b8dcde45454a87593126af47778ec98cb3f84', mtime: '1627529921', size: '5708', md5: 'fe4c14ab6a6f5ae30a5de31053019f10', crc32: '2544c890', sha1: '6a8d84e2bf0d40aa7443ec2100a38afa440999d8', format: 'Archive BitTorrent'
+  }, {
+    name: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women_files.xml', source: 'original', format: 'Metadata', md5: 'b5cf1d7f19d1eb9b8505fa097604cdd5', summation: 'md5'
+  }, {
+    name: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women_meta.sqlite', source: 'original', mtime: '1627528044', size: '28672', md5: '3360ca901cd01e888abcc21cf7af0bec', crc32: '33b0fbf1', sha1: 'd7a626519b3af2fdb1203064d706296749707ca3', format: 'Metadata'
+  }, {
+    name: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women_meta.xml', source: 'original', mtime: '1627529918', size: '1314', md5: '47da1d26c2e8acf128e4b706e2667151', crc32: '8a633fad', sha1: 'ac4cb32a0dfdf8df789c1d235979f80cc0ffaf30', format: 'Metadata'
+  }],
+  files_count: 13,
+  item_last_updated: 1627529921,
+  item_size: 48182202,
+  metadata: {
+    identifier: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women', mediatype: 'audio', creator: 'Red Ingle and the Natural Seven', date: '1947-10', description: '78 record with performer Red Ingle.<div><br /></div><div>Record information:\u00a0<a href="https://78discography.com/Capitol15000.htm" rel="nofollow">Capitol 15045</a></div><div><br /></div><div>Side\u00a0A: <a href="https://archive.org/details/capitol-15045-a-pearly-maude" rel="nofollow">Pearly Maude</a></div>', language: 'eng', scanner: 'Internet Archive HTML5 Uploader 1.6.4', subject: '78rpm;Red Ingle', title: 'Cigareetes, Whuskey, and Wild, Wild Women', uploader: 'discs-78rpms@hotmail.com', publicdate: '2021-07-27 22:16:17', addeddate: '2021-07-27 22:16:17', curation: '[curator]validator@archive.org[/curator][date]20210727221715[/date][comment]checked for malware[/comment]', year: '1947', notes: 'Recorded at 45rpm then digitally adjusted to 78.26rpm and equalized using 400N-12.7.', collection: ['78rpm', 'audio_music']
+  },
+  server: 'ia802303.us.archive.org',
+  uniq: 25704253,
+  workable_servers: ['ia802303.us.archive.org', 'ia902303.us.archive.org']
+};
+
+const jwplayerPlaylist = [{
+  title: 'Cigareetes, Whuskey, and Wild, Wild Women',
+  orig: 'Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.wav',
+  image: '/download/capitol-15045-b-cigarettes-whiskey-and-wild-wild-women/Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.png',
+  duration: '158.04',
+  sources: [{
+    file: '/download/capitol-15045-b-cigarettes-whiskey-and-wild-wild-women/Capitol 15045B - Cigareetes, Whuskey, and Wild, Wild Women - 3.0 CT 400N-12.7 EQ.mp3', type: 'mp3', height: '621', width: '640'
+  }]
+}];
+
+
+export default {
+  itemInfo,
+  jwplayerPlaylist,
+  linerNotes: []
+};

--- a/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import axios from 'axios';
+import albumData from '../../data-for-stories/album-78-w-one-image';
 
-import albumData from '../../data-for-stories/album-private-with-spotify-youtube';
+// import albumData from '../../data-for-stories/album-private-with-spotify-youtube';
 import AudioPlayerWithYoutubeSpotify from './audio-with-youtube-spotify-main';
 import './audio-with-youtube-spotify.less';
 
@@ -184,7 +185,8 @@ class DataHydrator extends Component {
                         >
                           Show
                         </button>
-                        <a className="btn btn-link" href="https://archive.org/details/${id}">Details</a>
+                        <a className="btn btn-link" target="_blank" href="https://archive.org/metadata/${id}">Metadata</a>
+                        <a className="btn btn-link" target="_blank" href="https://archive.org/details/${id}">Details</a>
                       </td>
                       <td>
                         {id}

--- a/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/audio-with-youtube-spotify.stories.js
@@ -7,6 +7,53 @@ import './audio-with-youtube-spotify.less';
 
 const { itemInfo, jwplayerPlaylist, linerNotes } = albumData;
 
+const items = [
+  {
+    id: 'capitol-15045-b-cigarettes-whiskey-and-wild-wild-women',
+    desc: '78 - w/o jp2 (only 1 item image)'
+  },
+  {
+    id: 'bestofdollyparto00part',
+    desc: 'LP - older'
+  },
+  {
+    id: 'lp_dancing-tonight_freddy-martin-and-his-orchestra',
+    desc: 'LP - current, ~ 2020'
+  },
+  {
+    id: 'cd_beethoven-complete-works-for-string-trio_the-adaskin-string-trio',
+    desc: 'what_cd'
+  },
+  {
+    id: 'wcd_message-in-a-box-th_the-police_flac_lossless_807968',
+    desc: 'Irregular Photo - (portrait)'
+  },
+  {
+    id: 'lak-JC_Burris-James_Booker',
+    desc: 'No photo + long track list'
+  },
+  {
+    id: 'wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623',
+    desc: 'Complilation, various artists'
+  },
+  {
+    id: 'lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos',
+    desc: 'Track names, multiple but same as album artist (should be omitted)'
+  },
+  {
+    id: 'illegal-art',
+    desc: '3 column track list wide view pagination check'
+  },
+  {
+    id: 'wcd_borghild_die-warzau_mp3_320_1648819',
+    desc: 'Track time display, 60 seconds adds another minute. should display as 10:00'
+  },
+  {
+    id: 'cd_aaliyah_aaliyah-static-from-playa-timbaland',
+    desc: 'Has 3rd party "Full Album". Clicking on Full Album should highlight full album'
+  },
+];
+
 /**
  * Component wrapper around the music player
  * The intent is for quick debugging with the music player
@@ -85,7 +132,7 @@ class DataHydrator extends Component {
     const { itemInfo, jwplayerPlaylist, error } = this.state;
     const { metadata: { identifier } } = itemInfo;
 
-    console.log('***** RENDER: ', itemInfo, jwplayerPlaylist.length);
+    console.log('***** RENDER: ', { itemInfo, error, jwplayerPlaylist });
     // using bootstrap v3 styling for container for pretty UI
     return (
       <div>
@@ -113,144 +160,46 @@ class DataHydrator extends Component {
         <section className="container">
           <h3>Supported Items</h3>
           <h4>Archive </h4>
-          <table>
-            <thead>
-              <tr>Collection</tr>
-              <tr>Identifier</tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>album_recordings (Older LP)</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-warning"
-                    data-identifier="bestofdollyparto00part"
-                    onClick={this.getItem}
-                  >
-                    bestofdollyparto00part
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>album_recordings (Latest LP)</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-info"
-                    data-identifier="lp_dancing-tonight_freddy-martin-and-his-orchestra"
-                    onClick={this.getItem}
-                  >
-                    lp_dancing-tonight_freddy-martin-and-his-orchestra
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>what_cd</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-success"
-                    data-identifier="cd_beethoven-complete-works-for-string-trio_the-adaskin-string-trio"
-                    onClick={this.getItem}
-                  >
-                    cd_beethoven-complete-works-for-string-trio_the-adaskin-string-trio
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>what_cd (Irregular Photo)</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-success"
-                    data-identifier="wcd_message-in-a-box-th_the-police_flac_lossless_807968"
-                    onClick={this.getItem}
-                  >
-                    wcd_message-in-a-box-th_the-police_flac_lossless_807968
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>acdc (NO PHOTO)</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="lak-JC_Burris-James_Booker"
-                    onClick={this.getItem}
-                  >
-                    lak-JC_Burris-James_Booker
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>what CD compilation - all track artists names show</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623"
-                    onClick={this.getItem}
-                  >
-                  wcd_various-artiststhe-best-of-country-music_flac_lossless_29887623
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>Track names, multiple but same as album artist (should be omitted)</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos"
-                    onClick={this.getItem}
-                  >
-                  lp_emperor-concerto_ludwig-van-beethoven-arthur-rubinstein-bos
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>3 column track list wide view pagination check</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="illegal-art"
-                    onClick={this.getItem}
-                  >
-                  illegal-art
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>Track time display, 60 seconds adds another minute. should display as 10:00</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="wcd_borghild_die-warzau_mp3_320_1648819"
-                    onClick={this.getItem}
-                  >
-                  wcd_borghild_die-warzau_mp3_320_1648819
-                  </button>
-                </td>
-              </tr>
-              <tr>
-                <td>Has 3rd party "Full Album". Clicking on Full Album should highlight full album</td>
-                <td>
-                  <button
-                    type="button"
-                    className="btn btn-lg btn-primary"
-                    data-identifier="cd_aaliyah_aaliyah-static-from-playa-timbaland"
-                    onClick={this.getItem}
-                  >
-                  cd_aaliyah_aaliyah-static-from-playa-timbaland
-                  </button>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <div id="liner-notes-list">
+            <table id="examples">
+              <thead>
+                <tr>
+                  <th scope="col">item actions</th>
+                  <th scope="col">ID</th>
+                  <th scope="col">it's quirks</th>
+                </tr>
+              </thead>
+              <tbody>
+                {
+                items.map((item) => {
+                  const { id, desc } = item;
+                  return (
+                    <tr>
+                      <td>
+                        <button
+                          type="button"
+                          className="btn btn-info"
+                          data-identifier={id}
+                          onClick={this.getItem}
+                        >
+                          Show
+                        </button>
+                        <a className="btn btn-link" href="https://archive.org/details/${id}">Details</a>
+                      </td>
+                      <td>
+                        {id}
+                      </td>
+                      <td>
+                        {desc}
+                      </td>
+                    </tr>
+                  );
+                })
+              }
+              </tbody>
+            </table>
+          </div>
+
         </section>
       </div>
     );

--- a/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
@@ -39,7 +39,7 @@ const archiveDefaultAlbumParser = ({ fileDirectoryPrefix, files }) => {
     const isOriginal = source === 'original';
     const isAudioFile = isValidAudioFile(currentFileName);
     const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
-    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg/g);
+    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg$/g);
     // skip unneeded files
     if (isThumbnail || (!isOriginal && !isAudioFile)) return neededItems;
 

--- a/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-default-album-parser.js
@@ -39,10 +39,11 @@ const archiveDefaultAlbumParser = ({ fileDirectoryPrefix, files }) => {
     const isOriginal = source === 'original';
     const isAudioFile = isValidAudioFile(currentFileName);
     const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
-
+    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg/g);
     // skip unneeded files
-    if (!isOriginal && !isAudioFile) return neededItems;
+    if (isThumbnail || (!isOriginal && !isAudioFile)) return neededItems;
 
+    console.log('*** looking for images ***', { isItemImageFile, isOriginal, currentFileName });
     if (isItemImageFile) {
       itemPhoto = `${fileDirectoryPrefix}${encodeURIComponent(currentFileName)}`;
 
@@ -52,12 +53,12 @@ const archiveDefaultAlbumParser = ({ fileDirectoryPrefix, files }) => {
 
       if (isDesignatedFirstImage) {
         itemPhotoCandidates.designated = itemPhoto;
-      }
-      if (actualFirstImage) {
+      } else if (actualFirstImage) {
         itemPhotoCandidates.actual = itemPhoto;
-      }
-      if (isFormatItemImage) {
+      } else if (isFormatItemImage) {
         itemPhotoCandidates.formattedAsFirst = itemPhoto;
+      } else {
+        itemPhotoCandidates.actual = itemPhoto;
       }
     }
 

--- a/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
@@ -41,23 +41,24 @@ const archiveDerivedAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier 
     const fileToSkip = `${itemIdentifier}.mp3`; // phantom audio file to map to full album
     const isAudioFile = isValidAudioFile(currentFileName);
     const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
+    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg/g);
+
     // skip unneeded files
-    if ((!isOriginal && !isAudioFile) || (fileToSkip === currentFileName)) return neededItems;
+    if (isThumbnail || (!isOriginal && !isAudioFile) || (fileToSkip === currentFileName)) return neededItems;
 
     if (isItemImageFile) {
       itemPhoto = `${fileDirectoryPrefix}${encodeURIComponent(currentFileName)}`;
-
       const isFormatItemImage = !!currentFileName.match(/_itemimage./g); // can be jpg, png
       const isDesignatedFirstImage = !!currentFileName.match(/IMG_00001.jpg/g);
       const actualFirstImage = !!currentFileName.match(/IMG_0001.jpg/g);
       if (isDesignatedFirstImage) {
         itemPhotoCandidates.designated = itemPhoto;
-      }
-      if (actualFirstImage) {
+      } else if (actualFirstImage) {
         itemPhotoCandidates.actual = itemPhoto;
-      }
-      if (isFormatItemImage) {
+      } else if (isFormatItemImage) {
         itemPhotoCandidates.formattedAsFirst = itemPhoto;
+      } else {
+        itemPhotoCandidates.actual = itemPhoto;
       }
     }
 

--- a/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
+++ b/packages/ia-components/components/theatres/with-youtube-spotify/utils/archive-derived-album-parser.js
@@ -41,7 +41,7 @@ const archiveDerivedAlbumParser = ({ fileDirectoryPrefix, files, itemIdentifier 
     const fileToSkip = `${itemIdentifier}.mp3`; // phantom audio file to map to full album
     const isAudioFile = isValidAudioFile(currentFileName);
     const isItemImageFile = isOriginal && isValidImageFile(currentFileName);
-    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg/g);
+    const isThumbnail = !!currentFileName.match(/__ia_thumb.jpg$/g);
 
     // skip unneeded files
     if (isThumbnail || (!isOriginal && !isAudioFile) || (fileToSkip === currentFileName)) return neededItems;


### PR DESCRIPTION
**Description**
Adds safety net to use floating/single image as cover for media window

Demo updates
- use list to draw table
- smol table redesign
- new stub for 78 item w/ 1 image

