### PR TITLE
[ia-topnav] WEBDEV-5768 Override search beta opt-in status when current user in launch bucket

### DIFF
--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -42,7 +42,8 @@ class NavSearch extends TrackedElement {
   }
 
   initSearchBetaOptIn() {
-    this.inSearchBeta = !!window.localStorage?.getItem('SearchBeta-opt-in');
+    this.inSearchBeta = !!window.localStorage?.getItem('SearchBeta-opt-in') ||
+      !!window.localStorage?.getItem('SearchBeta-launched');
   }
 
   search(e) {


### PR DESCRIPTION
**Description**
Updates the `ia-topnav` search bar endpoint to reflect whether the user is included in the launch of the new search, overriding their previous beta opt-in preference. If they are in the launched variant, searches will target the new search page instead of the old one.

**Technical**
Relies on the `SearchBeta-launched` localStorage key being set by offshoot.

**Testing**
> What steps should the reviewer take to verify this PR resolves the issue?

**Evidence**
> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
