### PR TITLE
Work around Safari bug preventing activity indicator from spinning

### DIFF
--- a/packages/ia-activity-indicator/src/ia-activity-indicator.js
+++ b/packages/ia-activity-indicator/src/ia-activity-indicator.js
@@ -144,6 +144,10 @@ class IAActivityIndicator extends LitElement {
         0% {
           transform: rotate(-360deg);
         }
+        100% {
+          /* This frame is supposed to be inferred, but Safari doesn't rotate it unless we're explicit */
+          transform: rotate(0deg);
+        }
       }
 
       @keyframes dot {


### PR DESCRIPTION
**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.

Fixes a bug where the activity indicator doesn't spin on Safari.

**Technical**

> What should be noted about the implementation?

For some reason Safari doesn't infer the end state of `@keyframes` animations when not provided, while all other major browsers do (in accordance with spec). So we need to provide the end frame explicitly for Safari to rotate the spinner.

**Testing**

> What steps should the reviewer take to verify this PR resolves the issue?

Run the demo app and open in Safari. Verify that the activity indicator spins continuously. (Current behavior is that it doesn't spin at all)

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
