### PR TITLE
Topnav updates - `--topOffset` with fallbacks, readme prune, ensure displayed `screenname` updates when `username` updates

### DIFF
--- a/packages/ia-topnav/README.md
+++ b/packages/ia-topnav/README.md
@@ -12,6 +12,8 @@ yarn add @internetarchive/ia-topnav
 
 @see [demo.html](demo.html) for the simplest example with all the defaults
 
+`yarn start` => open demo: `http://localhost:8000/demo.html`
+
 It shows a dynamic change of the logged in user name -- and how it will re-paint the menus.
 
 
@@ -119,6 +121,7 @@ yarn install
 ```bash
 yarn start  // start development server and typescript compiler
 ```
+then open demo - http://localhost:8000/demo.html
 
 ## Testing
 
@@ -130,12 +133,6 @@ yarn test
 
 ```bash
 yarn test:bs
-```
-
-## Demoing using storybook
-
-```bash
-yarn storybook
 ```
 
 ## Linting

--- a/packages/ia-topnav/README.md
+++ b/packages/ia-topnav/README.md
@@ -82,6 +82,8 @@ export default IATopNav;
     --savePageSubmitText: var(--white);
     --savePageInputBorder: var(--grey60);
     --savePageErrorText: var(--errorYellow);
+
+    --topOffset: -1500px;
   }
 </style>
 

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -18,10 +18,7 @@
     "format:prettier": "prettier \"**/*.js\" --write --ignore-path .gitignore",
     "lint": "npm run lint:eslint",
     "format": "npm run format:eslint && npm run format:prettier",
-    "test": "ulimit -v unlimited;  web-test-runner  'test/**/*.test.js' --node-resolve --coverage --puppeteer",
-    "site:build": "npm run storybook:build",
-    "storybook": "start-storybook -p 9001",
-    "storybook:build": "build-storybook -o _site -s storybook-static"
+    "test": "ulimit -v unlimited;  web-test-runner  'test/**/*.test.js' --node-resolve --coverage --puppeteer"
   },
   "dependencies": {
     "@internetarchive/ia-wayback-search": "^0.2.3"
@@ -60,6 +57,5 @@
       "eslint-config-prettier"
     ]
   },
-  "prettier": "@open-wc/prettier-config",
-  "gitHead": "5de5e1e871f061f14838886d0bb5de5035e1cafd"
+  "prettier": "@open-wc/prettier-config"
 }

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -85,6 +85,7 @@ export default class IATopNav extends LitElement {
   menuSetup() {
     this.localLinks = this.getAttribute('localLinks') !== 'false' && this.getAttribute('localLinks') !== false;
     this.username = this.getAttribute('username')
+    this.screenName = this.username; // set screenName when username changes to display
     this.waybackPagesArchived = this.getAttribute('waybackPagesArchived') ?? ''
 
     // ensure we update other components that use `baseHost`

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -1,10 +1,6 @@
 import { css } from 'https://offshoot.ux.archive.org/lit.js';
 
 export default css`
-  :host {
-    --topOffset: -1500px;
-  }
-
   .nav-container {
     position: relative;
   }
@@ -23,7 +19,7 @@ export default css`
 
   .initial,
   .closed {
-    top: var(--topOffset);
+    top: var(--topOffset, -1500px);
   }
 
   .closed {

--- a/packages/ia-topnav/src/styles/search-menu.js
+++ b/packages/ia-topnav/src/styles/search-menu.js
@@ -1,10 +1,6 @@
 import { css } from 'https://offshoot.ux.archive.org/lit.js';
 
 export default css`
-  :host {
-    --topOffset: -800px;
-  }
-
   .menu-wrapper {
     position: relative;
   }
@@ -32,8 +28,7 @@ export default css`
   }
   .initial,
   .closed {
-    top: var(--topOffset);
-    display: none;
+    top: var(--topOffset, -1500px);
   }
   .closed {
     transition-duration: 0.2s;


### PR DESCRIPTION
**Some Fixes **
- `--topOffset` now has fallback values
  - this helps us remove `display: none;` from primary nav functionality
- ensure `this.screenName` updates when `this.username` updates - so that the nav can dynamically update the displayed screen name.
- readme updates
- package.json prune - remove storybook, remove lerna artifact `gitHead`