### PR TITLE
WEBDEV-8763: Export radio-player theater building blocks from the package root

### DIFF
--- a/packages/radio-player/index.d.ts
+++ b/packages/radio-player/index.d.ts
@@ -1,15 +1,40 @@
+import {
+  TranscriptConfig,
+  TranscriptEntryConfig
+} from '@internetarchive/transcript-view';
+import { AudioSource } from '@internetarchive/audio-element';
+
 import RadioPlayer from './lib/src/radio-player.d';
 import SearchResultsSwitcher from './lib/src/search-results-switcher.d';
 import MusicZone from './lib/src/models/music-zone.d';
 import RadioPlayerConfig from './lib/src/models/radio-player-config.d';
+import { SearchHandler } from './lib/src/search-handler/search-handler.d';
+import { LocalSearchBackend } from './lib/src/search-handler/search-backends/local-search-backend/local-search-backend.d';
+import { FullTextSearchBackend } from './lib/src/search-handler/search-backends/full-text-search-backend/full-text-search-backend.d';
+import { TranscriptIndex } from './lib/src/search-handler/transcript-index.d';
+import {
+  FullTextSearchResponse,
+  FullTextSearchResponseDoc
+} from './lib/src/search-handler/search-backends/full-text-search-backend/full-text-search-response.d';
 import { FullTextSearchServiceInterface } from './lib/src/search-handler/search-backends/full-text-search-backend/full-text-search-service-interface.d';
 import { SearchBackendInterface } from './lib/src/search-handler/search-backends/search-backend-interface.d';
+import { SearchHandlerInterface } from './lib/src/search-handler/search-handler-interface.d';
 
 export {
   RadioPlayer,
   SearchResultsSwitcher,
   MusicZone,
   RadioPlayerConfig,
+  TranscriptConfig,
+  TranscriptEntryConfig,
+  AudioSource,
+  SearchHandler,
+  LocalSearchBackend,
+  FullTextSearchBackend,
+  TranscriptIndex,
+  FullTextSearchResponse,
+  FullTextSearchResponseDoc,
   FullTextSearchServiceInterface,
-  SearchBackendInterface
+  SearchBackendInterface,
+  SearchHandlerInterface
 };

--- a/packages/radio-player/package.json
+++ b/packages/radio-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/radio-player",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Radio Player LitElement.",
   "license": "AGPL-3.0-only",
   "main": "index.js",


### PR DESCRIPTION
`index.js` already re-exports these at runtime; `index.d.ts` didn't. This syncs the type declarations so consumers can import `AudioSource`, `TranscriptConfig`, `TranscriptEntryConfig`, `SearchHandler`, `LocalSearchBackend`, `FullTextSearchBackend`, `TranscriptIndex`, the full-text-search response types, and `SearchHandlerInterface` from the package root instead of reaching into the transitive `audio-element` / `transcript-view` packages or `radio-player/lib/src` deep paths.

Type-only, no runtime change. Bumps 1.0.0 to 1.0.1.

Unblocks the offshoot theater-player decoupling (WEBDEV-8762). Validated by pointing offshoot at a patched copy carrying these re-exports: it typechecks importing everything from the root.

Didn't build locally (repo isn't installed in my checkout); CI covers the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
