### PR TITLE
[ia-topnav] WEBDEV-8660 Use shared constant for mobile breakpoint value

### DIFF
--- a/packages/ia-topnav/index.ts
+++ b/packages/ia-topnav/index.ts
@@ -1,3 +1,3 @@
-import { IATopNav } from './src/ia-topnav';
+export { IATopNav } from './src/ia-topnav';
 
-export { IATopNav };
+export { TOPNAV_MOBILE_BREAKPOINT } from './src/models';

--- a/packages/ia-topnav/src/models.ts
+++ b/packages/ia-topnav/src/models.ts
@@ -1,3 +1,13 @@
+/**
+ * The pixel width at which ia-topnav switches from mobile to desktop layout.
+ * Desktop styles apply at `min-width: TOPNAV_MOBILE_BREAKPOINT px`.
+ * Mobile styles apply at `max-width: (TOPNAV_MOBILE_BREAKPOINT - 1) px`.
+ *
+ * Exported so that host applications can derive their own media queries from
+ * this value rather than hard-coding it independently.
+ */
+export const TOPNAV_MOBILE_BREAKPOINT = 890;
+
 export interface IATopNavConfig {
   /**
    * Google Analytics event category

--- a/packages/ia-topnav/src/styles/base.ts
+++ b/packages/ia-topnav/src/styles/base.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export const subnavListCSS = css`
   h4 {
@@ -20,7 +21,7 @@ export const subnavListCSS = css`
     padding-top: 1.5rem;
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     h4 {
       margin: 0 0 1rem 0;
       font-weight: 100;

--- a/packages/ia-topnav/src/styles/dropdown-menu.ts
+++ b/packages/ia-topnav/src/styles/dropdown-menu.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   .nav-container {
@@ -90,7 +91,7 @@ export default css`
     width: 1.4rem;
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     nav {
       display: flex;
       overflow: visible;

--- a/packages/ia-topnav/src/styles/ia-topnav.ts
+++ b/packages/ia-topnav/src/styles/ia-topnav.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   :host {
@@ -77,7 +78,7 @@ export default css`
     z-index: 4;
   }
 
-  @media (max-width: 889px) {
+  @media (max-width: ${TOPNAV_MOBILE_BREAKPOINT - 1}px) {
     desktop-subnav {
       display: none;
     }

--- a/packages/ia-topnav/src/styles/login-button.ts
+++ b/packages/ia-topnav/src/styles/login-button.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   .logged-out-menu {
@@ -61,7 +62,7 @@ export default css`
     outline-offset: inherit !important;
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     .logged-out-toolbar {
       padding: 1rem 0.5rem;
       vertical-align: middle;

--- a/packages/ia-topnav/src/styles/media-button.ts
+++ b/packages/ia-topnav/src/styles/media-button.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   a {
@@ -64,7 +65,7 @@ export default css`
     fill: #f00;
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     .menu-item {
       width: auto;
       height: 5rem;

--- a/packages/ia-topnav/src/styles/media-menu.ts
+++ b/packages/ia-topnav/src/styles/media-menu.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   :host {
@@ -22,7 +23,7 @@ export default css`
   }
 
   /* Mobile view styles */
-  @media (max-width: 889px) {
+  @media (max-width: ${TOPNAV_MOBILE_BREAKPOINT - 1}px) {
     .media-menu-inner {
       position: absolute;
       width: 100%;
@@ -50,7 +51,7 @@ export default css`
   }
 
   /* Desktop view styles */
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     .media-menu-inner {
       display: block;
       position: static;

--- a/packages/ia-topnav/src/styles/media-slider.ts
+++ b/packages/ia-topnav/src/styles/media-slider.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   .media-slider-container {
@@ -40,7 +41,7 @@ export default css`
     padding: 1rem;
   }
 
-  @media (max-width: 889px) {
+  @media (max-width: ${TOPNAV_MOBILE_BREAKPOINT - 1}px) {
     .overflow-clip.open {
       display: block;
       height: 35.8rem;
@@ -49,7 +50,7 @@ export default css`
     }
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     .overflow-clip {
       display: block;
     }

--- a/packages/ia-topnav/src/styles/media-subnav.ts
+++ b/packages/ia-topnav/src/styles/media-subnav.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 import { subnavListCSS } from './base';
 
 export default [
@@ -45,7 +46,7 @@ export default [
       display: none;
     }
 
-    @media (min-width: 890px) {
+    @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
       :host {
         display: -ms-grid;
         display: grid;

--- a/packages/ia-topnav/src/styles/primary-nav.ts
+++ b/packages/ia-topnav/src/styles/primary-nav.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   button:focus,
@@ -211,7 +212,7 @@ export default css`
     outline-offset: 1px;
   }
 
-  @media only screen and (min-width: 890px) and (max-device-width: 905px) {
+  @media only screen and (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) and (max-device-width: 905px) {
     .branding.second-logo {
       padding-right: 0;
     }
@@ -223,7 +224,7 @@ export default css`
     }
   }
 
-  @media (max-width: 889px) {
+  @media (max-width: ${TOPNAV_MOBILE_BREAKPOINT - 1}px) {
     slot[name='opt-sec-logo'] {
       display: none;
     }
@@ -236,7 +237,7 @@ export default css`
     }
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     :host {
       --userIconWidth: 3.2rem;
       --userIconHeight: 3.2rem;

--- a/packages/ia-topnav/src/styles/save-page-form.ts
+++ b/packages/ia-topnav/src/styles/save-page-form.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   div {
@@ -45,7 +46,7 @@ export default css`
     display: block;
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     h3 {
       margin-top: 0;
       font: normal 100 1.6rem var(--themeFontFamily);

--- a/packages/ia-topnav/src/styles/wayback-search.ts
+++ b/packages/ia-topnav/src/styles/wayback-search.ts
@@ -1,4 +1,5 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 
 export default css`
   form {
@@ -34,7 +35,7 @@ export default css`
     transform: translateY(-50%);
   }
 
-  @media (min-width: 890px) {
+  @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
     fieldset a,
     .search-field {
       display: block;

--- a/packages/ia-topnav/src/styles/wayback-slider.ts
+++ b/packages/ia-topnav/src/styles/wayback-slider.ts
@@ -1,10 +1,11 @@
 import { css } from 'lit';
+import { TOPNAV_MOBILE_BREAKPOINT } from '../models';
 import { subnavListCSS } from './base';
 
 export default [
   subnavListCSS,
   css`
-    @media (min-width: 890px) {
+    @media (min-width: ${TOPNAV_MOBILE_BREAKPOINT}px) {
       :host {
         display: block;
         grid-column: 1 / 4;


### PR DESCRIPTION
Currently the main mobile/desktop breakpoint used by our `ia-topnav` component hard-codes the same magic-number breakpoint widths into many of its style files. This not only makes them brittle to changes, but also makes the breakpoint entirely opaque to host applications, which can at best hard-code a matching one when needed.

This PR instead pulls the breakpoint out into a shared constant so that the value only needs to be defined in one place, and exports it for host usage as well.