### PR TITLE
WEBDEV-8889: Fix transcript-view search results never scrolling into view

### DIFF
--- a/packages/transcript-view/package.json
+++ b/packages/transcript-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/transcript-view",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Transcript View LitElement that displays closed captioning and search results.",
   "license": "AGPL-3.0-only",
   "main": "index.js",

--- a/packages/transcript-view/src/transcript-view.ts
+++ b/packages/transcript-view/src/transcript-view.ts
@@ -102,7 +102,7 @@ export default class TranscriptView extends LitElement {
         ?isSearchResult=${isSearchResult}
         ?isMusicEntry=${isMusicEntry}
         ?isClickable=${true}
-        .data-search-result-index=${entry.searchMatchIndex}
+        data-search-result-index=${entry.searchMatchIndex}
         data-identifier=${entry.id}
         @click=${this.transcriptEntrySelected}
       >

--- a/packages/transcript-view/test/transcript-view.test.js
+++ b/packages/transcript-view/test/transcript-view.test.js
@@ -91,6 +91,34 @@ describe('TranscriptView', () => {
     expect(response).to.exist;
   });
 
+  it('renders `data-search-result-index` as an attribute so search results can be found', async () => {
+    const entry1 = new TranscriptEntryConfig(1, 64, 67, 'foo', false, undefined);
+    const entry2 = new TranscriptEntryConfig(2, 68, 73, 'bar', false, 0);
+    const entry3 = new TranscriptEntryConfig(3, 74, 78, 'baz', false, 1);
+
+    const config = new TranscriptConfig([entry1, entry2, entry3])
+
+    const el = await fixture(html`
+      <transcript-view
+        .config=${config}>
+      </transcript-view>
+    `);
+
+    const entries = el.shadowRoot.querySelectorAll('transcript-entry');
+
+    // `selectedSearchResult` looks entries up with an attribute selector, so a
+    // property binding here would leave it unable to find anything to scroll to.
+    expect(entries[1].getAttribute('data-search-result-index')).to.equal('0');
+    expect(entries[2].getAttribute('data-search-result-index')).to.equal('1');
+
+    expect(el.selectedSearchResult).to.equal(entries[1]);
+
+    el.selectedSearchResultIndex = 1;
+    await el.updateComplete;
+
+    expect(el.selectedSearchResult).to.equal(entries[2]);
+  });
+
   it('disables `autoScroll` if the user scrolls and reenables it after `scrollTimerDelay`', async () => {
     const entry1 = new TranscriptEntryConfig(1, 64, 67, 'foo', undefined);
     const entry2 = new TranscriptEntryConfig(2, 67, 73, 'bar', undefined);


### PR DESCRIPTION
`selectedSearchResult` looks the entry up with an attribute selector, but the template bound `data-search-result-index` as a Lit property, so the attribute was never written and the getter always returned null. The transcript stayed at the top on load and the `<` `>` switcher arrows did nothing. Dropping the dot fixes it.

Came out of debugging the offshoot radio player (WEBDEV-8886). petabox is unaffected because it's still on transcript-view 0.0.3, where the same line is a plain attribute binding.

Bumps 1.0.0 to 1.0.1.

## Verification

New test fails on master (`expected null to equal '0'`) and passes with the fix. Full package suite: 25 passing.

Also confirmed end to end by patching the built package into offshoot and loading a real radio item: transcript `scrollTop` went 0 to 2177, matching petabox exactly, and the `>` arrow advanced it to 3738.

Note `npm test` (with `--coverage`) can't run in this package right now: babel chokes on optional chaining in `@open-wc/testing-helpers`. Pre-existing on master, unrelated to this change. Ran `karma start` without coverage instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGzyVutjSEETR8wtd4YExL