### PR TITLE
WEBDEV-8723 Switch topnav to new logout URL

### DIFF
--- a/packages/ia-topnav/src/data/menus.ts
+++ b/packages/ia-topnav/src/data/menus.ts
@@ -574,7 +574,7 @@ export function buildTopNavMenus(
         analyticsEvent: 'UserHelp',
       },
       {
-        url: `${baseHost}/account/logout`,
+        url: `${baseHost}/logout`,
         title: 'Log out',
         analyticsEvent: 'UserLogOut',
       },


### PR DESCRIPTION
Switches `/account/logout` to `/logout` in the topnav menu
