### PR TITLE
ia-topnav@1.1.19

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Bump `ia-topnav` version 1.1.18 -> 1.1.19, with new beta search opt-in changes.