### PR TITLE
fix for rendertron-ed nav input type-in colors

### DIFF
--- a/packages/ia-topnav/src/styles/ia-topnav.js
+++ b/packages/ia-topnav/src/styles/ia-topnav.js
@@ -58,10 +58,6 @@ export default css`
     font-family: var(--themeFontFamily);
   }
 
-  input {
-    color: var(--grey13);
-  }
-
   primary-nav:focus {
     outline: none !important;
   }

--- a/packages/ia-topnav/src/styles/ia-topnav.js
+++ b/packages/ia-topnav/src/styles/ia-topnav.js
@@ -58,6 +58,10 @@ export default css`
     font-family: var(--themeFontFamily);
   }
 
+  input {
+    color: var(--grey13);
+  }
+
   primary-nav:focus {
     outline: none !important;
   }

--- a/packages/ia-topnav/src/styles/nav-search.js
+++ b/packages/ia-topnav/src/styles/nav-search.js
@@ -1,6 +1,10 @@
 import { css } from 'https://offshoot.ux.archive.org/lit.js';
 
 export default css`
+  input[type="text"] {
+    color: var(--grey13);
+  }
+
   input:focus {
     outline: none;
   }

--- a/packages/ia-topnav/src/styles/save-page-form.js
+++ b/packages/ia-topnav/src/styles/save-page-form.js
@@ -16,6 +16,7 @@ export default css`
     box-sizing: border-box;
     border: 1px solid var(--savePageInputBorder);
     border-radius: .5rem;
+    color: var(--grey13);
   }
 
   input[type="submit"] {


### PR DESCRIPTION
**Description**

> fixes archive.org non-offshoot-served pages nav form typeins from white-on-white

**Technical**

> seems like rendertron-created CSS causes browser defaults of `color:fieldtext` implicitly relied on rule to not work.  so need to get explicit

**Testing**

> IDK.  dont have spoons to push 3 MRs, npm publish, offshoot package.json version, mr, push, and pi web -- so would like to get this thru from bottom up and i'll get more formal if this fix doesnt work (though it should!) 

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
