### PR TITLE
WEBDEV-9036: Add uploader and biblio sections to the ia-topnav admin user menu

### DIFF
--- a/packages/ia-topnav/demo/app-root.ts
+++ b/packages/ia-topnav/demo/app-root.ts
@@ -18,6 +18,10 @@ export class AppRoot extends LitElement {
 
   @state() private itemIdentifier = '';
 
+  @state() private uploader = '';
+
+  @state() private biblio = '';
+
   render() {
     return html`
       <ia-topnav
@@ -26,6 +30,8 @@ export class AppRoot extends LitElement {
         .username=${this.username}
         .screenName=${this.screenName}
         .itemIdentifier=${this.itemIdentifier}
+        .uploader=${this.uploader}
+        .biblio=${this.biblio}
       >
       </ia-topnav>
 
@@ -107,6 +113,30 @@ export class AppRoot extends LitElement {
               >
                 Toggle manage flags mode (${this.canManageFlags ? 'on' : 'off'})
                 (requires admin mode)
+              </button>
+            </li>
+
+            <li>
+              <button
+                @click=${() => {
+                  this.uploader = this.uploader ? '' : 'uploader@example.com';
+                }}
+              >
+                Toggle uploader section (${this.uploader ? 'on' : 'off'})
+                (requires admin mode)
+              </button>
+            </li>
+
+            <li>
+              <button
+                @click=${() => {
+                  this.biblio = this.biblio
+                    ? ''
+                    : 'https://books-yaz.archive.org/biblio.php?b_id=boop&add=1';
+                }}
+              >
+                Toggle biblio section (${this.biblio ? 'on' : 'off'}) (requires
+                admin mode)
               </button>
             </li>
           </ul>

--- a/packages/ia-topnav/package-lock.json
+++ b/packages/ia-topnav/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.1.2",
+  "version": "2.2.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/ia-topnav",
-      "version": "2.1.2",
+      "version": "2.2.0-beta.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-styles": "^1.0.0",

--- a/packages/ia-topnav/package.json
+++ b/packages/ia-topnav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ia-topnav",
-  "version": "2.1.2",
+  "version": "2.2.0-beta.0",
   "description": "Top nav for Internet Archive",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/ia-topnav/src/data/menus.ts
+++ b/packages/ia-topnav/src/data/menus.ts
@@ -24,6 +24,8 @@ export function buildTopNavMenus(
   baseHost: string = 'https://archive.org',
   waybackPagesArchived: string = '',
   itemIdentifier: string = '',
+  uploader: string = '',
+  biblio: string = '',
 ): IATopNavMenuConfig {
   if (waybackPagesArchived)
     defaultTopNavConfig.waybackPagesArchived = waybackPagesArchived; // update to more accurate val
@@ -634,6 +636,45 @@ export function buildTopNavMenus(
         analyticsEvent: 'AdminUserManageFlags',
       },
     ],
+    userAdminBiblio: biblio
+      ? [
+          {
+            url: `${biblio}&ignored=${itemIdentifier}`,
+            title: 'biblio',
+            analyticsEvent: 'AdminUserBiblio',
+          },
+          {
+            url: `${baseHost}/bookview.php?mode=debug&identifier=${itemIdentifier}`,
+            title: 'bookview',
+            analyticsEvent: 'AdminUserBookView',
+          },
+          {
+            url: `${baseHost}/download/${itemIdentifier}/format=Single Page Processed JP2 ZIP`,
+            title: 'jp2 zip',
+            analyticsEvent: 'AdminUserJP2Zip',
+          },
+        ]
+      : [],
+    userAdminUploader: uploader
+      ? [
+          {
+            title: 'uploader:',
+          },
+          {
+            title: uploader,
+          },
+          {
+            url: `https://catalogd.archive.org/control/useradmin.php?email=${encodeURIComponent(uploader)}`,
+            title: 'user admin',
+            analyticsEvent: 'AdminUserUserAdmin',
+          },
+          {
+            url: `https://catalogd.archive.org/control/setadmin.php?user=${encodeURIComponent(uploader)}&ignore=${itemIdentifier}`,
+            title: 'user privs',
+            analyticsEvent: 'AdminUserUserPrivs',
+          },
+        ]
+      : [],
     signedOut: [
       {
         url: `${baseHost}/signup`,

--- a/packages/ia-topnav/src/ia-topnav.ts
+++ b/packages/ia-topnav/src/ia-topnav.ts
@@ -36,6 +36,19 @@ export class IATopNav extends LitElement {
 
   @property({ type: String }) itemIdentifier = '';
 
+  /**
+   * Email of the item's uploader. When set for an admin viewing an item, the
+   * user menu gets an "uploader:" section with user admin / user privs links.
+   */
+  @property({ type: String }) uploader = '';
+
+  /**
+   * Biblio URL for a texts item, which must already carry a query string
+   * (the item identifier is appended to it as `&ignored=`). When set for an
+   * admin viewing an item, the user menu gets biblio / bookview / jp2 zip links.
+   */
+  @property({ type: String }) biblio = '';
+
   @property({ type: Boolean }) mediaSliderOpen = false;
 
   @property({ type: String }) openMenu = '';
@@ -81,6 +94,8 @@ export class IATopNav extends LitElement {
       props.has('username') ||
       props.has('waybackPagesArchived') ||
       props.has('itemIdentifier') ||
+      props.has('uploader') ||
+      props.has('biblio') ||
       props.has('localLinks') ||
       props.has('baseHost')
     ) {
@@ -122,6 +137,8 @@ export class IATopNav extends LitElement {
       this.normalizedBaseHost,
       this.waybackPagesArchived,
       this.itemIdentifier,
+      this.uploader,
+      this.biblio,
     );
   }
 
@@ -248,18 +265,27 @@ export class IATopNav extends LitElement {
    * Most users just get the basic menu items.
    * For users with `/items` priv, additional admin menu items are included too.
    * Having the `/flags` priv adds a further admin item for managing flags.
+   * A `biblio` URL adds a section of book-scanning links, and an `uploader`
+   * adds a section with the uploader's email and account admin links. Each
+   * section is rendered with a divider above it.
    */
   get userMenuItems() {
     const basicItems = this.menus.user;
+    if (!this.itemIdentifier || !this.admin) return [basicItems];
 
     let adminItems = this.menus.userAdmin;
     if (this.canManageFlags) {
       adminItems = adminItems.concat(this.menus.userAdminFlags);
     }
 
-    return this.itemIdentifier && this.admin
-      ? [basicItems, adminItems]
-      : [basicItems];
+    // The built sections are empty until the matching prop is set and the
+    // menus have been rebuilt, so gating on them keeps a divider from ever
+    // rendering above an empty section.
+    const { userAdminBiblio, userAdminUploader } = this.menus;
+    const sections = [basicItems, adminItems];
+    if (userAdminBiblio.length) sections.push(userAdminBiblio);
+    if (userAdminUploader.length) sections.push(userAdminUploader);
+    return sections;
   }
 
   get allowSecondaryIcon() {

--- a/packages/ia-topnav/src/models.ts
+++ b/packages/ia-topnav/src/models.ts
@@ -61,6 +61,8 @@ export interface IATopNavMenuConfig {
   user: IATopNavLink[];
   userAdmin: IATopNavLink[];
   userAdminFlags: IATopNavLink[];
+  userAdminBiblio: IATopNavLink[];
+  userAdminUploader: IATopNavLink[];
   video: IATopNavMediaMenu;
   web: IATopNavMediaMenu;
 }

--- a/packages/ia-topnav/test/ia-topnav.test.ts
+++ b/packages/ia-topnav/test/ia-topnav.test.ts
@@ -280,3 +280,110 @@ describe('<ia-topnav>', () => {
     });
   });
 });
+
+describe('<ia-topnav> admin user menu sections', () => {
+  type ExtraSection = '' | 'uploader' | 'biblio' | 'both';
+  const adminFixture = async (extra: ExtraSection = '') =>
+    fixture<IATopNav>(
+      html`<ia-topnav
+        admin
+        username="brewster"
+        itemIdentifier="boop"
+        uploader=${extra === 'uploader' || extra === 'both'
+          ? 'up+loader@example.com'
+          : ''}
+        biblio=${extra === 'biblio' || extra === 'both'
+          ? 'https://books-yaz.archive.org/biblio.php?b_id=boop&add=1'
+          : ''}
+      ></ia-topnav>`,
+    );
+
+  it('renders the basic and item admin sections by default', async () => {
+    const el = await adminFixture();
+    expect(el.userMenuItems.length).to.equal(2);
+  });
+
+  it('adds an uploader section when an uploader is set', async () => {
+    const el = await adminFixture('uploader');
+    const sections = el.userMenuItems;
+    expect(sections.length).to.equal(3);
+
+    const uploaderSection = sections[2];
+    expect(uploaderSection.map((link) => link.title)).to.deep.equal([
+      'uploader:',
+      'up+loader@example.com',
+      'user admin',
+      'user privs',
+    ]);
+    expect(uploaderSection[0].url).to.be.undefined;
+    expect(uploaderSection[1].url).to.be.undefined;
+    expect(uploaderSection[2].url).to.equal(
+      'https://catalogd.archive.org/control/useradmin.php?email=up%2Bloader%40example.com',
+    );
+    expect(uploaderSection[3].url).to.equal(
+      'https://catalogd.archive.org/control/setadmin.php?user=up%2Bloader%40example.com&ignore=boop',
+    );
+  });
+
+  it('adds a biblio section when a biblio URL is set', async () => {
+    const el = await adminFixture('biblio');
+    const sections = el.userMenuItems;
+    expect(sections.length).to.equal(3);
+
+    const biblioSection = sections[2];
+    expect(biblioSection.map((link) => link.title)).to.deep.equal([
+      'biblio',
+      'bookview',
+      'jp2 zip',
+    ]);
+    expect(biblioSection[0].url).to.equal(
+      'https://books-yaz.archive.org/biblio.php?b_id=boop&add=1&ignored=boop',
+    );
+    expect(biblioSection[1].url).to.equal(
+      'https://archive.org/bookview.php?mode=debug&identifier=boop',
+    );
+    expect(biblioSection[2].url).to.equal(
+      'https://archive.org/download/boop/format=Single Page Processed JP2 ZIP',
+    );
+  });
+
+  it('orders the biblio section before the uploader section', async () => {
+    const el = await adminFixture('both');
+    const sections = el.userMenuItems;
+    expect(sections.length).to.equal(4);
+    expect(sections[2][0].title).to.equal('biblio');
+    expect(sections[3][0].title).to.equal('uploader:');
+  });
+
+  it('renders the sections in the user menu with dividers between them', async () => {
+    const el = await adminFixture('both');
+    // The menus rebuild in updated(), so the sections land one update later.
+    await el.updateComplete;
+    const userMenu = el.shadowRoot?.querySelector('user-menu') as UserMenu;
+    await userMenu.updateComplete;
+
+    const listItems = Array.from(
+      userMenu.shadowRoot?.querySelectorAll('li') ?? [],
+    );
+    const text = listItems.map((li) => li.textContent?.trim());
+    expect(text).to.include('uploader:');
+    expect(text).to.include('up+loader@example.com');
+    expect(text).to.include('user privs');
+    expect(text).to.include('jp2 zip');
+    expect(userMenu.shadowRoot?.querySelectorAll('.divider').length).to.equal(
+      3,
+    );
+  });
+
+  it('leaves the extra sections out for non-admins', async () => {
+    const el = await fixture<IATopNav>(
+      html`<ia-topnav
+        username="brewster"
+        itemIdentifier="boop"
+        uploader="up@example.com"
+        biblio="https://books-yaz.archive.org/biblio.php?b_id=boop&add=1"
+      ></ia-topnav>`,
+    );
+    expect(el.userMenuItems.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
Petabox's admin user menu has two more sections under the item links that ia-topnav didn't know about: the uploader's email with "user admin" / "user privs" links, and biblio / bookview / jp2 zip on texts items. Offshoot renders ia-topnav itself, so it had no way to show them (user support flagged it on [WEBDEV-9032](https://webarchive.jira.com/browse/WEBDEV-9032)).

New `uploader` and `biblio` props build those sections the same way petabox's `userMenuLinks()` does, in the same order (biblio, then uploader), with the same titles and analytics events. One deliberate difference: the uploader email is URL-encoded in the catalogd links. Petabox interpolates it raw, so a `+` in an address turns into a space there.

Needs a version bump + publish after merge so offshoot can pick it up ([WEBDEV-9037](https://webarchive.jira.com/browse/WEBDEV-9037)).

## Verification

Package suite: 53 passing, 6 new tests covering each section, their order, the dividers, and the non-admin case. Also patched the built package into a local offshoot and checked a texts item and an image item against petabox's menu.

JIRA: https://webarchive.jira.com/browse/WEBDEV-9036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNZVcHqwfzeReT2hPnrUjL


[WEBDEV-9032]: https://webarchive.jira.com/browse/WEBDEV-9032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-9037]: https://webarchive.jira.com/browse/WEBDEV-9037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ