### PR TITLE
topnav v1.3.8

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "1.3.6",
+  "version": "1.3.8",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
Updates topnav to new version to integrate changes from [WEBDEV-7139](https://webarchive.jira.com/browse/WEBDEV-7139) -- links now point to new `/about/` URLs. Skips from `1.3.6` > `1.3.8` because `1.3.7` had already been npm-published and used by Offshoot, just not merged.

[WEBDEV-7139]: https://webarchive.jira.com/browse/WEBDEV-7139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ