### PR TITLE
WEBDEV-8800: Install Playwright Chromium in CI bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     - name: Install dependencies
       run: ./scripts/bootstrap.sh
 
+    - name: Install Playwright Chromium
+      timeout-minutes: 5
+      run: npx --prefix packages/ia-zendesk-help-widget playwright install --with-deps chromium
+
     - name: Run tests
       run: ./scripts/test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,17 @@ jobs:
     - name: Install dependencies
       run: ./scripts/bootstrap.sh
 
-    - name: Install Playwright Chromium
+    # Only the headless shell is installed: tests run headless, and unpacking the full
+    # Chrome-for-Testing build hangs indefinitely on the runner.
+    - name: Install Playwright headless shell
       timeout-minutes: 5
-      run: npx --prefix packages/ia-zendesk-help-widget playwright install --with-deps chromium
+      run: |
+        df -h /
+        for pw in packages/*/node_modules/.bin/playwright; do
+          [ -x "$pw" ] || continue
+          echo "Installing Playwright browsers for package: ${pw%/node_modules/.bin/playwright}"
+          "$pw" install --with-deps --only-shell chromium
+        done
 
     - name: Run tests
       run: ./scripts/test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,14 @@ jobs:
         key: playwright-headless-shell-${{ runner.os }}-${{ hashFiles('packages/*/package-lock.json') }}
 
     # Tests run headless, so only the headless shell is installed: unpacking the full
-    # Chrome-for-Testing build hangs indefinitely on the runner. The headless shell
-    # download from Playwright's CDN occasionally stalls too, right after it reports
-    # 100%, so each attempt is time-boxed and retried instead of one long timeout.
+    # Chrome-for-Testing build hangs indefinitely on the runner. The download itself
+    # also reproducibly hangs right after reporting 100% -- Node's default DNS order
+    # tries the runner's IPv6 route to Playwright's CDN first, and that route never
+    # sends a proper connection close, so forcing IPv4 avoids the hang outright; the
+    # retry loop stays as a safety net in case of a genuine transient stall.
     - name: Install Playwright headless shell
+      env:
+        NODE_OPTIONS: --dns-result-order=ipv4first
       run: |
         for pw in packages/*/node_modules/.bin/playwright; do
           [ -x "$pw" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
 
     # Tests run headless, so only the headless shell is installed: unpacking the full
     # Chrome-for-Testing build hangs indefinitely on the runner. The download itself
-    # also reproducibly hangs right after reporting 100% -- Node's default DNS order
-    # tries the runner's IPv6 route to Playwright's CDN first, and that route never
-    # sends a proper connection close, so forcing IPv4 avoids the hang outright; the
-    # retry loop stays as a safety net in case of a genuine transient stall.
+    # also reproducibly hangs right after reporting 100%, every attempt, regardless of
+    # DNS family -- DEBUG=pw:install traces Playwright's own install steps so the next
+    # failure pinpoints which phase (download vs extract vs rename) actually stalls.
     - name: Install Playwright headless shell
       env:
         NODE_OPTIONS: --dns-result-order=ipv4first
+        DEBUG: pw:install
       run: |
         for pw in packages/*/node_modules/.bin/playwright; do
           [ -x "$pw" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,9 @@ jobs:
         key: playwright-headless-shell-${{ runner.os }}-${{ hashFiles('packages/*/package-lock.json') }}
 
     # Tests run headless, so only the headless shell is installed: unpacking the full
-    # Chrome-for-Testing build hangs indefinitely on the runner. The download itself
-    # also reproducibly hangs right after reporting 100%, every attempt, regardless of
-    # DNS family -- DEBUG=pw:install traces Playwright's own install steps so the next
-    # failure pinpoints which phase (download vs extract vs rename) actually stalls.
+    # Chrome-for-Testing build hangs indefinitely on the runner. Each install attempt
+    # is time-boxed and retried as a safety net against a stalled download.
     - name: Install Playwright headless shell
-      env:
-        NODE_OPTIONS: --dns-result-order=ipv4first
-        DEBUG: pw:install
       run: |
         for pw in packages/*/node_modules/.bin/playwright; do
           [ -x "$pw" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
         path: ~/.cache/ms-playwright
         key: playwright-headless-shell-${{ runner.os }}-${{ hashFiles('packages/*/package-lock.json') }}
 
+    - name: Diagnose disk space before Playwright install
+      run: |
+        df -h /
+        df -i /
+
     # Tests run headless, so only the headless shell is installed: unpacking the full
     # Chrome-for-Testing build hangs indefinitely on the runner. The download itself
     # also reproducibly hangs right after reporting 100%, every attempt, regardless of

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: latest
+        node-version: '24'
 
     - name: Install dependencies
       run: ./scripts/bootstrap.sh
@@ -24,11 +24,6 @@ jobs:
       with:
         path: ~/.cache/ms-playwright
         key: playwright-headless-shell-${{ runner.os }}-${{ hashFiles('packages/*/package-lock.json') }}
-
-    - name: Diagnose disk space before Playwright install
-      run: |
-        df -h /
-        df -i /
 
     # Tests run headless, so only the headless shell is installed: unpacking the full
     # Chrome-for-Testing build hangs indefinitely on the runner. The download itself

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,32 @@ jobs:
     - name: Install dependencies
       run: ./scripts/bootstrap.sh
 
-    # Only the headless shell is installed: tests run headless, and unpacking the full
-    # Chrome-for-Testing build hangs indefinitely on the runner.
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-headless-shell-${{ runner.os }}-${{ hashFiles('packages/*/package-lock.json') }}
+
+    # Tests run headless, so only the headless shell is installed: unpacking the full
+    # Chrome-for-Testing build hangs indefinitely on the runner. The headless shell
+    # download from Playwright's CDN occasionally stalls too, right after it reports
+    # 100%, so each attempt is time-boxed and retried instead of one long timeout.
     - name: Install Playwright headless shell
-      timeout-minutes: 5
       run: |
-        df -h /
         for pw in packages/*/node_modules/.bin/playwright; do
           [ -x "$pw" ] || continue
-          echo "Installing Playwright browsers for package: ${pw%/node_modules/.bin/playwright}"
-          "$pw" install --with-deps --only-shell chromium
+          pkg=${pw%/node_modules/.bin/playwright}
+          echo "Installing Playwright system deps for package: $pkg"
+          "$pw" install-deps chromium
+          for attempt in 1 2 3; do
+            echo "Installing Playwright headless shell for package: $pkg (attempt $attempt/3)"
+            timeout --kill-after=10s 2m "$pw" install --only-shell chromium && break
+            if [ "$attempt" = 3 ]; then
+              echo "::error::chromium headless shell install stalled 3 times for $pkg"
+              exit 1
+            fi
+            echo "Install stalled, retrying with a fresh connection"
+          done
         done
 
     - name: Run tests

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,3 +2,14 @@
 set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 for dir in $SCRIPT_DIR/../packages/*; do (echo "Installing dependencies for package: $dir" && cd "$dir" && npm install); done
+
+# Playwright browsers install into a shared machine-level cache (~/.cache/ms-playwright), so
+# one install covers every package that needs them. Skipped under CI, where the workflow
+# installs just the headless shell: unpacking the full Chrome build hangs on the runner.
+if [ -z "$CI" ]; then
+  for pw in $SCRIPT_DIR/../packages/*/node_modules/.bin/playwright; do
+    [ -x "$pw" ] || continue
+    echo "Installing Playwright browsers for package: ${pw%/node_modules/.bin/playwright}"
+    "$pw" install chromium || echo "warning: Playwright browser install failed; rerun '$pw install chromium' if you need browser tests" >&2
+  done
+fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,5 +2,3 @@
 set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 for dir in $SCRIPT_DIR/../packages/*; do (echo "Installing dependencies for package: $dir" && cd "$dir" && npm install); done
-
-npx --prefix $SCRIPT_DIR/../packages/ia-zendesk-help-widget playwright install --with-deps chromium

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,3 +2,5 @@
 set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 for dir in $SCRIPT_DIR/../packages/*; do (echo "Installing dependencies for package: $dir" && cd "$dir" && npm install); done
+
+npx --prefix $SCRIPT_DIR/../packages/ia-zendesk-help-widget playwright install --with-deps chromium


### PR DESCRIPTION
## Summary
- `scripts/bootstrap.sh` never installed Playwright's browser binary, so `ia-zendesk-help-widget`'s Vitest browser tests couldn't launch Chromium in CI.
- The actual blocker turned out to be `node-version: latest` resolving to Node v26.7.0 (a brand new Current release), which hangs during the browser zip's extraction step. Pinned to `node-version: '24'` (Active LTS) and it installs in seconds.
- Added `actions/cache` for `~/.cache/ms-playwright` so a successful run skips the download entirely next time, plus a bounded retry around the install as a safety net.

Fixes WEBDEV-8800.

## Test plan
- [x] CI green end to end: https://github.com/internetarchive/iaux/actions/runs/32792420601
