### PR TITLE
[ia-userlist-settings] WEBDEV-7515 Add service method for bulk list member removal

### DIFF
--- a/packages/ia-userlist-settings/src/user-lists-service/user-lists-service-interface.ts
+++ b/packages/ia-userlist-settings/src/user-lists-service/user-lists-service-interface.ts
@@ -113,14 +113,24 @@ export interface UserListsServiceInterface {
   ): Promise<Result<UserListMember, UserListsError>>;
 
   /**
-   * Removes the given member/members from the given User List. You may pass comma separated members.
+   * Removes the given member from the given User List.
    * @param listId The id of the list to remove a member from.
    * @param memberId The id of the member within the specified list that should be removed.
-   * @returns A Result object containing the remaining UserListMember if successful,
-   * or an error otherwise.
+   * @returns A Result object containing the updated UserList if successful, or an error otherwise.
    */
   removeMemberFromList(
     listId: string,
     memberId: string,
+  ): Promise<Result<UserList, UserListsError>>;
+
+  /**
+   * Removes all of the given members from the given User List.
+   * @param listId The id of the list to remove a member from.
+   * @param memberIds An array of member IDs within the specified list that should be removed.
+   * @returns A Result object containing the updated UserList if successful, or an error otherwise.
+   */
+  removeBulkMembersFromList(
+    listId: string,
+    memberIds: string[],
   ): Promise<Result<UserList, UserListsError>>;
 }

--- a/packages/ia-userlist-settings/src/user-lists-service/user-lists-service.ts
+++ b/packages/ia-userlist-settings/src/user-lists-service/user-lists-service.ts
@@ -238,6 +238,19 @@ export class UserListsService implements UserListsServiceInterface {
     );
   }
 
+  /** @inheritdoc */
+  async removeBulkMembersFromList(
+    listId: string,
+    memberIds: string[],
+  ): Promise<Result<UserList, UserListsError>> {
+    return this.fetchEndpoint<UserList>(
+      `${this.baseUrl}/services/users/me/lists/${listId}/members`,
+      'PATCH',
+      JSON.stringify({ remove: memberIds }),
+      { 'Content-Type': JSON_CONTENT_TYPE },
+    );
+  }
+
   /** Construct a UserListsError with the given reason and underlying error cause */
   private static getErrorResult(reason: UserListsErrorReason, err?: unknown) {
     return new UserListsError(reason, UserListsService.getErrorMessage(err), {


### PR DESCRIPTION
Currently, the ability to remove multiple list members in one request is allowed by passing a comma-separated string of member IDs or item identifiers into the `removeMemberFromList` function, thereby firing a `DELETE` request with the comma-separated string in the resource path. This is not particularly robust, suffering from some underlying ambiguity issues and resource paths that do not really adhere to the RESTful paradigm that we have aimed to follow.

This PR adds a new method `removeBulkMembersFromList` to properly handle the bulk removal case with a `PATCH` request against the list members, with a JSON body describing which member IDs should be removed. This matches changes that are being made to the corresponding service endpoint to handle these requests correctly.