### PR TITLE
WEBDEV-7139 Switch top nav URLs to new about pages

### DIFF
--- a/packages/ia-topnav/src/data/menus.js
+++ b/packages/ia-topnav/src/data/menus.js
@@ -170,19 +170,19 @@ export function buildTopNavMenus(userid = '___USERID___', localLinks = true, way
       },
       {
         title: 'Contact',
-        url: `${prefix}/about/contact.php`,
+        url: `${prefix}/about/contact`,
       },
       {
         title: 'Jobs',
-        url: `${prefix}/about/jobs.php`,
+        url: `${prefix}/about/jobs`,
       },
       {
         title: 'Volunteer',
-        url: `${prefix}/about/volunteerpositions.php`,
+        url: `${prefix}/about/volunteer-positions`,
       },
       {
         title: 'People',
-        url: `${prefix}/about/bios.php`,
+        url: `${prefix}/about/bios`,
       },
     ],
     software: {


### PR DESCRIPTION
**Description**
Switches the top-nav URLs to `/about` pages to point to the new links created for the Offshoot versions of these pages, i.e. `/jobs.php` > `/jobs`, `/volunteerpositions.php` > `/volunteer-positions`

