### PR TITLE
Lazy load topnav images

### DIFF
--- a/packages/ia-topnav/src/media-subnav.js
+++ b/packages/ia-topnav/src/media-subnav.js
@@ -49,7 +49,7 @@ class MediaSubnav extends TrackedElement {
   get iconLinks() {
     return this.links.iconLinks.map(link => (
       html`
-        <a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}"><img src="${link.icon}" />${link.title}</a>
+        <a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.analyticsEvent(link.title)}"><img src="${link.icon}" loading="lazy" />${link.title}</a>
       `
     ));
   }


### PR DESCRIPTION
**Description**

Remove 10 network requests of images we might not need:

![image](https://user-images.githubusercontent.com/6251786/211916210-7d8e1abd-3670-494f-a707-ade94d048965.png)


**Technical**

> What should be noted about the implementation?

**Testing**

I haven't tested this... should hopefully do the trick, but at worst it'll just be the same as it was before.

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
