### PR TITLE
WEBDEV-8530: Update topnav Favorites link to user profile Favorites tab

### DIFF
--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/ia-topnav/src/data/menus.ts
+++ b/packages/ia-topnav/src/data/menus.ts
@@ -544,7 +544,7 @@ export function buildTopNavMenus(
         analyticsEvent: 'UserLoans',
       },
       {
-        url: `${baseHost}/details/fav-${userid}`,
+        url: `${baseHost}/details/@${userid}/favorites`,
         title: 'My favorites',
         analyticsEvent: 'UserFavorites',
       },


### PR DESCRIPTION
## Summary
- Updates the \"My favorites\" link in the topnav profile menu from \`/details/fav-{userid}\` to \`/details/@{userid}/favorites\`
- This points users to the Favorites tab on the user profile page instead of the old \`fav-\` collection

## Test plan
- [ ] Log in to archive.org and open the topnav profile dropdown
- [ ] Verify \"My favorites\" links to \`/details/@{username}/favorites\`
- [ ] Confirm the Favorites tab loads correctly on the user profile page

JIRA: https://webarchive.jira.com/browse/WEBDEV-8530

🤖 Generated with [Claude Code](https://claude.com/claude-code)