### PR TITLE
WEBDEV-8384: Declare ia-activity-indicator lit ^2.8.0 || ^3.3.2 dual range

### DIFF
--- a/packages/ia-activity-indicator/package-lock.json
+++ b/packages/ia-activity-indicator/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "lit": "^2.8.0"
+        "lit": "^2.8.0 || ^3.3.2"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -967,18 +967,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -3427,14 +3415,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -10889,18 +10869,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -11221,27 +11189,6 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/text-decoder": {
@@ -12635,18 +12582,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true
-    },
-    "@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
@@ -14350,14 +14285,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "bytes": {
       "version": "3.1.2",
@@ -19424,18 +19351,6 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -19653,20 +19568,6 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
       }
     },
     "text-decoder": {

--- a/packages/ia-activity-indicator/package.json
+++ b/packages/ia-activity-indicator/package.json
@@ -22,7 +22,7 @@
     "ghpages:generate": "gh-pages -t -d ghpages -m \"Build for $(git log --pretty=format:\"%h %an %ai %s\" -n1) [skip ci]\""
   },
   "dependencies": {
-    "lit": "^2.8.0"
+    "lit": "^2.8.0 || ^3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
## Summary

- One-line dep change: `lit: "^2.8.0"` → `"^2.8.0 || ^3.3.2"` for `@internetarchive/ia-activity-indicator`.
- Mirrors the dual-range pattern already established by `modal-manager@2.0.5`, `icon-close@1.4.1`, `icon-user@1.4.1`, `icon-info@1.4.1`, and `iaux-book-actions` ([PR #89](https://github.com/internetarchive/iaux-book-actions/pull/89)).
- After publishing this, `iaux-book-actions`'s runtime tree will collapse to a **single Lit 3** with no separate Lit 2 subtrees. ia-activity-indicator was the last holdout.
- Tracks [WEBDEV-8384](https://webarchive.jira.com/browse/WEBDEV-8384) under the [WEBDEV-8364](https://webarchive.jira.com/browse/WEBDEV-8364) Lit migration umbrella.

## Diff

```diff
   "dependencies": {
-    "lit": "^2.8.0"
+    "lit": "^2.8.0 || ^3.3.2"
   },
```

(`package-lock.json` also updated; the additional removals are stale optional-peer entries unrelated to this change.)

## Test plan

- [x] `npm install` clean
- [x] `npm test` — **4/4 tests pass** under the package's existing test stack (`@open-wc/testing@4`, `@web/test-runner@0.19`)
- [x] `npm run lint` passes (only the unrelated `jsxBracketSameLine deprecated` warning from prettier config)
- [x] Component uses standard Lit APIs only — no Lit-3 incompatibilities
- [ ] Reviewer: confirm CI is green
- [ ] Maintainer: bump version and publish (current source is at `1.0.0`, npm latest is `0.0.6`)

## Why this is needed

In `iaux-book-actions`'s tree, after the recent Lit migration ([WEBDEV-8373](https://webarchive.jira.com/browse/WEBDEV-8373) / [WEBDEV-8374](https://webarchive.jira.com/browse/WEBDEV-8374) / [WEBDEV-8382](https://webarchive.jira.com/browse/WEBDEV-8382) + the icon-close/icon-user/icon-info 1.4.1 republishes), `ia-activity-indicator` is the only remaining package forcing a separate Lit 2 subtree:

```
@internetarchive/ia-book-actions@1.4.1
├─ @internetarchive/icon-info@1.4.1            → lit@3.3.2 deduped ✓
├─ @internetarchive/modal-manager@2.0.5
│  ├─ @internetarchive/ia-activity-indicator   → lit@2.8.0 ← holdout
│  ├─ @internetarchive/icon-close@1.4.1        → lit@3.3.2 deduped ✓
│  └─ @internetarchive/icon-user@1.4.1         → lit@3.3.2 deduped ✓
└─ lit@3.3.2
```

After this PR + a publish, that branch collapses cleanly to a single Lit 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8384]: https://webarchive.jira.com/browse/WEBDEV-8384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8364]: https://webarchive.jira.com/browse/WEBDEV-8364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8373]: https://webarchive.jira.com/browse/WEBDEV-8373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ