### PR TITLE
[ia-topnav] WEBDEV-6272 Add admin items to user menu

### DIFF
--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -19,9 +19,10 @@ export const defaultTopNavConfig = {
  *                                        older/less accurate version.  Otherwise,
  *                                        @see waybackPagesArchivedFN() (below) (please cache it)
  *                                        for a live service accurate count result.
+ * @param { string } itemIdentifier The current item being viewed, to populate admin menu items
  * @returns { object }
  */
-export function buildTopNavMenus(userid = '___USERID___', localLinks = true, waybackPagesArchived = '') {
+export function buildTopNavMenus(userid = '___USERID___', localLinks = true, waybackPagesArchived = '', itemIdentifier = '') {
   if (waybackPagesArchived)
     defaultTopNavConfig.waybackPagesArchived = waybackPagesArchived // update to more accurate val
 
@@ -558,6 +559,61 @@ export function buildTopNavMenus(userid = '___USERID___', localLinks = true, way
         url: `${prefix}/account/logout`,
         title: 'Log out',
         analyticsEvent: 'UserLogOut',
+      },
+    ],
+    userAdmin: [
+      {
+        title: 'ADMINS:',
+      },
+      {
+        title: 'item:',
+      },
+      {
+        url: `${prefix}/editxml/${itemIdentifier}`,
+        title: 'edit xml',
+        analyticsEvent: 'AdminUserEditXML',
+      },
+      {
+        url: `${prefix}/edit.php?redir=1&identifier=${itemIdentifier}`,
+        title: 'edit files',
+        analyticsEvent: 'AdminUserEditFiles',
+      },
+      {
+        url: `${prefix}/download/${itemIdentifier}/`,
+        title: 'download',
+        analyticsEvent: 'AdminUserDownload',
+      },
+      {
+        url: `${prefix}/metadata/${itemIdentifier}/`,
+        title: 'metadata',
+        analyticsEvent: 'AdminUserMetadata',
+      },
+      {
+        url: `https://catalogd.archive.org/history/${itemIdentifier}`,
+        title: 'history',
+        analyticsEvent: 'AdminUserHistory',
+      },
+      {
+        url: `${prefix}/manage/${itemIdentifier}`,
+        title: 'manage',
+        analyticsEvent: 'AdminUserManager',
+      },
+      {
+        url: `${prefix}/manage/${itemIdentifier}#make_dark`,
+        title: 'curate',
+        analyticsEvent: 'AdminUserCurate',
+      },
+      {
+        url: `${prefix}/manage/${itemIdentifier}#modify_xml`,
+        title: 'modify xml',
+        analyticsEvent: 'AdminUserModifyXML',
+      },
+    ],
+    userAdminFlags: [
+      {
+        url: `${prefix}/services/flags/admin.php?identifier=${itemIdentifier}`,
+        title: 'manage flags',
+        analyticsEvent: 'AdminUserManageFlags',
       },
     ],
     signedOut: [

--- a/packages/ia-topnav/src/ia-topnav.js
+++ b/packages/ia-topnav/src/ia-topnav.js
@@ -29,6 +29,10 @@ export default class IATopNav extends LitElement {
       // the media base host is the base host for images, such as the profile picture
       // which may not be hosted locally
       mediaBaseHost: { type: String },
+      /** Whether the user has privs to edit all items */
+      admin: { type: Boolean },
+      /** Whether the user has privs to manage item flags */
+      canManageFlags: { type: Boolean },
       config: {
         type: Object,
         converter(value) {
@@ -36,6 +40,8 @@ export default class IATopNav extends LitElement {
         },
       },
       hideSearch: { type: Boolean },
+      /** Identifier for the item or collection currently being viewed */
+      itemIdentifier: { type: String },
       mediaSliderOpen: { type: Boolean },
       menus: {
         type: Object,
@@ -75,7 +81,7 @@ export default class IATopNav extends LitElement {
 
   updated(props) {
     if (props.has('username') || props.has('localLinks') || props.has('baseHost') ||
-        props.has('waybackPagesArchived')) {
+        props.has('waybackPagesArchived') || props.has('itemIdentifier')) {
       this.menuSetup();
     }
   }
@@ -90,7 +96,7 @@ export default class IATopNav extends LitElement {
     this.baseHost = this.localLinks ? '' : 'https://archive.org';
 
     // re/build the nav
-    this.menus = buildTopNavMenus(this.username, this.localLinks, this.waybackPagesArchived);
+    this.menus = buildTopNavMenus(this.username, this.localLinks, this.waybackPagesArchived, this.itemIdentifier);
   }
 
   menuToggled({ detail }) {
@@ -207,8 +213,22 @@ export default class IATopNav extends LitElement {
     return this.menus.signedOut;
   }
 
+  /**
+   * Most users just get the basic menu items.
+   * For users with `/items` priv, additional admin menu items are included too.
+   * Having the `/flags` priv adds a further admin item for managing flags.
+   */
   get userMenuItems() {
-    return this.menus.user;
+    const basicItems = this.menus.user;
+    
+    let adminItems = this.menus.userAdmin;
+    if (this.canManageFlags) {
+      adminItems = adminItems.concat(this.menus.userAdminFlags);
+    }
+
+    return this.admin
+      ? [basicItems, adminItems]
+      : basicItems;
   }
 
   get desktopSubnavMenuItems() {
@@ -226,6 +246,10 @@ export default class IATopNav extends LitElement {
           <slot name="opt-sec-logo-mobile" slot="opt-sec-logo-mobile"></slot>
         `
       : nothing;
+  }
+
+  get separatorTemplate() {
+    return html`<li class="divider" role="presentation"></li>`;
   }
 
   render() {


### PR DESCRIPTION
**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.

This PR adds admin items to the user menu, which are only displayed when the user has certain edit privileges. This is migrating functionality that exists on petabox-rendered pages, but currently has no Offshoot equivalent.

**Technical**

> What should be noted about the implementation?

The admin pages being linked are themselves separately gated behind the appropriate privs -- this PR only impacts the visibility of those links in the topnav.

**Testing**

> What steps should the reviewer take to verify this PR resolves the issue?

As a user with privs to edit arbitrary items, visit any collection page and open your user menu in the topnav. There should be an admin section after the usual user items, with various links to admin functionality.

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.

(TBD)
