### PR TITLE
Bump ia-topnav to v2.1.0

### DIFF
--- a/packages/ia-topnav/package-lock.json
+++ b/packages/ia-topnav/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-topnav",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-styles": "^1.0.0",

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Version includes new exported constant for mobile breakpoint (#1010)