### PR TITLE
WEBDEV-8890: Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __snapshots__
 /publish_dev.sh
 /dist
 *.log
+
+# Claude Code worktrees live here; never commit them.
+.claude/worktrees/


### PR DESCRIPTION
Worktrees created under `.claude/worktrees/` were showing up as untracked files in the primary checkout. Ignores that path only, so per-repo `.claude` config stays committable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGzyVutjSEETR8wtd4YExL