### PR TITLE
WEBDEV-5525: Direct topnav search to legacy/beta search according to opt-in

### DIFF
--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -29,6 +29,9 @@ class NavSearch extends TrackedElement {
     this.open = false;
     this.openMenu = '';
     this.searchIn = '';
+    this.inSearchBeta = false;
+
+    this.initSearchBetaOptIn();
   }
 
   updated() {
@@ -36,6 +39,14 @@ class NavSearch extends TrackedElement {
       this.shadowRoot.querySelector('[name=query]').focus();
     }
     return true;
+  }
+
+  initSearchBetaOptIn() {
+    try {
+      this.inSearchBeta = JSON.parse(window.localStorage?.getItem('SearchBeta-opt-in'));
+    } catch (err) {
+      // This is fine, as the key may simply not exist
+    }
   }
 
   search(e) {
@@ -74,6 +85,10 @@ class NavSearch extends TrackedElement {
     return this.searchIn ? html`<input type='hidden' name='sin' value='${this.searchIn}' />` : nothing;
   }
 
+  get searchEndpoint() {
+    return this.inSearchBeta ? '/search' : '/search.php';
+  }
+
   render() {
     const searchMenuClass = this.open ? 'flex' : 'search-inactive';
 
@@ -82,7 +97,7 @@ class NavSearch extends TrackedElement {
         <form
           id="nav-search"
           class="highlight"
-          action=${formatUrl('/search.php', this.baseHost)}
+          action=${formatUrl(this.searchEndpoint, this.baseHost)}
           method="get"
           @submit=${this.search}
           data-event-submit-tracking="${this.config.eventCategory}|NavSearchSubmit"

--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -42,11 +42,7 @@ class NavSearch extends TrackedElement {
   }
 
   initSearchBetaOptIn() {
-    try {
-      this.inSearchBeta = JSON.parse(window.localStorage?.getItem('SearchBeta-opt-in'));
-    } catch (err) {
-      // This is fine, as the key may simply not exist
-    }
+    this.inSearchBeta = !!window.localStorage?.getItem('SearchBeta-opt-in');
   }
 
   search(e) {

--- a/packages/ia-topnav/src/search-menu.js
+++ b/packages/ia-topnav/src/search-menu.js
@@ -44,7 +44,7 @@ class SearchMenu extends TrackedElement {
   get searchTypesTemplate() {
     const searchTypes = [
       {
-        label: 'Metadata',
+        label: 'metadata',
         value: '',
         isDefault: true,
       },
@@ -61,7 +61,7 @@ class SearchMenu extends TrackedElement {
         value: 'RADIO'
       },
       {
-        label: 'archived websites',
+        label: 'archived web sites',
         value: 'WEB',
       },
     ].map(({ value, label, isDefault }) => {


### PR DESCRIPTION
**Description**

Updates the ia-topnav component to respect the user's opt-in/opt-out preference for the search beta, ensuring that searches from the topnav's search bar go to the correct search page. Also slightly updates the search option labels to match how they are written on the actual search page widget.

**Technical**

Uses the `SearchBeta-opt-in` localStorage key that gets set upon clicking legacy/beta search links.

**Testing**

- For a user in the search beta segment who has opted in by clicking a "Try the new search beta" link, performing a search from the topnav should direct to the beta search page (`/search`).
- For users who either aren't in the search beta, or haven't yet opted into beta search, performing a search from the topnav should direct to the legacy search page (`/search.php`).
