### PR TITLE
ia-topnav: Check for a shadowRoot before querying it

### DIFF
--- a/packages/ia-topnav/src/media-slider.js
+++ b/packages/ia-topnav/src/media-slider.js
@@ -27,7 +27,7 @@ class MediaSlider extends LitElement {
   }
 
   shouldUpdate() {
-    const scrollPane = this.shadowRoot.querySelector('.information-menu');
+    const scrollPane = this.shadowRoot ? this.shadowRoot.querySelector('.information-menu') : null;
 
     if (scrollPane) {
       scrollPane.scrollTop = 0;


### PR DESCRIPTION
The `media-slider` component is trying to access the `shadowRoot` before it's ready so now we just skip this update if the `shadowRoot` isn't ready yet.