### PR TITLE
[ia-topnav] WEBDEV-6909 Remove old references to search.php (now /search) and obsolete beta flag

### DIFF
--- a/packages/ia-topnav/src/nav-search.js
+++ b/packages/ia-topnav/src/nav-search.js
@@ -29,9 +29,6 @@ class NavSearch extends TrackedElement {
     this.open = false;
     this.openMenu = '';
     this.searchIn = '';
-    this.inSearchBeta = false;
-
-    this.initSearchBetaOptIn();
   }
 
   updated() {
@@ -39,11 +36,6 @@ class NavSearch extends TrackedElement {
       this.shadowRoot.querySelector('[name=query]').focus();
     }
     return true;
-  }
-
-  initSearchBetaOptIn() {
-    this.inSearchBeta = !!window.localStorage?.getItem('SearchBeta-opt-in') ||
-      !!window.localStorage?.getItem('SearchBeta-launched');
   }
 
   search(e) {
@@ -83,7 +75,7 @@ class NavSearch extends TrackedElement {
   }
 
   get searchEndpoint() {
-    return this.inSearchBeta ? '/search' : '/search.php';
+    return '/search';
   }
 
   render() {


### PR DESCRIPTION
Converts old references to the `/search.php` endpoint to `/search`, so that searches are sent directly to the newer page without an extra redirect. Also eliminates a related obsolete flag for the search beta opt-in, which is no longer required.