### PR TITLE
WEBDEV-6727 Only include 'New feature' label when callout is present

### DIFF
--- a/packages/ia-topnav/src/dropdown-menu.js
+++ b/packages/ia-topnav/src/dropdown-menu.js
@@ -57,7 +57,7 @@ class DropdownMenu extends TrackedElement {
       href="${formatUrl(link.url, this.baseHost)}"
       @click=${this.trackClick}
       data-event-click-tracking="${this.config.eventCategory}|Nav${link.analyticsEvent}"
-      aria-label=${`New feature: ${link.title}`}>
+      aria-label=${calloutText ? `New feature: ${link.title}` : nothing}>
         ${link.title}
         ${calloutText ? html`<span class="callout" aria-hidden="true">${calloutText}</span>` : nothing}
     </a>`;


### PR DESCRIPTION
Currently the `aria-label` for callouts is being erroneously applied to every item in the user menu. This PR adds the intended condition so that it only appears on called-out items.