### PR TITLE
WEBDEV-7504 Update ia-activity-indicator to version 1.0.0

### DIFF
--- a/packages/ia-activity-indicator/package-lock.json
+++ b/packages/ia-activity-indicator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-activity-indicator",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-activity-indicator",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "lit": "^2.8.0"

--- a/packages/ia-activity-indicator/package.json
+++ b/packages/ia-activity-indicator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-activity-indicator",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Webcomponent ia-activity-indicator following open-wc recommendations",
   "author": "ia-activity-indicator",
   "license": "MIT",


### PR DESCRIPTION
Simple version update to our new standard `1.0.0` starting point
