### PR TITLE
WEBDEV-8937: Require transcript-view ^1.0.1

### DIFF
--- a/packages/radio-player/package.json
+++ b/packages/radio-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/radio-player",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Radio Player LitElement.",
   "license": "AGPL-3.0-only",
   "main": "index.js",
@@ -39,7 +39,7 @@
     "@internetarchive/ia-activity-indicator": "^0.0.6",
     "@internetarchive/playback-controls": "0.0.2",
     "@internetarchive/scrubber-bar": "^0.0.2",
-    "@internetarchive/transcript-view": "^1.0.0",
+    "@internetarchive/transcript-view": "^1.0.1",
     "@internetarchive/waveform-progress": "^0.0.2",
     "lit": "^2.8.0"
   },

--- a/packages/radio-player/yarn.lock
+++ b/packages/radio-player/yarn.lock
@@ -826,10 +826,10 @@
   dependencies:
     lit "^2.2.7"
 
-"@internetarchive/transcript-view@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/transcript-view/-/transcript-view-1.0.0.tgz#8ba3a8fe1e30300ed58c00cbbc6a01871dd7ce25"
-  integrity sha512-oXZYvmnwZV5WS2uarlhmYoV6ue+nf29UgIB1S6ZKGrCuh3o4Lbz5zPYZR1N0nN42btBZsRc7PyYk4irGWCfdjg==
+"@internetarchive/transcript-view@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/transcript-view/-/transcript-view-1.0.1.tgz#0d726c2694f50152fe02797d37794e21602ed921"
+  integrity sha512-oq0nDSUaAZaAKI9mi1G31qRN4CavZZptLfFlblIbwlx6ABwmI5XZDpq/u5xqo3g9LtzLuipiOr58t0NZqehs6Q==
   dependencies:
     lit "^2.2.7"
 


### PR DESCRIPTION
Bumps the range so the WEBDEV-8889 scroll fix is required, not just available. A fresh resolve already gets 1.0.1, but a consumer with a lockfile pinned to 1.0.0 keeps the broken build until someone refreshes it by hand (that's WEBDEV-8886).

Also bumps radio-player to 1.0.2 for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sdEUHvndFvK8qvG8ZLm6k