### PR TITLE
[ia-topnav] WEBDEV-6698 Add user menu callout on My Lists item

### DIFF
--- a/packages/ia-topnav/index.d.ts
+++ b/packages/ia-topnav/index.d.ts
@@ -17,6 +17,11 @@ export interface IATopNavConfig {
    * Array of strings representing the values of options that should be hidden from search options
    */
   hiddenSearchOptions: [];
+
+  /**
+   * Map from dropdown item ids to any callout text that should be applied beside them
+   */
+  callouts?: Record<string, string>;
 }
 
 export interface IATopNavLink {

--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -531,7 +531,7 @@ export function buildTopNavMenus(userid = '___USERID___', localLinks = true, way
         analyticsEvent: 'UserLibrary',
       },
       {
-        url: `${prefix}/details/@${userid}?tab=loans`,
+        url: `${prefix}/details/@${userid}/loans`,
         title: 'My loans',
         analyticsEvent: 'UserLoans',
       },
@@ -539,6 +539,16 @@ export function buildTopNavMenus(userid = '___USERID___', localLinks = true, way
         url: `${prefix}/details/fav-${userid}`,
         title: 'My favorites',
         analyticsEvent: 'UserFavorites',
+      },
+      {
+        url: `${prefix}/details/@${userid}/lists`,
+        title: 'My lists',
+        analyticsEvent: 'UserLists',
+      },
+      {
+        url: `${prefix}/details/@${userid}/collections`,
+        title: 'My collections',
+        analyticsEvent: 'UserCollections',
       },
       {
         url: `${prefix}/details/@${userid}/web-archive`,

--- a/packages/ia-topnav/src/dropdown-menu.js
+++ b/packages/ia-topnav/src/dropdown-menu.js
@@ -59,7 +59,7 @@ class DropdownMenu extends TrackedElement {
       data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}"
       aria-label=${`New feature: ${link.title}`}>
         ${link.title}
-        ${calloutText ? html`<span class="callout">${calloutText}</span>` : nothing}
+        ${calloutText ? html`<span class="callout" aria-hidden="true">${calloutText}</span>` : nothing}
     </a>`;
   }
 

--- a/packages/ia-topnav/src/dropdown-menu.js
+++ b/packages/ia-topnav/src/dropdown-menu.js
@@ -52,7 +52,15 @@ class DropdownMenu extends TrackedElement {
   }
 
   dropdownLink(link) {
-    return html`<a href="${formatUrl(link.url, this.baseHost)}" @click=${this.trackClick} data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}">${link.title}</a>`;
+    const calloutText = this.config.callouts?.[link.title];
+    return html`<a
+      href="${formatUrl(link.url, this.baseHost)}"
+      @click=${this.trackClick}
+      data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}"
+      aria-label=${`New feature: ${link.title}`}>
+        ${link.title}
+        ${calloutText ? html`<span class="callout">${calloutText}</span>` : nothing}
+    </a>`;
   }
 
   static dropdownText(item) {

--- a/packages/ia-topnav/src/styles/dropdown-menu.js
+++ b/packages/ia-topnav/src/styles/dropdown-menu.js
@@ -67,6 +67,17 @@ export default css`
     color: var(--dropdownMenuInfoItem);
   }
 
+  .callout {
+    position: absolute;
+    margin-left: 10px;
+    padding: 0 5px;
+    border-radius: 2px;
+    background: #fee257;
+    color: #2c2c2c;
+    font-size: 1.4rem;
+    font-weight: bold;
+  }
+
   @media (min-width: 890px) {
     nav {
       overflow: visible;


### PR DESCRIPTION
**Description**

> What does this PR achieve? Is it a feature/hotfix/refactor? Does it close an Issue? If so, use `Closes #`.

Adds a "NEW" callout bubble beside the new "My lists" item on the user menu of the topnav.

**Technical**

> What should be noted about the implementation?

Adds a new config value to the topnav, `callouts`, for the parent to specify any callouts that should appear on menu items. This allows Offshoot's app root to specify whether or not the callout should be shown, for instance.

**Testing**

> What steps should the reviewer take to verify this PR resolves the issue?

Load the Offshoot review app that includes these topnav changes with the appropriate AB variant override set, and open the user menu. The "My lists" item should be listed, with a "NEW" badge beside it.

**Evidence**

> If this PR touches UI, please post evidence (screenshot) of it behaving correctly.
