### PR TITLE
wayback home is moving from petabox to web.archive.org

### DIFF
--- a/packages/ia-topnav/src/media-menu.js
+++ b/packages/ia-topnav/src/media-menu.js
@@ -8,7 +8,7 @@ const menuSelection = [
   {
     icon: 'web',
     menu: 'web',
-    href: '/web/',
+    href: 'https://web.archive.org',
     label: 'Wayback Machine',
   },
   {

--- a/packages/ia-topnav/src/wayback-slider.js
+++ b/packages/ia-topnav/src/wayback-slider.js
@@ -56,7 +56,6 @@ class WaybackSlider extends TrackedElement {
     return html`
       <div class="grid">
         <wayback-search
-          .baseHost=${this.baseHost}
           waybackPagesArchived=${this.config.waybackPagesArchived}
           .queryHandler=${queryHandler}></wayback-search>
         <div class="link-lists">

--- a/packages/ia-wayback-search/README.md
+++ b/packages/ia-wayback-search/README.md
@@ -4,7 +4,6 @@
 
 ```html
 <ia-wayback-search
-  .baseHost=${'archive.org'}
   waybackPagesArchived="32 trillion pages"
 ></ia-wayback-search>
 ```
@@ -20,7 +19,6 @@ document.querySelector('ia-wayback-search').locationHandler = {
 ### Properties:
 
 ```js
-baseHost: { type: String }, // host used to build the logo href attribute
 locationHandler: { type: Function }, // function called when form submitted. @param url string
 waybackPagesArchived: { type: String }, // Pages archived message, e.g. "428 billion pages"
 ```

--- a/packages/ia-wayback-search/index.html
+++ b/packages/ia-wayback-search/index.html
@@ -39,7 +39,6 @@
 
       render(html`<ia-wayback-search
         waybackPagesArchived="32 trillion pages"
-        .baseHost=${'https://archive.org'}
         .queryHandler=${queryHandler}
       ></ia-wayback-search>`, document.getElementById('root'));
 

--- a/packages/ia-wayback-search/src/ia-wayback-search.js
+++ b/packages/ia-wayback-search/src/ia-wayback-search.js
@@ -10,7 +10,6 @@ class WaybackSearch extends LitElement {
 
   static get properties() {
     return {
-      baseHost: { type: String },
       queryHandler: { type: Object },
       waybackPagesArchived: { type: String },
     };
@@ -63,7 +62,7 @@ class WaybackSearch extends LitElement {
           <a
             @click=${this.emitWaybackMachineLogoLinkClicked}
             data-event-click-tracking="TopNav|WaybackMachineLogoLink"
-            href=${`${this.baseHost}/web/`}
+            href="https://web.archive.org"
             >${logo}</a>
           <label for="url">Search the Wayback Machine</label>
           <div class="search-field">

--- a/packages/ia-wayback-search/test/wayback-search.test.js
+++ b/packages/ia-wayback-search/test/wayback-search.test.js
@@ -10,10 +10,9 @@ import '../src/ia-wayback-search.js';
 
 const component = (properties = {
   waybackPagesArchived: '32 trillion pages'
-}, baseHost = 'archive.org') => (
+}) => (
   html`
     <ia-wayback-search
-      .baseHost=${baseHost}
       waybackPagesArchived=${properties.waybackPagesArchived}
     ></ia-wayback-search>
   `


### PR DESCRIPTION
Update WB link

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.
relates to https://webarchive.jira.com/browse/WEBDEV-6584

> What should be noted about the implementation?
very simple

> What steps should the reviewer take to verify this PR resolves the issue?
check the nav

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
wayback links in the nav should be web.archive.org 
