### PR TITLE
Bump ia-userlist-settings to v1.0.21

### DIFF
--- a/packages/ia-userlist-settings/package.json
+++ b/packages/ia-userlist-settings/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump to prep for federated search carousel merge.
