### PR TITLE
ia-topnav@1.1.27

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Bump `<ia-topnav>` version to 1.1.27. Version includes admin items in user menu.