### PR TITLE
WEBDEV-8238 Remove /account from signup links

### DIFF
--- a/packages/ia-topnav/src/data/menus.ts
+++ b/packages/ia-topnav/src/data/menus.ts
@@ -638,7 +638,7 @@ export function buildTopNavMenus(
     ],
     signedOut: [
       {
-        url: `${baseHost}/account/signup`,
+        url: `${baseHost}/signup`,
         title: 'Sign up for free',
         analyticsEvent: 'AvatarMenu-Signup',
       },

--- a/packages/ia-topnav/src/login-button.ts
+++ b/packages/ia-topnav/src/login-button.ts
@@ -21,7 +21,7 @@ export class LoginButton extends TrackedElement {
   }
 
   get signupPath() {
-    return formatUrl('/account/signup', this.baseHost);
+    return formatUrl('/signup', this.baseHost);
   }
 
   get loginPath() {


### PR DESCRIPTION
Switches all signup links to `/signup` from `/account/signup` to prepare them to point to the new version of the page without redirects once it is released.