### PR TITLE
Bump ia-topnav to v1.3.6

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Version includes fixes to search endpoint for inclusion of radio searches within Offshoot.