### PR TITLE
ia-topnav bump to 1.1.37

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Version includes fixes for search menu dropdown should dismiss when click outside:
https://webarchive.jira.com/browse/WEBDEV-6739